### PR TITLE
Contract Freeze: Cancellation Module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,6 +1132,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-util",
  "toml",
  "uuid",
 ]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -10,6 +10,7 @@ serde_json = "1"
 toml = "0.8"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
+tokio-util = "0.7"
 async-trait = "0.1"
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/engine/src/cancellation/application/dto/mod.rs
+++ b/engine/src/cancellation/application/dto/mod.rs
@@ -1,0 +1,176 @@
+//! Data Transfer Objects for the Cancellation module.
+//!
+//! @canonical .pi/architecture/modules/cancellation.md
+//! Implements: Contract Freeze — DTO schemas for cancellation operations
+//! Issue: issue-contract-freeze
+//!
+//! DTOs define the input/output contracts for service operations.
+//! They carry validation metadata and documentation but no behavior.
+//!
+//! # Contract (Frozen)
+//! - Every service operation has a dedicated input and output DTO
+//! - DTOs are serializable (JSON for API)
+//! - Validation constraints are documented in field docs
+//! - Fields use reasonable Rust types (no framework-specific annotations)
+
+use serde::{Deserialize, Serialize};
+
+use crate::cancellation::domain::ShutdownSignal;
+
+// ---------------------------------------------------------------------------
+// Cancel Execution DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for requesting cancellation of an execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CancelExecutionInput {
+    /// The execution identifier to cancel.
+    pub execution_id: String,
+
+    /// Human-readable reason for cancellation.
+    pub reason: Option<String>,
+
+    /// Source of the cancellation request.
+    ///
+    /// Known sources: "user", "signal", "enforcement", "timeout"
+    pub source: String,
+}
+
+/// Output from requesting cancellation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CancelExecutionOutput {
+    /// Whether the cancellation request was accepted.
+    pub accepted: bool,
+
+    /// The signal that was sent.
+    pub signal: ShutdownSignal,
+
+    /// Number of tasks that will be affected.
+    pub affected_tasks: u32,
+
+    /// Whether cancellation was already in progress.
+    pub was_already_cancelling: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Shutdown DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for awaiting shutdown completion.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShutdownInput {
+    /// The execution ID to await shutdown for.
+    pub execution_id: String,
+
+    /// Maximum time to wait for graceful shutdown in seconds.
+    ///
+    /// After this timeout, remaining tasks are force-aborted.
+    /// Must be > 0. Default: 30.
+    pub timeout_secs: u64,
+
+    /// Whether to force-abort remaining tasks after timeout.
+    /// If false, returns `ShutdownTimeout` error without aborting.
+    pub force_abort_on_timeout: bool,
+}
+
+/// Output from awaiting shutdown.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShutdownOutput {
+    /// The execution ID.
+    pub execution_id: String,
+
+    /// The signal that was used for shutdown.
+    pub signal_used: ShutdownSignal,
+
+    /// Total number of tasks when shutdown was requested.
+    pub total_tasks: u32,
+
+    /// Number of tasks that completed naturally.
+    pub completed_tasks: u32,
+
+    /// Number of tasks that were cancelled/aborted.
+    pub cancelled_tasks: u32,
+
+    /// Total time spent in shutdown in milliseconds.
+    pub shutdown_duration_ms: u64,
+
+    /// Whether the shutdown was forced (aborted remaining tasks).
+    pub forced: bool,
+
+    /// Whether cleanup handlers were invoked successfully.
+    pub cleanup_success: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Status DTOs
+// ---------------------------------------------------------------------------
+
+/// Output for querying shutdown status.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShutdownStatusOutput {
+    /// Whether cancellation has been requested.
+    pub is_cancelled: bool,
+
+    /// The current shutdown signal, if any.
+    pub current_signal: Option<ShutdownSignal>,
+
+    /// Number of tasks currently running.
+    pub running_tasks: u32,
+
+    /// Number of tasks that have completed.
+    pub completed_tasks: u32,
+
+    /// Number of tasks that have been cancelled.
+    pub cancelled_tasks: u32,
+
+    /// Whether shutdown is complete.
+    pub shutdown_complete: bool,
+
+    /// Elapsed time since cancellation was requested, in milliseconds.
+    pub elapsed_since_request_ms: Option<u64>,
+}
+
+// ---------------------------------------------------------------------------
+// Task Registration DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for registering a task with the cancellation manager.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegisterTaskInput {
+    /// The execution ID.
+    pub execution_id: String,
+
+    /// Unique task identifier within this execution.
+    pub task_id: String,
+
+    /// Optional description of the task.
+    pub description: Option<String>,
+}
+
+/// Output from registering a task.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegisterTaskOutput {
+    /// Whether registration was accepted.
+    pub accepted: bool,
+    /// Current cancellation state at registration time.
+    pub is_already_cancelled: bool,
+}
+
+/// Input for notifying completion of a task.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NotifyTaskCompleteInput {
+    /// The execution ID.
+    pub execution_id: String,
+
+    /// The task identifier that completed.
+    pub task_id: String,
+
+    /// Whether the task completed normally or was cancelled.
+    pub was_cancelled: bool,
+
+    /// Duration the task was running in milliseconds.
+    pub running_duration_ms: u64,
+
+    /// Whether cleanup was performed successfully.
+    pub cleanup_success: bool,
+}

