### PR TITLE
feat: implement SecretService with env var loading

### DIFF
--- a/engine/.pi/.guardian-pipeline-state.json
+++ b/engine/.pi/.guardian-pipeline-state.json
@@ -49,7 +49,7 @@
       }
     }
   ],
-  "currentItemIndex": 1,
+  "currentItemIndex": 2,
   "currentStepIndex": 0,
   "status": "running",
   "retryCount": 0,
@@ -99,9 +99,55 @@
           "reason": ""
         }
       ]
+    },
+    {
+      "item": "issue-config",
+      "status": "done",
+      "stepResults": [
+        {
+          "step": "implement",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "implement",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "validate",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "validate",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "create-mr",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "create-mr",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "merge",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "merge",
+          "status": "passed",
+          "reason": ""
+        }
+      ]
     }
   ],
   "mergeOnValid": true,
   "createdAt": "2026-06-13T05:28:54.582Z",
-  "updatedAt": "2026-06-13T07:13:25.577Z"
+  "updatedAt": "2026-06-13T07:27:55.189Z"
 }

--- a/engine/src/configuration/application/factory.rs
+++ b/engine/src/configuration/application/factory.rs
@@ -69,5 +69,5 @@ pub trait SecretFactory: Send + Sync {
     /// Create a secret from a string value.
     ///
     /// Used for secrets that come from configuration files or CLI args.
-    fn create_from_value(&self, value: impl Into<String>) -> Secret;
+    fn create_from_value(&self, value: &str) -> Secret;
 }

--- a/engine/src/configuration/application/mod.rs
+++ b/engine/src/configuration/application/mod.rs
@@ -18,9 +18,11 @@
 pub mod config_service_impl;
 pub mod dto;
 pub mod factory;
+pub mod secret_service_impl;
 pub mod service;
 
 pub use config_service_impl::*;
 pub use dto::*;
 pub use factory::*;
+pub use secret_service_impl::*;
 pub use service::*;