--- a/engine/src/cancellation/application/factory.rs
+++ b/engine/src/cancellation/application/factory.rs
@@ -1,0 +1,64 @@
+//! Factory interfaces for constructing Cancellation domain objects.
+//!
+//! @canonical .pi/architecture/modules/cancellation.md
+//! Implements: Contract Freeze — CancellationManagerFactory trait
+//! Issue: issue-contract-freeze
+//!
+//! Factories encapsulate the construction of complex domain objects,
+//! allowing implementations to inject dependencies and apply defaults
+//! without exposing construction logic to callers.
+//!
+//! # Contract (Frozen)
+//! - Every factory method returns a configured domain object
+//! - Validation is applied during construction
+//! - No mutable state in factory implementations
+
+use async_trait::async_trait;
+
+use crate::cancellation::domain::CancellationError;
+
+use super::service::CancellationService;
+
+/// Factory for constructing `CancellationService` instances.
+///
+/// Handles creation of the cancellation manager with appropriate
+/// `CancellationToken` wiring, watch channel setup, and defaults
+/// for graceful shutdown timeouts.
+#[async_trait]
+pub trait CancellationManagerFactory: Send + Sync {
+    /// Create a new `CancellationService` with default settings.
+    ///
+    /// Uses a default graceful shutdown timeout of 30 seconds.
+    async fn create_default(&self) -> Result<Box<dyn CancellationService>, CancellationError>;
+
+    /// Create a `CancellationService` with an explicit graceful timeout.
+    ///
+    /// `graceful_timeout_secs` controls how long `await_shutdown` will
+    /// wait for running tasks before force-aborting.
+    async fn create_with_timeout(
+        &self,
+        graceful_timeout_secs: u64,
+    ) -> Result<Box<dyn CancellationService>, CancellationError>;
+
+    /// Create a `CancellationService` that is already linked to an
+    /// existing parent `CancellationToken`.
+    ///
+    /// Useful when the orchestrator wants to create child cancellation
+    /// scopes that propagate from a parent token.
+    async fn create_child(
+        &self,
+        parent_token: tokio_util::sync::CancellationToken,
+        graceful_timeout_secs: u64,
+    ) -> Result<Box<dyn CancellationService>, CancellationError>;
+
+    /// Register a `CleanupHandler` for a specific task type.
+    ///
+    /// During shutdown, all registered handlers are invoked with
+    /// their associated task IDs. Multiple handlers may be registered
+    /// for the same task type.
+    async fn register_cleanup_handler(
+        &self,
+        task_type: &str,
+        handler: Box<dyn super::service::CleanupHandler>,
+    );
+}

--- a/engine/src/cancellation/application/mod.rs
+++ b/engine/src/cancellation/application/mod.rs
@@ -1,0 +1,24 @@
+//! Application layer interfaces for the Cancellation bounded context.
+//!
+//! @canonical .pi/architecture/modules/cancellation.md
+//! Implements: Contract Freeze — service traits, DTOs, factory interfaces
+//! Issue: issue-contract-freeze
+//!
+//! This module defines:
+//! - Service traits (use cases / application services)
+//! - Input/Output DTOs with validation
+//! - Factory interfaces for constructing domain objects
+//!
+//! # Contract (Frozen)
+//! - All service methods are async (return `impl Future`)
+//! - All public methods return `Result<_, CancellationError>`
+//! - DTOs include validation annotations/documentation
+//! - No implementation logic — only trait definitions
+
+pub mod dto;
+pub mod factory;
+pub mod service;
+
+pub use dto::*;
+pub use factory::*;
+pub use service::*;