--- a/engine/src/configuration/application/secret_service_impl.rs
+++ b/engine/src/configuration/application/secret_service_impl.rs
@@ -1,0 +1,169 @@
+//! Implementation of `SecretService`.
+//!
+//! @canonical .pi/architecture/modules/configuration.md#secret
+//! Implements: SecretService trait — load and validate secrets
+//! Issue: #4
+
+use async_trait::async_trait;
+
+use crate::configuration::application::dto::{LoadSecretInput, LoadSecretOutput};
+use crate::configuration::application::factory::SecretFactory;
+use crate::configuration::application::service::SecretService;
+use crate::configuration::domain::ConfigurationError;
+use crate::configuration::infrastructure::secret_factory_impl::SecretFactoryImpl;
+
+/// Implementation of `SecretService` using `SecretFactory` for loading.
+pub struct SecretServiceImpl {
+    factory: Box<dyn SecretFactory>,
+}
+
+impl SecretServiceImpl {
+    pub fn new(factory: Box<dyn SecretFactory>) -> Self {
+        Self { factory }
+    }
+}
+
+impl Default for SecretServiceImpl {
+    fn default() -> Self {
+        Self::new(Box::new(SecretFactoryImpl::new()))
+    }
+}
+
+#[async_trait]
+impl SecretService for SecretServiceImpl {
+    async fn load(&self, input: LoadSecretInput) -> Result<LoadSecretOutput, ConfigurationError> {
+        let secret = self
+            .factory
+            .load_from_env(&input.env_var, input.fallback.clone())
+            .await;
+
+        match secret {
+            Some(secret) => {
+                let source = if std::env::var(&input.env_var).is_ok() {
+                    format!("env:{}", input.env_var)
+                } else {
+                    "fallback".to_string()
+                };
+                Ok(LoadSecretOutput { secret, source })
+            }
+            None => {
+                if input.required {
+                    Err(ConfigurationError::EnvVarError {
+                        var: input.env_var.clone(),
+                        detail: "Environment variable not set and no fallback provided".to_string(),
+                    })
+                } else {
+                    Ok(LoadSecretOutput {
+                        secret: crate::configuration::domain::Secret::new(""),
+                        source: "none".to_string(),
+                    })
+                }
+            }
+        }
+    }
+
+    async fn validate_required(
+        &self,
+        required_keys: Vec<String>,
+    ) -> Result<Vec<String>, ConfigurationError> {
+        let mut missing = Vec::new();
+        for key in required_keys {
+            match std::env::var(&key) {
+                Ok(value) => {
+                    if value.is_empty() {
+                        missing.push(key);
+                    }
+                }
+                Err(_) => {
+                    missing.push(key);
+                }
+            }
+        }
+        Ok(missing)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::configuration::infrastructure::secret_factory_impl::SecretFactoryImpl;
+
+    fn create_service() -> SecretServiceImpl {
+        SecretServiceImpl::new(Box::new(SecretFactoryImpl::new()))
+    }
+
+    #[tokio::test]
+    async fn test_load_secret_found() {
+        let service = create_service();
+        let input = LoadSecretInput {
+            env_var: "PATH".to_string(),
+            fallback: None,
+            required: false,
+        };
+        let output = service.load(input).await.unwrap();
+        assert!(!output.secret.is_empty());
+        assert!(output.source.starts_with("env:"));
+    }
+
+    #[tokio::test]
+    async fn test_load_secret_not_found_not_required() {
+        let service = create_service();
+        let input = LoadSecretInput {
+            env_var: "RIGORIX_TEST_NONEXISTENT_99999".to_string(),
+            fallback: None,
+            required: false,
+        };
+        let output = service.load(input).await.unwrap();
+        assert!(output.secret.is_empty());
+        assert_eq!(output.source, "none");
+    }
+
+    #[tokio::test]
+    async fn test_load_secret_not_found_required() {
+        let service = create_service();
+        let input = LoadSecretInput {
+            env_var: "RIGORIX_TEST_NONEXISTENT_99999".to_string(),
+            fallback: None,
+            required: true,
+        };
+        let result = service.load(input).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_load_secret_with_fallback() {
+        let service = create_service();
+        let input = LoadSecretInput {
+            env_var: "RIGORIX_TEST_NONEXISTENT_99999".to_string(),
+            fallback: Some("fallback-key".to_string()),
+            required: false,
+        };
+        let output = service.load(input).await.unwrap();
+        assert_eq!(output.secret.expose(), "fallback-key");
+        assert_eq!(output.source, "fallback");
+    }
+
+    #[tokio::test]
+    async fn test_validate_required_all_present() {
+        let service = create_service();
+        let missing = service
+            .validate_required(vec!["PATH".to_string()])
+            .await
+            .unwrap();
+        assert!(missing.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_validate_required_some_missing() {
+        let service = create_service();
+        let missing = service
+            .validate_required(vec![
+                "PATH".to_string(),
+                "RIGORIX_TEST_NONEXISTENT_99999".to_string(),
+            ])
+            .await
+            .unwrap();
+        assert_eq!(missing.len(), 1);
+        assert_eq!(missing[0], "RIGORIX_TEST_NONEXISTENT_99999");
+    }
+}

--- a/engine/src/configuration/infrastructure/mod.rs
+++ b/engine/src/configuration/infrastructure/mod.rs
@@ -11,3 +11,4 @@
 pub mod config_factory_impl;
 pub mod filesystem_config_repository;
 pub mod repository;
+pub mod secret_factory_impl;

--- a/engine/src/configuration/infrastructure/secret_factory_impl.rs
+++ b/engine/src/configuration/infrastructure/secret_factory_impl.rs
@@ -1,0 +1,90 @@
+//! Implementation of `SecretFactory`.
+//!
+//! @canonical .pi/architecture/modules/configuration.md#secret
+//! Implements: SecretFactory trait — loads secrets from env or strings
+//! Issue: #4
+
+use async_trait::async_trait;
+
+use crate::configuration::application::factory::SecretFactory;
+use crate::configuration::domain::Secret;
+
+/// Implementation of `SecretFactory` that reads from environment variables
+/// or wraps string values.
+pub struct SecretFactoryImpl;
+
+impl SecretFactoryImpl {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for SecretFactoryImpl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SecretFactory for SecretFactoryImpl {
+    async fn load_from_env(&self, env_var: &str, fallback: Option<String>) -> Option<Secret> {
+        match std::env::var(env_var) {
+            Ok(value) => {
+                if value.is_empty() {
+                    fallback.map(Secret::new)
+                } else {
+                    Some(Secret::new(value))
+                }
+            }
+            Err(_) => fallback.map(Secret::new),
+        }
+    }
+
+    fn create_from_value(&self, value: &str) -> Secret {
+        Secret::new(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_load_from_env_found() {
+        let factory = SecretFactoryImpl::new();
+        // PATH is always set
+        let result = factory.load_from_env("PATH", None).await;
+        assert!(result.is_some());
+        assert!(!result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_load_from_env_not_found_no_fallback() {
+        let factory = SecretFactoryImpl::new();
+        let result = factory
+            .load_from_env("RIGORIX_TEST_NONEXISTENT_99999", None)
+            .await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_load_from_env_not_found_with_fallback() {
+        let factory = SecretFactoryImpl::new();
+        let result = factory
+            .load_from_env(
+                "RIGORIX_TEST_NONEXISTENT_99999",
+                Some("fallback-value".to_string()),
+            )
+            .await;
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().expose(), "fallback-value");
+    }
+
+    #[tokio::test]
+    async fn test_create_from_value() {
+        let factory = SecretFactoryImpl::new();
+        let secret = factory.create_from_value("sk-test-abc123");
+        assert_eq!(secret.expose(), "sk-test-abc123");
+        assert_eq!(format!("{secret:?}"), "[REDACTED]");
+    }
+}


### PR DESCRIPTION
## Summary

Implements SecretService for loading API keys and secrets from environment variables.

Closes #4

## Changes

- **SecretFactoryImpl** — read secrets from env vars with fallback
- **SecretServiceImpl** — load and validate required secrets
- 10 new tests, 27 total passing