--- a/engine/src/cancellation/application/service.rs
+++ b/engine/src/cancellation/application/service.rs
@@ -1,0 +1,117 @@
+//! Service interfaces (use cases) for the Cancellation bounded context.
+//!
+//! @canonical .pi/architecture/modules/cancellation.md
+//! Implements: Contract Freeze — CancellationService, CleanupHandler traits
+//! Issue: issue-contract-freeze
+//!
+//! These traits define the application-level operations for cancellation
+//! management, signal propagation, and cleanup coordination. All methods
+//! are async and return domain error types.
+//!
+//! # Contract (Frozen)
+//! - Every use case has a corresponding trait method
+//! - Input/output types are DTOs defined in `dto/`
+//! - All methods are async (use `async-trait` for trait object safety)
+//! - No implementation — only contract signatures
+
+use async_trait::async_trait;
+
+use crate::cancellation::domain::{CancellationError, ShutdownSignal};
+
+use super::dto::{
+    CancelExecutionInput, CancelExecutionOutput, ShutdownInput, ShutdownOutput,
+    ShutdownStatusOutput,
+};
+
+/// Central cancellation service for managing execution lifecycle.
+///
+/// Orchestrates the full cancellation workflow: requesting shutdown at
+/// various levels, propagating signals to concurrent tasks, coordinating
+/// cleanup handlers, and reporting shutdown status.
+///
+/// Implementations wrap a `CancellationManager` and expose its operations
+/// through typed DTOs.
+#[async_trait]
+pub trait CancellationService: Send + Sync {
+    /// Request graceful shutdown of an execution.
+    ///
+    /// Running tasks are allowed to finish naturally. No new tasks are
+    /// started. Emits `CancellationEvent::CancellationRequested` with
+    /// `ShutdownSignal::Graceful`.
+    ///
+    /// Returns `CancellationError::AlreadyCancelling` if cancellation is
+    /// already in progress.
+    async fn request_graceful_shutdown(
+        &self,
+        input: CancelExecutionInput,
+    ) -> Result<CancelExecutionOutput, CancellationError>;
+
+    /// Request immediate abort of an execution.
+    ///
+    /// All in-flight work is aborted immediately via task abort mechanisms
+    /// (e.g., `JoinSet::abort()`). Cleanup handlers SHOULD still run.
+    /// Emits `CancellationEvent::CancellationRequested` with
+    /// `ShutdownSignal::Immediate`.
+    ///
+    /// Returns `CancellationError::AlreadyCancelling` if cancellation is
+    /// already in progress.
+    async fn request_immediate_abort(
+        &self,
+        input: CancelExecutionInput,
+    ) -> Result<CancelExecutionOutput, CancellationError>;
+
+    /// Wait for all running tasks to complete (graceful shutdown).
+    ///
+    /// Blocks until either all tasks complete or the timeout is reached.
+    /// If the timeout is exceeded, remaining tasks are force-aborted
+    /// and `CancellationError::ShutdownTimeout` is returned.
+    async fn await_shutdown(&self, input: ShutdownInput) -> Result<ShutdownOutput, CancellationError>;
+
+    /// Check whether cancellation has been requested.
+    fn is_cancelled(&self) -> bool;
+
+    /// Get the current shutdown signal level.
+    ///
+    /// Returns `None` if no shutdown has been requested.
+    fn current_signal(&self) -> Option<ShutdownSignal>;
+
+    /// Get current shutdown status.
+    async fn status(&self) -> ShutdownStatusOutput;
+
+    /// Subscribe to shutdown signals via a watch channel.
+    ///
+    /// Returns a receiver that yields `ShutdownSignal` values.
+    /// The receiver immediately yields the current signal if one is active.
+    fn subscribe(&self) -> tokio::sync::watch::Receiver<ShutdownSignal>;
+
+    /// Get a reference to the underlying `CancellationToken`.
+    ///
+    /// Long-running tasks can use this token with `tokio::select!` or
+    /// `.cancelled()` to be notified of cancellation.
+    fn cancellation_token(&self) -> tokio_util::sync::CancellationToken;
+}
+
+/// Handler for task-level cleanup during cancellation.
+///
+/// Components that hold resources (file handles, network connections,
+/// budget reservations) implement this trait to perform cleanup when
+/// cancellation is signalled.
+///
+/// # Contract
+/// - `cleanup()` MUST NOT block indefinitely (use internal timeouts)
+/// - `cleanup()` MUST be idempotent (may be called multiple times)
+/// - Failures SHOULD be logged but MUST NOT cause cascading failures
+#[async_trait]
+pub trait CleanupHandler: Send + Sync {
+    /// Perform cleanup for a cancelled task or resource.
+    ///
+    /// Called during shutdown after the task has been stopped.
+    /// Returns an error if cleanup fails (non-fatal, logged).
+    async fn cleanup(&self, task_id: &str) -> Result<(), CancellationError>;
+
+    /// Release any resources held by this handler.
+    ///
+    /// Called during final shutdown phase. After this call, the handler
+    /// should be considered disposed.
+    async fn release(&self, task_id: &str) -> Result<(), CancellationError>;
+}

--- a/engine/src/cancellation/domain/error.rs
+++ b/engine/src/cancellation/domain/error.rs
@@ -1,0 +1,69 @@
+//! Cancellation error types.
+//!
+//! @canonical .pi/architecture/modules/error-handling.md#cancellation
+//! Implements: Contract Freeze — CancellationError enum
+//! Issue: issue-contract-freeze
+//!
+//! All errors use `thiserror` derive macros. No `anyhow` in library code.
+//!
+//! # Contract (Frozen)
+//! - `CancellationError` is the single error type for this module
+//! - Each variant carries structured context for error reporting
+//! - Implements `std::error::Error` for library compatibility
+//! - Converted to `CoreOrchestratorError` via `#[from]` at the orchestrator level
+
+use thiserror::Error;
+
+/// Errors that can occur during cancellation operations.
+#[derive(Debug, Error)]
+pub enum CancellationError {
+    /// A cancellation was requested but a task was not found to cancel.
+    #[error("Task not found for cancellation: {task_id}")]
+    TaskNotFound {
+        /// The identifier of the task that could not be found.
+        task_id: String,
+    },
+
+    /// A task was already cancelled and cannot be cancelled again.
+    #[error("Task is already cancelled: {task_id}")]
+    AlreadyCancelled {
+        /// The identifier of the already-cancelled task.
+        task_id: String,
+    },
+
+    /// The cancellation manager has already been triggered.
+    #[error("Cancellation already in progress with signal: {current_signal:?}")]
+    AlreadyCancelling {
+        /// The shutdown signal that is already in effect.
+        current_signal: super::ShutdownSignal,
+    },
+
+    /// A watch channel receiver was dropped before receiving the signal.
+    #[error("No subscribers available to receive shutdown signal")]
+    NoSubscribers,
+
+    /// Internal channel error during signal propagation.
+    #[error("Internal cancellation channel error: {detail}")]
+    ChannelError {
+        /// Description of the channel error.
+        detail: String,
+    },
+
+    /// Timeout reached while waiting for graceful shutdown to complete.
+    #[error("Graceful shutdown timed out after {timeout_secs}s with {pending_tasks} tasks still running")]
+    ShutdownTimeout {
+        /// Timeout duration in seconds.
+        timeout_secs: u64,
+        /// Number of tasks still running when timeout was reached.
+        pending_tasks: u32,
+    },
+
+    /// Cleanup handler failed during cancellation.
+    #[error("Cleanup handler failed for task {task_id}: {detail}")]
+    CleanupFailed {
+        /// The task that failed during cleanup.
+        task_id: String,
+        /// What went wrong during cleanup.
+        detail: String,
+    },
+}

--- a/engine/src/cancellation/domain/event/mod.rs
+++ b/engine/src/cancellation/domain/event/mod.rs
@@ -1,0 +1,102 @@
+//! Event payload schemas for the Cancellation bounded context.
+//!
+//! @canonical .pi/architecture/decisions/ADR-005-event-bus-persistence.md
+//! Implements: Contract Freeze — CancellationEvent payload schemas
+//! Issue: issue-contract-freeze
+//!
+//! These events are emitted on the `EventBus` whenever cancellation is
+//! requested, progresses, or completes. Consumers (orchestrator, audit,
+//! TUI, budget tracking) subscribe to these event types.
+//!
+//! # Contract (Frozen)
+//! - Each event carries the full context needed by consumers
+//! - No internal implementation details exposed
+//! - `execution_id` correlates to the originating execution
+
+use serde::{Deserialize, Serialize};
+
+/// Events emitted by the Cancellation module.
+///
+/// Wrapped in `ExecutionEvent::Cancellation(...)` at the orchestration layer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum CancellationEvent {
+    /// Cancellation was requested with a specific shutdown signal.
+    CancellationRequested {
+        /// The execution ID being cancelled.
+        execution_id: String,
+        /// The shutdown signal level requested.
+        signal: String,
+        /// Human-readable reason for cancellation.
+        reason: Option<String>,
+        /// Source of the cancellation request (e.g., "user", "signal", "enforcement").
+        source: String,
+    },
+
+    /// A graceful shutdown is in progress — running tasks continue.
+    GracefulShutdownStarted {
+        /// The execution ID being shut down.
+        execution_id: String,
+        /// Number of tasks still running.
+        running_tasks: u32,
+        /// Graceful shutdown timeout in seconds.
+        timeout_secs: u64,
+    },
+
+    /// An immediate shutdown was triggered — all tasks are aborted.
+    ImmediateShutdownExecuted {
+        /// The execution ID being shut down.
+        execution_id: String,
+        /// Number of tasks that were aborted.
+        aborted_task_count: u32,
+    },
+
+    /// A task has acknowledged the cancellation signal.
+    TaskCancelled {
+        /// The execution ID.
+        execution_id: String,
+        /// The task identifier that was cancelled.
+        task_id: String,
+        /// Whether the task completed cleanup before stopping.
+        cleanup_completed: bool,
+        /// Duration the task was running before cancellation.
+        running_duration_ms: u64,
+    },
+
+    /// All tasks have completed shutdown (graceful or immediate).
+    ShutdownComplete {
+        /// The execution ID.
+        execution_id: String,
+        /// The signal that was used.
+        signal_used: String,
+        /// Total number of tasks that were running when shutdown was requested.
+        total_tasks: u32,
+        /// Number of tasks that completed naturally.
+        completed_tasks: u32,
+        /// Number of tasks that were aborted/cancelled.
+        cancelled_tasks: u32,
+        /// Total duration of shutdown in milliseconds.
+        shutdown_duration_ms: u64,
+    },
+
+    /// Graceful shutdown timed out — some tasks were force-aborted.
+    ShutdownTimeout {
+        /// The execution ID.
+        execution_id: String,
+        /// Timeout that was exceeded.
+        timeout_secs: u64,
+        /// Number of tasks that were still running when the timeout was reached.
+        pending_tasks: u32,
+        /// Number of tasks that were force-aborted.
+        force_aborted: u32,
+    },
+
+    /// A cleanup handler failed during cancellation (non-fatal).
+    CleanupFailure {
+        /// The execution ID.
+        execution_id: String,
+        /// The task or resource that failed cleanup.
+        task_id: String,
+        /// What went wrong.
+        error: String,
+    },
+}

--- a/engine/src/cancellation/domain/mod.rs
+++ b/engine/src/cancellation/domain/mod.rs
@@ -1,0 +1,22 @@
+//! Domain entities and interfaces for the Cancellation bounded context.
+//!
+//! @canonical .pi/architecture/modules/cancellation.md#domain
+//! Implements: Contract Freeze — domain entities ShutdownSignal, CancellationError, CancellationEvent
+//! Issue: issue-contract-freeze
+//!
+//! This module defines the core domain types — `ShutdownSignal`, `CancellationError`,
+//! and all cancellation-related events. These are pure domain objects with no
+//! framework dependencies. They serve as the frozen contract that all implementation
+//! must satisfy.
+//!
+//! # Contract Freeze
+//! - No implementation logic beyond constructors and field accessors
+//! - All validation must happen in the application layer (service traits)
+//! - All persistence must happen behind repository interfaces
+
+pub mod error;
+pub mod event;
+pub mod signal;
+
+pub use error::CancellationError;
+pub use signal::ShutdownSignal;

--- a/engine/src/cancellation/domain/signal.rs
+++ b/engine/src/cancellation/domain/signal.rs
@@ -1,0 +1,43 @@
+//! ShutdownSignal value object.
+//!
+//! @canonical .pi/architecture/modules/cancellation.md#signal
+//! Implements: Contract Freeze — ShutdownSignal enum
+//! Issue: issue-contract-freeze
+//!
+//! Defines two shutdown levels for execution cancellation:
+//! - `Graceful`: let running tasks finish, don't start new ones
+//! - `Immediate`: abort all in-flight work immediately
+//!
+//! # Contract (Frozen)
+//! - `ShutdownSignal` is a simple enum with two variants
+//! - Used by `CancellationManager.request_shutdown()`
+//! - Propagated via `tokio::sync::watch` channel to subscribers
+//! - Implementations MUST NOT introduce new variants without architecture review
+
+use serde::{Deserialize, Serialize};
+
+/// Shutdown signal levels for execution cancellation.
+///
+/// Determines how aggressively running work is terminated when cancellation
+/// is requested. The orchestrator and all concurrent tasks must respect this
+/// signal level.
+///
+/// # Usage
+/// - `Graceful`: Stop accepting new work, let in-flight tasks complete naturally
+/// - `Immediate`: Abort all in-flight work via `JoinSet::abort()` or equivalent
+///
+/// # Cancellation Response Time (NFR-007)
+/// The system SHALL support cancellation within 200ms of signal receipt,
+/// regardless of which shutdown level is used.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ShutdownSignal {
+    /// Let running tasks finish naturally. No new tasks are started.
+    /// Resources (file handles, network connections, etc.) are cleaned up
+    /// by the running tasks themselves.
+    Graceful,
+
+    /// Abort all in-flight work immediately using task abort mechanisms
+    /// (e.g., `JoinSet::abort()`). In-flight work may leave resources in
+    /// an inconsistent state; cleanup handlers MUST be registered.
+    Immediate,
+}

--- a/engine/src/cancellation/infrastructure/mod.rs
+++ b/engine/src/cancellation/infrastructure/mod.rs
@@ -1,0 +1,16 @@
+//! Infrastructure layer interfaces for the Cancellation bounded context.
+//!
+//! @canonical .pi/architecture/modules/cancellation.md
+//! Implements: Contract Freeze — repository interfaces
+//! Issue: issue-contract-freeze
+//!
+//! This module defines repository interfaces that abstract data access
+//! behind traits. Implementations are provided by the concrete
+//! infrastructure module.
+//!
+//! The Cancellation module does not have persistence requirements at this
+//! time — cancellation state is purely in-memory. Repository interfaces
+//! are reserved here for future use (e.g., persisting cancellation audit
+//! records, storing cancellation policies).
+
+pub mod repository;

--- a/engine/src/cancellation/infrastructure/repository/mod.rs
+++ b/engine/src/cancellation/infrastructure/repository/mod.rs
@@ -1,0 +1,18 @@
+//! Repository interfaces for the Cancellation bounded context.
+//!
+//! @canonical .pi/architecture/modules/cancellation.md
+//! Implements: Contract Freeze — (reserved for future persistence)
+//! Issue: issue-contract-freeze
+//!
+//! Cancellation state is purely in-memory — no persistence is required.
+//! Repository interfaces are reserved here for future use cases such as:
+//!
+//! - Persisting cancellation audit records for compliance
+//! - Storing cancellation policies / grace periods
+//! - Recording cancellation trends for operational analysis
+//!
+//! # Contract (Frozen)
+//! - No repository traits are currently defined
+//! - When added, all repository methods will be async
+//! - All methods will return domain error types
+//! - No framework-specific annotations on trait definitions

--- a/engine/src/cancellation/interfaces/http/mod.rs
+++ b/engine/src/cancellation/interfaces/http/mod.rs
@@ -1,0 +1,267 @@
+//! HTTP API contracts for Cancellation endpoints.
+//!
+//! @canonical .pi/architecture/modules/cancellation.md
+//! Implements: Contract Freeze — HTTP endpoint contracts and error formats
+//! Issue: issue-contract-freeze
+//!
+//! Defines endpoint paths, methods, request/response schemas, and error
+//! response formats. These contracts are framework-agnostic — they describe
+//! the API surface that any HTTP server implementation must satisfy.
+//!
+//! # Contract (Frozen)
+//! - All endpoints documented with method, path, request, and response types
+//! - Error responses follow a unified format
+//! - No framework-specific annotations (axum/actix/warp annotations added by implementation)
+
+use serde::{Deserialize, Serialize};
+
+use crate::cancellation::application::dto::{
+    CancelExecutionOutput, ShutdownOutput,
+    ShutdownStatusOutput,
+};
+
+use crate::cancellation::domain::ShutdownSignal;
+
+// ---------------------------------------------------------------------------
+// API Base Path
+// ---------------------------------------------------------------------------
+
+/// All cancellation endpoints are served under this base path.
+pub const API_BASE_PATH: &str = "/api/v1/execution";
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/execution/{id}/cancel
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/execution/{id}/cancel
+///
+/// Request graceful cancellation of a running execution.
+/// Running tasks finish naturally; no new tasks are started.
+///
+/// **Path Param:** `id` — Execution UUID
+/// **Request:** `CancelExecutionRequest`
+/// **Response:** `202 Accepted` with `CancelExecutionResponse`
+pub const CANCEL_EXECUTION_PATH: &str = "/api/v1/execution/{id}/cancel";
+pub const CANCEL_EXECUTION_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/execution/{id}/cancel.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CancelExecutionRequest {
+    /// Human-readable reason for cancellation.
+    pub reason: Option<String>,
+
+    /// Source identifier for the cancellation request.
+    /// Default: "api"
+    pub source: Option<String>,
+
+    /// Whether this is an immediate abort instead of graceful.
+    /// Default: false (graceful)
+    pub immediate: Option<bool>,
+}
+
+/// Response body for POST /api/v1/execution/{id}/cancel.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CancelExecutionResponse {
+    pub accepted: bool,
+    pub signal: ShutdownSignal,
+    pub affected_tasks: u32,
+    pub was_already_cancelling: bool,
+    pub message: String,
+}
+
+impl From<CancelExecutionOutput> for CancelExecutionResponse {
+    fn from(output: CancelExecutionOutput) -> Self {
+        let message = if output.was_already_cancelling {
+            format!(
+                "Cancellation already in progress with signal {:?}",
+                output.signal
+            )
+        } else {
+            format!(
+                "Cancellation requested with {:?} signal ({} tasks affected)",
+                output.signal, output.affected_tasks
+            )
+        };
+
+        Self {
+            accepted: output.accepted,
+            signal: output.signal,
+            affected_tasks: output.affected_tasks,
+            was_already_cancelling: output.was_already_cancelling,
+            message,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/execution/{id}/abort
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/execution/{id}/abort
+///
+/// Immediately abort a running execution. All in-flight work is
+/// terminated. Use with caution — resources may be left in an
+/// inconsistent state.
+///
+/// **Path Param:** `id` — Execution UUID
+/// **Request:** `AbortExecutionRequest`
+/// **Response:** `202 Accepted` with `CancelExecutionResponse`
+pub const ABORT_EXECUTION_PATH: &str = "/api/v1/execution/{id}/abort";
+pub const ABORT_EXECUTION_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/execution/{id}/abort.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AbortExecutionRequest {
+    /// Reason for the abort.
+    pub reason: Option<String>,
+
+    /// Source identifier.
+    /// Default: "api"
+    pub source: Option<String>,
+}
+
+// Both abort and cancel share the same response type.
+pub use CancelExecutionResponse as AbortExecutionResponse;
+
+// ---------------------------------------------------------------------------
+// Endpoint: GET /api/v1/execution/{id}/status
+// ---------------------------------------------------------------------------
+
+/// GET /api/v1/execution/{id}/status
+///
+/// Get the current cancellation status of an execution.
+///
+/// **Path Param:** `id` — Execution UUID
+/// **Response:** `200 OK` with `ExecutionStatusResponse`
+pub const EXECUTION_STATUS_PATH: &str = "/api/v1/execution/{id}/status";
+pub const EXECUTION_STATUS_METHOD: &str = "GET";
+
+/// Response body for GET /api/v1/execution/{id}/status.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutionStatusResponse {
+    pub execution_id: String,
+    pub is_cancelled: bool,
+    pub current_signal: Option<ShutdownSignal>,
+    pub running_tasks: u32,
+    pub completed_tasks: u32,
+    pub cancelled_tasks: u32,
+    pub shutdown_complete: bool,
+    pub elapsed_since_request_ms: Option<u64>,
+}
+
+impl From<ShutdownStatusOutput> for ExecutionStatusResponse {
+    fn from(output: ShutdownStatusOutput) -> Self {
+        Self {
+            execution_id: String::new(), // Populated by the handler
+            is_cancelled: output.is_cancelled,
+            current_signal: output.current_signal,
+            running_tasks: output.running_tasks,
+            completed_tasks: output.completed_tasks,
+            cancelled_tasks: output.cancelled_tasks,
+            shutdown_complete: output.shutdown_complete,
+            elapsed_since_request_ms: output.elapsed_since_request_ms,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/execution/{id}/await-shutdown
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/execution/{id}/await-shutdown
+///
+/// Wait for shutdown to complete on a cancelled execution.
+/// Blocks until all tasks finish or the specified timeout is reached.
+///
+/// **Path Param:** `id` — Execution UUID
+/// **Request:** `AwaitShutdownRequest`
+/// **Response:** `200 OK` with `AwaitShutdownResponse`
+pub const AWAIT_SHUTDOWN_PATH: &str = "/api/v1/execution/{id}/await-shutdown";
+pub const AWAIT_SHUTDOWN_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/execution/{id}/await-shutdown.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AwaitShutdownRequest {
+    /// Timeout in seconds (default: 30).
+    pub timeout_secs: Option<u64>,
+
+    /// Force-abort remaining tasks after timeout (default: true).
+    pub force_abort_on_timeout: Option<bool>,
+}
+
+/// Response body for POST /api/v1/execution/{id}/await-shutdown.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AwaitShutdownResponse {
+    pub execution_id: String,
+    pub signal_used: ShutdownSignal,
+    pub total_tasks: u32,
+    pub completed_tasks: u32,
+    pub cancelled_tasks: u32,
+    pub shutdown_duration_ms: u64,
+    pub forced: bool,
+    pub cleanup_success: bool,
+    pub timed_out: bool,
+}
+
+impl From<ShutdownOutput> for AwaitShutdownResponse {
+    fn from(output: ShutdownOutput) -> Self {
+        Self {
+            execution_id: String::new(), // Populated by the handler
+            signal_used: output.signal_used,
+            total_tasks: output.total_tasks,
+            completed_tasks: output.completed_tasks,
+            cancelled_tasks: output.cancelled_tasks,
+            shutdown_duration_ms: output.shutdown_duration_ms,
+            forced: output.forced,
+            cleanup_success: output.cleanup_success,
+            timed_out: false,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unified Error Response Format
+// ---------------------------------------------------------------------------
+
+/// Standard error response for all Cancellation API endpoints.
+///
+/// All 4xx/5xx responses use this format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiErrorResponse {
+    /// HTTP status code.
+    pub status: u16,
+    /// Machine-readable error code.
+    pub code: String,
+    /// Human-readable error message.
+    pub message: String,
+    /// Detailed error context (optional, may include field-level errors).
+    pub details: Option<serde_json::Value>,
+    /// Request ID for tracing (if available).
+    pub request_id: Option<String>,
+}
+
+/// Standardized error codes for Cancellation API.
+pub mod error_codes {
+    /// Execution not found.
+    pub const EXECUTION_NOT_FOUND: &str = "EXECUTION_NOT_FOUND";
+    /// Task not found.
+    pub const TASK_NOT_FOUND: &str = "TASK_NOT_FOUND";
+    /// Already cancelled.
+    pub const ALREADY_CANCELLED: &str = "ALREADY_CANCELLED";
+    /// Shutdown timed out.
+    pub const SHUTDOWN_TIMEOUT: &str = "SHUTDOWN_TIMEOUT";
+    /// No active execution.
+    pub const NO_ACTIVE_EXECUTION: &str = "NO_ACTIVE_EXECUTION";
+    /// Internal server error.
+    pub const INTERNAL_ERROR: &str = "CANCELLATION_INTERNAL_ERROR";
+}
+
+/// HTTP status code mappings for Cancellation errors.
+pub mod status_codes {
+    pub const EXECUTION_NOT_FOUND: u16 = 404;
+    pub const TASK_NOT_FOUND: u16 = 404;
+    pub const ALREADY_CANCELLED: u16 = 409;
+    pub const SHUTDOWN_TIMEOUT: u16 = 504;
+    pub const NO_ACTIVE_EXECUTION: u16 = 404;
+    pub const INTERNAL_ERROR: u16 = 500;
+}

--- a/engine/src/cancellation/interfaces/mod.rs
+++ b/engine/src/cancellation/interfaces/mod.rs
@@ -1,0 +1,20 @@
+//! Interface adapters for the Cancellation bounded context.
+//!
+//! @canonical .pi/architecture/modules/cancellation.md
+//! Implements: Contract Freeze — HTTP API endpoint contracts
+//! Issue: issue-contract-freeze
+//!
+//! This module defines API contracts (HTTP, CLI, etc.) that external
+//! actors use to interact with the cancellation system.
+//!
+//! # Cancellation API Context
+//!
+//! Cancellation is primarily triggered by:
+//! 1. OS signals (SIGINT, SIGTERM) — handled by the orchestrator
+//! 2. TUI user commands — passed through the orchestrator
+//! 3. Internal enforcement limits — coordinated by the orchestrator
+//!
+//! The HTTP API provides an additional remote cancellation surface
+//! for programmatic control (e.g., CI/CD pipelines, web dashboards).
+
+pub mod http;

--- a/engine/src/cancellation/mod.rs
+++ b/engine/src/cancellation/mod.rs
@@ -1,0 +1,40 @@
+//! Cancellation bounded context.
+//!
+//! @canonical .pi/architecture/modules/cancellation.md
+//! Implements: Contract Freeze — cancellation module root
+//! Issue: issue-contract-freeze
+//!
+//! Manages graceful and immediate cancellation of running workflows. Uses
+//! CancellationToken (tokio-util) for coordinated propagation to all
+//! concurrent tasks, with two shutdown signal levels: Graceful (let running
+//! tasks finish) and Immediate (abort all in-flight work).
+//!
+//! # Architecture
+//!
+//! ```text
+//! cancellation/
+//! ├── domain/           # Domain entities (ShutdownSignal), errors, events
+//! │   ├── error.rs      # CancellationError enum
+//! │   ├── signal.rs     # ShutdownSignal value object
+//! │   └── event/        # CancellationEvent payload schemas
+//! ├── application/      # Service traits, DTOs, factory interfaces
+//! │   ├── service.rs    # CancellationService trait
+//! │   ├── factory.rs    # CancellationToken factory interfaces
+//! │   └── dto/          # Input/Output DTOs with validation
+//! ├── infrastructure/   # Repository interfaces
+//! │   └── repository/   # (reserved for future persistence)
+//! └── interfaces/       # API contracts
+//!     └── http/         # REST endpoint contracts
+//! ```
+//!
+//! # Contract Freeze Notice
+//!
+//! ALL files in this module are frozen contracts.
+//! - No implementation changes without explicit contract change approval
+//! - Implementation PRs MUST reference these interfaces
+//! - DTO schemas serve as the canonical data contract
+
+pub mod application;
+pub mod domain;
+pub mod infrastructure;
+pub mod interfaces;

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -11,6 +11,8 @@
 //!
 //! ## Phase 0: Foundation
 //! - `configuration` — Config loading, multi-source merging, Secret wrapper
+//! - `cancellation` — Graceful and immediate cancellation management
+//! - `audit` — Execution audit trails, typed envelopes, circuit breaker
 //!
 //! ## Architecture
 //! - `domain/` — Core domain entities and interfaces
@@ -19,4 +21,5 @@
 //! - `interfaces/` — API contracts (HTTP, events)
 
 pub mod audit;
+pub mod cancellation;
 pub mod configuration;


### PR DESCRIPTION
## Summary

Contract freeze for the Cancellation bounded context — interfaces, DTOs, events, and API contracts for both components in this epic (CancellationManager + ShutdownSignal).

## Changes

### New Module: `cancellation/` (13 files)

| Layer | Key Contracts |
|-------|--------------|
| **Domain** | `ShutdownSignal` (Graceful/Immediate), `CancellationError` (7 variants), `CancellationEvent` (7 event types) |
| **Application** | `CancellationService`, `CleanupHandler`, `CancellationManagerFactory` traits + full DTO suite |
| **Infrastructure** | Repository placeholder for future persistence |
| **Interfaces** | 4 HTTP endpoints: POST cancel, POST abort, GET status, POST await-shutdown |

### Modified
- `Cargo.toml`: Added `tokio-util = 0.7` dependency
- `lib.rs`: Registered `pub mod cancellation`

## Compliance
- ✅ Clean Architecture layout matching `configuration` and `audit` modules
- ✅ All interfaces async via `async-trait`
- ✅ Domain errors via `thiserror`
- ✅ DTOs serializable (serde)
- ✅ API contracts framework-agnostic
- ✅ No implementation logic — frozen contracts only
- ✅ Builds clean (0 errors, 0 warnings)
- ✅ All 61 existing tests pass