### PR TITLE
feat(#58): implement EnforcementConfig with preset builders and validation

### DIFF
--- a/engine/.pi/.guardian-pipeline-state.json
+++ b/engine/.pi/.guardian-pipeline-state.json
@@ -49,12 +49,44 @@
       }
     }
   ],
-  "currentItemIndex": 0,
+  "currentItemIndex": 1,
   "currentStepIndex": 0,
   "status": "running",
   "retryCount": 0,
-  "results": [],
+  "results": [
+    {
+      "item": "issue-contract-freeze",
+      "status": "done",
+      "stepResults": [
+        {
+          "step": "implement",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "implement",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "validate",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "create-mr",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "merge",
+          "status": "passed",
+          "reason": ""
+        }
+      ]
+    }
+  ],
   "mergeOnValid": true,
   "createdAt": "2026-06-13T11:24:54.408Z",
-  "updatedAt": "2026-06-13T11:24:54.408Z"
+  "updatedAt": "2026-06-13T11:28:54.093Z"
 }

--- a/engine/src/enforcement/application/config_service_impl.rs
+++ b/engine/src/enforcement/application/config_service_impl.rs
@@ -1,0 +1,540 @@
+//! Implementation of enforcement configuration building and validation.
+//!
+//! @canonical .pi/architecture/modules/enforcement.md#application
+//! Implements: ISSUE-ENFORCEMENT-1 — EnforcementConfig preset builders and validation
+//! Issue: #58
+//!
+//! Provides concrete implementations for building `EnforcementConfig` instances
+//! from `EnforcementPresetProfile` selections, merging user overrides, and
+//! validating configurations against safety hard caps.
+//!
+//! # Contract (Frozen)
+//! - All preset profiles produce deterministic, safe configurations
+//! - Validation is always performed before returning a configuration
+//! - Warnings are non-blocking; hard cap violations are errors
+
+use crate::enforcement::domain::{
+    ConfigValidationError, EnforcementConfig, EnforcementPresetProfile, SafetyCaps,
+};
+
+/// Build and validate enforcement configurations from preset profiles.
+///
+/// Provides methods to:
+/// - Build configs from preset profiles (Standard, Strict, Maximum)
+/// - Apply user overrides to budgets and tool policies
+/// - Validate configs against safety hard caps
+/// - Merge multiple config sources
+pub struct ConfigBuilder;
+
+impl ConfigBuilder {
+    /// Build an `EnforcementConfig` from a preset profile.
+    ///
+    /// Returns the config immediately. If validation is needed,
+    /// call `validate()` separately.
+    pub fn build_from_preset(preset: &EnforcementPresetProfile) -> EnforcementConfig {
+        EnforcementConfig::from_preset(preset)
+    }
+
+    /// Build and validate a config from a preset profile.
+    ///
+    /// Returns the config if it passes safety cap validation, or
+    /// a list of validation errors if any caps are exceeded.
+    pub fn build_from_preset_with_validation(
+        preset: &EnforcementPresetProfile,
+        safety_caps: Option<&SafetyCaps>,
+    ) -> Result<EnforcementConfig, Vec<ConfigValidationError>> {
+        let config = Self::build_from_preset(preset);
+        let default_caps = SafetyCaps::default();
+        let caps = safety_caps.unwrap_or(&default_caps);
+        let errors = config.validate(caps);
+        if errors.is_empty() {
+            Ok(config)
+        } else {
+            Err(errors)
+        }
+    }
+
+    /// Merge a user-provided `EnforcementConfig` with the preset defaults.
+    ///
+    /// User budgets and policies take precedence over preset defaults.
+    /// Execution limits from `user_config` override preset defaults if set
+    /// (non-default), otherwise preset values are kept.
+    pub fn merge_with_preset(
+        preset: &EnforcementPresetProfile,
+        user_config: EnforcementConfig,
+    ) -> EnforcementConfig {
+        let mut config = Self::build_from_preset(preset);
+
+        // Merge budgets: user budgets override preset budgets
+        for (name, budget) in user_config.budgets {
+            config.budgets.insert(name, budget);
+        }
+
+        // Merge tool policies: user policies override preset policies
+        for (tool, policy) in user_config.tool_policies {
+            config.tool_policies.insert(tool, policy);
+        }
+
+        // Apply user execution limits if they differ from defaults
+        let user_defaults = EnforcementConfig::default();
+        if user_config.execution_limits != user_defaults.execution_limits {
+            config.execution_limits = user_config.execution_limits;
+        }
+
+        // Apply user default tool policy if it differs from defaults
+        if user_config.default_tool_policy != user_defaults.default_tool_policy {
+            config.default_tool_policy = user_config.default_tool_policy;
+        }
+
+        config
+    }
+
+    /// Validate an `EnforcementConfig` against safety caps.
+    ///
+    /// Returns `Ok(())` if all values are within bounds, or a list
+    /// of validation errors.
+    pub fn validate(
+        config: &EnforcementConfig,
+        safety_caps: Option<&SafetyCaps>,
+    ) -> Result<(), Vec<ConfigValidationError>> {
+        let default_caps = SafetyCaps::default();
+        let caps = safety_caps.unwrap_or(&default_caps);
+        let errors = config.validate(caps);
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+
+    /// Check if a specific tool policy is valid.
+    ///
+    /// Validates that:
+    /// - `max_calls` is not 0 (if set)
+    /// - The budget_key references an existing budget (if set)
+    pub fn validate_tool_policy(
+        policy: &crate::enforcement::domain::ToolPolicy,
+        config: &EnforcementConfig,
+    ) -> Result<(), Vec<ConfigValidationError>> {
+        let mut errors = Vec::new();
+
+        if let Some(max_calls) = policy.max_calls {
+            if max_calls == 0 {
+                errors.push(ConfigValidationError {
+                    field: "tool_policy.max_calls".to_string(),
+                    message: "max_calls must be greater than 0 if set".to_string(),
+                    value: Some("0".to_string()),
+                });
+            }
+        }
+
+        if let Some(budget_key) = &policy.budget_key {
+            if !config.budgets.contains_key(budget_key) {
+                errors.push(ConfigValidationError {
+                    field: "tool_policy.budget_key".to_string(),
+                    message: format!(
+                        "budget_key '{}' does not reference an existing budget",
+                        budget_key
+                    ),
+                    value: Some(budget_key.clone()),
+                });
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::enforcement::domain::{EnforcementPresetProfile, SafetyCaps, ToolPolicy, ToolRiskLevel};
+
+    // -----------------------------------------------------------------------
+    // Preset Building Tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_build_standard_preset() {
+        let config = ConfigBuilder::build_from_preset(&EnforcementPresetProfile::Standard);
+        assert_eq!(config.preset, EnforcementPresetProfile::Standard);
+        assert!(config.budgets.contains_key("tokens"));
+        assert!(config.budgets.contains_key("tool_calls"));
+        assert!(config.budgets.contains_key("execution_time_ms"));
+        assert!(config.tool_policies.contains_key("bash"));
+        assert!(config.tool_policies.contains_key("write"));
+        assert!(config.tool_policies.contains_key("read"));
+        assert_eq!(config.execution_limits.max_tool_calls, 500);
+        assert_eq!(config.execution_limits.max_tokens, 100_000);
+    }
+
+    #[test]
+    fn test_build_strict_preset() {
+        let config = ConfigBuilder::build_from_preset(&EnforcementPresetProfile::Strict);
+        assert_eq!(config.preset, EnforcementPresetProfile::Strict);
+        assert_eq!(config.budgets.get("tokens").unwrap().hard_limit, 50_000);
+        assert_eq!(config.budgets.get("tool_calls").unwrap().hard_limit, 200);
+        assert_eq!(config.execution_limits.max_tool_calls, 200);
+        assert_eq!(config.execution_limits.max_concurrent_tools, 5);
+        // Strict requires confirmation for writes
+        assert!(config.tool_policies.get("write").unwrap().requires_confirmation);
+        assert!(config.tool_policies.get("bash").unwrap().requires_confirmation);
+    }
+
+    #[test]
+    fn test_build_maximum_preset() {
+        let config = ConfigBuilder::build_from_preset(&EnforcementPresetProfile::Maximum);
+        assert_eq!(config.preset, EnforcementPresetProfile::Maximum);
+        assert_eq!(config.budgets.get("tokens").unwrap().hard_limit, 20_000);
+        assert_eq!(config.budgets.get("tool_calls").unwrap().hard_limit, 50);
+        assert_eq!(config.execution_limits.max_tool_calls, 50);
+        assert_eq!(config.execution_limits.max_concurrent_tools, 2);
+        // Maximum blocks bash
+        assert!(!config.tool_policies.get("bash").unwrap().allowed);
+        // Maximum sets dry_run on write
+        assert!(config.tool_policies.get("write").unwrap().dry_run);
+    }
+
+    #[test]
+    fn test_from_preset_standard() {
+        let config = EnforcementConfig::from_preset(&EnforcementPresetProfile::Standard);
+        assert_eq!(config.preset, EnforcementPresetProfile::Standard);
+    }
+
+    #[test]
+    fn test_from_preset_strict() {
+        let config = EnforcementConfig::from_preset(&EnforcementPresetProfile::Strict);
+        assert_eq!(config.preset, EnforcementPresetProfile::Strict);
+    }
+
+    #[test]
+    fn test_from_preset_maximum() {
+        let config = EnforcementConfig::from_preset(&EnforcementPresetProfile::Maximum);
+        assert_eq!(config.preset, EnforcementPresetProfile::Maximum);
+    }
+
+    // -----------------------------------------------------------------------
+    // Builder Method Tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_with_budget_override() {
+        let mut config = EnforcementConfig::standard();
+        let original = config.budgets.get("tokens").unwrap().hard_limit;
+        assert_eq!(original, 100_000);
+
+        let override_budget = crate::enforcement::domain::ResourceBudget {
+            resource: "tokens".to_string(),
+            soft_warning_threshold: 0.9,
+            hard_limit: 200_000,
+            current_usage: 0,
+        };
+        config = config.with_budget(override_budget);
+        assert_eq!(config.budgets.get("tokens").unwrap().hard_limit, 200_000);
+    }
+
+    #[test]
+    fn test_with_tool_policy_override() {
+        let mut config = EnforcementConfig::standard();
+        assert!(config.tool_policies.get("bash").unwrap().allowed);
+
+        let blocked_bash = ToolPolicy {
+            allowed: false,
+            risk_level: ToolRiskLevel::Critical,
+            requires_confirmation: true,
+            dry_run: false,
+            max_calls: Some(0),
+            budget_key: None,
+        };
+        config = config.with_tool_policy("bash", blocked_bash);
+        assert!(!config.tool_policies.get("bash").unwrap().allowed);
+    }
+
+    #[test]
+    fn test_with_execution_limits() {
+        let mut config = EnforcementConfig::standard();
+        let tight_limits = crate::enforcement::domain::ExecutionLimits {
+            max_tool_calls: 10,
+            max_execution_time_secs: 60,
+            max_tokens: 5_000,
+            max_retries_per_node: 1,
+            max_concurrent_tools: 1,
+        };
+        config = config.with_execution_limits(tight_limits);
+        assert_eq!(config.execution_limits.max_tool_calls, 10);
+        assert_eq!(config.execution_limits.max_concurrent_tools, 1);
+    }
+
+    #[test]
+    fn test_with_default_tool_policy() {
+        let mut config = EnforcementConfig::standard();
+        let restrictive_default = ToolPolicy {
+            allowed: true,
+            risk_level: ToolRiskLevel::High,
+            requires_confirmation: true,
+            dry_run: true,
+            max_calls: Some(5),
+            budget_key: None,
+        };
+        config = config.with_default_tool_policy(restrictive_default);
+        assert!(config.default_tool_policy.requires_confirmation);
+        assert!(config.default_tool_policy.dry_run);
+    }
+
+    // -----------------------------------------------------------------------
+    // Validation Tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_standard_config_valid_against_default_caps() {
+        let config = EnforcementConfig::standard();
+        let caps = SafetyCaps::default();
+        assert!(config.is_valid(&caps));
+    }
+
+    #[test]
+    fn test_strict_config_valid_against_default_caps() {
+        let config = EnforcementConfig::strict();
+        let caps = SafetyCaps::default();
+        assert!(config.is_valid(&caps));
+    }
+
+    #[test]
+    fn test_maximum_config_valid_against_default_caps() {
+        let config = EnforcementConfig::maximum();
+        let caps = SafetyCaps::default();
+        assert!(config.is_valid(&caps));
+    }
+
+    #[test]
+    fn test_validation_detects_exceeded_tool_call_cap() {
+        let mut config = EnforcementConfig::standard();
+        config.execution_limits.max_tool_calls = 999_999;
+        let caps = SafetyCaps {
+            max_parallel_tasks_cap: 10,
+            max_tool_calls_cap: 1000,
+            max_retries_cap: 5,
+            max_timeout_secs_cap: 3600,
+            max_tokens_cap: 200_000,
+            max_concurrent_tools_cap: 20,
+            max_budget_cap: 1_000_000,
+        };
+        let errors = config.validate(&caps);
+        assert!(errors.iter().any(|e| e.field.contains("max_tool_calls")));
+    }
+
+    #[test]
+    fn test_validation_detects_exceeded_timeout_cap() {
+        let mut config = EnforcementConfig::standard();
+        config.execution_limits.max_execution_time_secs = 999_999;
+        let caps = SafetyCaps {
+            max_timeout_secs_cap: 3600,
+            ..SafetyCaps::default()
+        };
+        let errors = config.validate(&caps);
+        assert!(errors.iter().any(|e| e.field.contains("max_execution_time_secs")));
+    }
+
+    #[test]
+    fn test_validation_detects_exceeded_budget_cap() {
+        let mut config = EnforcementConfig::standard();
+        config.budgets.get_mut("tokens").unwrap().hard_limit = 99_999_999;
+        let caps = SafetyCaps {
+            max_budget_cap: 1_000_000,
+            ..SafetyCaps::default()
+        };
+        let errors = config.validate(&caps);
+        assert!(errors.iter().any(|e| e.field.contains("tokens")));
+    }
+
+    #[test]
+    fn test_validation_detects_invalid_warning_threshold() {
+        let mut config = EnforcementConfig::standard();
+        config.budgets.get_mut("tokens").unwrap().soft_warning_threshold = 1.5;
+        let caps = SafetyCaps::default();
+        let errors = config.validate(&caps);
+        assert!(errors.iter().any(|e| e.field.contains("soft_warning_threshold")));
+    }
+
+    #[test]
+    fn test_validation_passes_for_strict_config_with_tight_caps() {
+        let config = EnforcementConfig::strict();
+        // Caps that exactly match the strict preset values
+        let caps = SafetyCaps {
+            max_parallel_tasks_cap: 10,
+            max_tool_calls_cap: 200,
+            max_retries_cap: 5,
+            max_timeout_secs_cap: 1800,
+            max_tokens_cap: 100_000,
+            max_concurrent_tools_cap: 5,
+            max_budget_cap: 1_000_000, // Must cover execution_time_ms budget (600_000)
+        };
+        assert!(config.is_valid(&caps));
+    }
+
+    #[test]
+    fn test_config_builder_validate_tool_policy_invalid_max_calls() {
+        let config = EnforcementConfig::standard();
+        let bad_policy = ToolPolicy {
+            allowed: true,
+            risk_level: ToolRiskLevel::Low,
+            requires_confirmation: false,
+            dry_run: false,
+            max_calls: Some(0),
+            budget_key: None,
+        };
+        let result = ConfigBuilder::validate_tool_policy(&bad_policy, &config);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_config_builder_validate_tool_policy_invalid_budget_key() {
+        let config = EnforcementConfig::standard();
+        let bad_policy = ToolPolicy {
+            allowed: true,
+            risk_level: ToolRiskLevel::Low,
+            requires_confirmation: false,
+            dry_run: false,
+            max_calls: None,
+            budget_key: Some("nonexistent_budget".to_string()),
+        };
+        let result = ConfigBuilder::validate_tool_policy(&bad_policy, &config);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_config_builder_validate_tool_policy_valid() {
+        let config = EnforcementConfig::standard();
+        let good_policy = ToolPolicy {
+            allowed: true,
+            risk_level: ToolRiskLevel::Low,
+            requires_confirmation: false,
+            dry_run: false,
+            max_calls: Some(10),
+            budget_key: Some("tokens".to_string()),
+        };
+        let result = ConfigBuilder::validate_tool_policy(&good_policy, &config);
+        assert!(result.is_ok());
+    }
+
+    // -----------------------------------------------------------------------
+    // Merge Tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_merge_with_preset_overrides_budgets() {
+        let user_config = EnforcementConfig {
+            budgets: {
+                let mut b = std::collections::HashMap::new();
+                b.insert(
+                    "custom_resource".to_string(),
+                    crate::enforcement::domain::ResourceBudget {
+                        resource: "custom_resource".to_string(),
+                        soft_warning_threshold: 0.5,
+                        hard_limit: 100,
+                        current_usage: 0,
+                    },
+                );
+                b
+            },
+            ..EnforcementConfig::default()
+        };
+
+        let merged = ConfigBuilder::merge_with_preset(&EnforcementPresetProfile::Standard, user_config);
+        assert!(merged.budgets.contains_key("custom_resource"));
+        // Original preset budgets should still exist
+        assert!(merged.budgets.contains_key("tokens"));
+        assert!(merged.budgets.contains_key("tool_calls"));
+    }
+
+    #[test]
+    fn test_merge_with_preset_overrides_tool_policies() {
+        let mut user_config = EnforcementConfig::default();
+        user_config.tool_policies.insert(
+            "bash".to_string(),
+            ToolPolicy {
+                allowed: false,
+                ..ToolPolicy::default()
+            },
+        );
+
+        let merged = ConfigBuilder::merge_with_preset(&EnforcementPresetProfile::Standard, user_config);
+        // User's block policy should win
+        assert!(!merged.tool_policies.get("bash").unwrap().allowed);
+    }
+
+    // -----------------------------------------------------------------------
+    // Builder with Validation Tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_build_from_preset_with_validation_passes() {
+        let result = ConfigBuilder::build_from_preset_with_validation(
+            &EnforcementPresetProfile::Standard,
+            None,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_build_from_preset_with_validation_fails_with_tight_caps() {
+        let tight_caps = SafetyCaps {
+            max_tool_calls_cap: 10,
+            ..SafetyCaps::default()
+        };
+        let result = ConfigBuilder::build_from_preset_with_validation(
+            &EnforcementPresetProfile::Standard,
+            Some(&tight_caps),
+        );
+        // Standard preset has max_tool_calls=500 which exceeds cap of 10
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.iter().any(|e| e.field.contains("max_tool_calls")));
+    }
+
+    // -----------------------------------------------------------------------
+    // Default Implementation Tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_default_config_is_standard() {
+        let config = EnforcementConfig::default();
+        assert_eq!(config.preset, EnforcementPresetProfile::Standard);
+        assert_eq!(config.budgets.len(), 3);
+    }
+
+    #[test]
+    fn test_default_safety_caps() {
+        let caps = SafetyCaps::default();
+        assert_eq!(caps.max_parallel_tasks_cap, 10);
+        assert_eq!(caps.max_retries_cap, 5);
+        assert_eq!(caps.max_timeout_secs_cap, 3600);
+        assert_eq!(caps.max_tokens_cap, 200_000);
+        assert_eq!(caps.max_concurrent_tools_cap, 20);
+        assert_eq!(caps.max_budget_cap, 1_000_000);
+    }
+
+    // -----------------------------------------------------------------------
+    // Serde Round-Trip Tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_config_serde_roundtrip() {
+        let config = EnforcementConfig::standard();
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: EnforcementConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, config);
+    }
+
+    #[test]
+    fn test_safety_caps_serde_roundtrip() {
+        let caps = SafetyCaps::default();
+        let json = serde_json::to_string(&caps).unwrap();
+        let deserialized: SafetyCaps = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, caps);
+    }
+}

--- a/engine/src/enforcement/application/mod.rs
+++ b/engine/src/enforcement/application/mod.rs
@@ -15,10 +15,12 @@
 //! - DTOs include validation annotations/documentation
 //! - No implementation logic — only trait definitions
 
+pub mod config_service_impl;
 pub mod dto;
 pub mod factory;
 pub mod service;
 
+pub use config_service_impl::*;
 pub use dto::*;
 pub use factory::*;
 pub use service::*;

--- a/engine/src/enforcement/domain/config.rs
+++ b/engine/src/enforcement/domain/config.rs
@@ -48,14 +48,460 @@ pub struct EnforcementConfig {
 
 impl Default for EnforcementConfig {
     fn default() -> Self {
+        Self::standard()
+    }
+}
+
+impl EnforcementConfig {
+    // -----------------------------------------------------------------------
+    // Preset Builders
+    // -----------------------------------------------------------------------
+
+    /// Build the Standard enforcement configuration.
+    ///
+    /// Suitable for normal operation. Provides reasonable safety limits
+    /// without being overly restrictive.
+    pub fn standard() -> Self {
+        let mut budgets = HashMap::new();
+        budgets.insert(
+            "tokens".to_string(),
+            ResourceBudget {
+                resource: "tokens".to_string(),
+                soft_warning_threshold: 0.8,
+                hard_limit: 100_000,
+                current_usage: 0,
+            },
+        );
+        budgets.insert(
+            "tool_calls".to_string(),
+            ResourceBudget {
+                resource: "tool_calls".to_string(),
+                soft_warning_threshold: 0.8,
+                hard_limit: 500,
+                current_usage: 0,
+            },
+        );
+        budgets.insert(
+            "execution_time_ms".to_string(),
+            ResourceBudget {
+                resource: "execution_time_ms".to_string(),
+                soft_warning_threshold: 0.85,
+                hard_limit: 900_000, // 15 minutes
+                current_usage: 0,
+            },
+        );
+
+        let mut tool_policies = HashMap::new();
+        tool_policies.insert(
+            "bash".to_string(),
+            ToolPolicy {
+                allowed: true,
+                risk_level: ToolRiskLevel::High,
+                requires_confirmation: true,
+                dry_run: false,
+                max_calls: Some(100),
+                budget_key: Some("tool_calls".to_string()),
+            },
+        );
+        tool_policies.insert(
+            "write".to_string(),
+            ToolPolicy {
+                allowed: true,
+                risk_level: ToolRiskLevel::Medium,
+                requires_confirmation: false,
+                dry_run: false,
+                max_calls: None,
+                budget_key: Some("tool_calls".to_string()),
+            },
+        );
+        tool_policies.insert(
+            "read".to_string(),
+            ToolPolicy {
+                allowed: true,
+                risk_level: ToolRiskLevel::Low,
+                requires_confirmation: false,
+                dry_run: false,
+                max_calls: None,
+                budget_key: None,
+            },
+        );
+
         Self {
-            budgets: HashMap::new(),
+            budgets,
             execution_limits: ExecutionLimits::default(),
-            tool_policies: HashMap::new(),
+            tool_policies,
             default_tool_policy: ToolPolicy::default(),
             preset: EnforcementPresetProfile::Standard,
         }
     }
+
+    /// Build the Strict enforcement configuration.
+    ///
+    /// Suitable for production or untrusted code. Applies tighter
+    /// budgets and more restrictive tool policies, requiring confirmation
+    /// for medium-risk tools as well.
+    pub fn strict() -> Self {
+        let mut budgets = HashMap::new();
+        budgets.insert(
+            "tokens".to_string(),
+            ResourceBudget {
+                resource: "tokens".to_string(),
+                soft_warning_threshold: 0.7,
+                hard_limit: 50_000,
+                current_usage: 0,
+            },
+        );
+        budgets.insert(
+            "tool_calls".to_string(),
+            ResourceBudget {
+                resource: "tool_calls".to_string(),
+                soft_warning_threshold: 0.7,
+                hard_limit: 200,
+                current_usage: 0,
+            },
+        );
+        budgets.insert(
+            "execution_time_ms".to_string(),
+            ResourceBudget {
+                resource: "execution_time_ms".to_string(),
+                soft_warning_threshold: 0.75,
+                hard_limit: 600_000, // 10 minutes
+                current_usage: 0,
+            },
+        );
+
+        let mut tool_policies = HashMap::new();
+        tool_policies.insert(
+            "bash".to_string(),
+            ToolPolicy {
+                allowed: true,
+                risk_level: ToolRiskLevel::Critical,
+                requires_confirmation: true,
+                dry_run: false,
+                max_calls: Some(50),
+                budget_key: Some("tool_calls".to_string()),
+            },
+        );
+        tool_policies.insert(
+            "write".to_string(),
+            ToolPolicy {
+                allowed: true,
+                risk_level: ToolRiskLevel::High,
+                requires_confirmation: true,
+                dry_run: false,
+                max_calls: Some(100),
+                budget_key: Some("tool_calls".to_string()),
+            },
+        );
+        tool_policies.insert(
+            "read".to_string(),
+            ToolPolicy {
+                allowed: true,
+                risk_level: ToolRiskLevel::Low,
+                requires_confirmation: false,
+                dry_run: false,
+                max_calls: None,
+                budget_key: None,
+            },
+        );
+
+        Self {
+            budgets,
+            execution_limits: ExecutionLimits {
+                max_tool_calls: 200,
+                max_execution_time_secs: 1800,
+                max_tokens: 50_000,
+                max_retries_per_node: 2,
+                max_concurrent_tools: 5,
+            },
+            tool_policies,
+            default_tool_policy: ToolPolicy {
+                allowed: true,
+                risk_level: ToolRiskLevel::Medium,
+                requires_confirmation: true,
+                dry_run: false,
+                max_calls: None,
+                budget_key: None,
+            },
+            preset: EnforcementPresetProfile::Strict,
+        }
+    }
+
+    /// Build the Maximum enforcement configuration.
+    ///
+    /// Suitable for high-risk operations. Applies the most restrictive
+    /// budgets, limits, and policies. All state-modifying operations
+    /// require confirmation and are heavily constrained.
+    pub fn maximum() -> Self {
+        let mut budgets = HashMap::new();
+        budgets.insert(
+            "tokens".to_string(),
+            ResourceBudget {
+                resource: "tokens".to_string(),
+                soft_warning_threshold: 0.5,
+                hard_limit: 20_000,
+                current_usage: 0,
+            },
+        );
+        budgets.insert(
+            "tool_calls".to_string(),
+            ResourceBudget {
+                resource: "tool_calls".to_string(),
+                soft_warning_threshold: 0.5,
+                hard_limit: 50,
+                current_usage: 0,
+            },
+        );
+        budgets.insert(
+            "execution_time_ms".to_string(),
+            ResourceBudget {
+                resource: "execution_time_ms".to_string(),
+                soft_warning_threshold: 0.6,
+                hard_limit: 600_000, // 10 minutes
+                current_usage: 0,
+            },
+        );
+
+        let mut tool_policies = HashMap::new();
+        tool_policies.insert(
+            "bash".to_string(),
+            ToolPolicy {
+                allowed: false,
+                risk_level: ToolRiskLevel::Critical,
+                requires_confirmation: true,
+                dry_run: true,
+                max_calls: Some(10),
+                budget_key: Some("tool_calls".to_string()),
+            },
+        );
+        tool_policies.insert(
+            "write".to_string(),
+            ToolPolicy {
+                allowed: true,
+                risk_level: ToolRiskLevel::High,
+                requires_confirmation: true,
+                dry_run: true,
+                max_calls: Some(20),
+                budget_key: Some("tool_calls".to_string()),
+            },
+        );
+        tool_policies.insert(
+            "read".to_string(),
+            ToolPolicy {
+                allowed: true,
+                risk_level: ToolRiskLevel::Low,
+                requires_confirmation: false,
+                dry_run: false,
+                max_calls: Some(200),
+                budget_key: None,
+            },
+        );
+
+        Self {
+            budgets,
+            execution_limits: ExecutionLimits {
+                max_tool_calls: 50,
+                max_execution_time_secs: 600,
+                max_tokens: 20_000,
+                max_retries_per_node: 1,
+                max_concurrent_tools: 2,
+            },
+            tool_policies,
+            default_tool_policy: ToolPolicy {
+                allowed: true,
+                risk_level: ToolRiskLevel::Medium,
+                requires_confirmation: true,
+                dry_run: true,
+                max_calls: Some(10),
+                budget_key: None,
+            },
+            preset: EnforcementPresetProfile::Maximum,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Builder Methods
+    // -----------------------------------------------------------------------
+
+    /// Create an EnforcementConfig from the given preset profile.
+    pub fn from_preset(preset: &EnforcementPresetProfile) -> Self {
+        match preset {
+            EnforcementPresetProfile::Standard => Self::standard(),
+            EnforcementPresetProfile::Strict => Self::strict(),
+            EnforcementPresetProfile::Maximum => Self::maximum(),
+        }
+    }
+
+    /// Add or override a resource budget.
+    pub fn with_budget(mut self, budget: ResourceBudget) -> Self {
+        self.budgets.insert(budget.resource.clone(), budget);
+        self
+    }
+
+    /// Add or override a tool policy.
+    pub fn with_tool_policy(mut self, tool: &str, policy: ToolPolicy) -> Self {
+        self.tool_policies.insert(tool.to_string(), policy);
+        self
+    }
+
+    /// Replace the execution limits.
+    pub fn with_execution_limits(mut self, limits: ExecutionLimits) -> Self {
+        self.execution_limits = limits;
+        self
+    }
+
+    /// Replace the default tool policy.
+    pub fn with_default_tool_policy(mut self, policy: ToolPolicy) -> Self {
+        self.default_tool_policy = policy;
+        self
+    }
+
+    // -----------------------------------------------------------------------
+    // Validation
+    // -----------------------------------------------------------------------
+
+    /// Validate the configuration against safety caps.
+    ///
+    /// Checks that all values are within acceptable bounds.
+    /// Returns a list of validation errors (empty if valid).
+    pub fn validate(&self, safety_caps: &SafetyCaps) -> Vec<ConfigValidationError> {
+        let mut errors = Vec::new();
+
+        // Check execution limits against caps
+        if self.execution_limits.max_tool_calls > safety_caps.max_tool_calls_cap {
+            errors.push(ConfigValidationError {
+                field: "execution_limits.max_tool_calls".to_string(),
+                message: format!(
+                    "max_tool_calls {} exceeds safety cap {}",
+                    self.execution_limits.max_tool_calls,
+                    safety_caps.max_tool_calls_cap
+                ),
+                value: Some(self.execution_limits.max_tool_calls.to_string()),
+            });
+        }
+
+        if self.execution_limits.max_execution_time_secs > safety_caps.max_timeout_secs_cap {
+            errors.push(ConfigValidationError {
+                field: "execution_limits.max_execution_time_secs".to_string(),
+                message: format!(
+                    "max_execution_time_secs {} exceeds safety cap {}",
+                    self.execution_limits.max_execution_time_secs,
+                    safety_caps.max_timeout_secs_cap
+                ),
+                value: Some(self.execution_limits.max_execution_time_secs.to_string()),
+            });
+        }
+
+        if (self.execution_limits.max_retries_per_node as u64) > safety_caps.max_retries_cap {
+            errors.push(ConfigValidationError {
+                field: "execution_limits.max_retries_per_node".to_string(),
+                message: format!(
+                    "max_retries_per_node {} exceeds safety cap {}",
+                    self.execution_limits.max_retries_per_node,
+                    safety_caps.max_retries_cap
+                ),
+                value: Some(self.execution_limits.max_retries_per_node.to_string()),
+            });
+        }
+
+        if (self.execution_limits.max_concurrent_tools as u64) > safety_caps.max_concurrent_tools_cap {
+            errors.push(ConfigValidationError {
+                field: "execution_limits.max_concurrent_tools".to_string(),
+                message: format!(
+                    "max_concurrent_tools {} exceeds safety cap {}",
+                    self.execution_limits.max_concurrent_tools,
+                    safety_caps.max_concurrent_tools_cap
+                ),
+                value: Some(self.execution_limits.max_concurrent_tools.to_string()),
+            });
+        }
+
+        // Check budgets against caps
+        for (name, budget) in &self.budgets {
+            if budget.hard_limit > safety_caps.max_budget_cap {
+                errors.push(ConfigValidationError {
+                    field: format!("budgets.{}.hard_limit", name),
+                    message: format!(
+                        "hard_limit {} for budget '{}' exceeds safety cap {}",
+                        budget.hard_limit, name, safety_caps.max_budget_cap
+                    ),
+                    value: Some(budget.hard_limit.to_string()),
+                });
+            }
+
+            if budget.soft_warning_threshold < 0.0 || budget.soft_warning_threshold > 1.0 {
+                errors.push(ConfigValidationError {
+                    field: format!("budgets.{}.soft_warning_threshold", name),
+                    message: format!(
+                        "soft_warning_threshold {} for budget '{}' must be between 0.0 and 1.0",
+                        budget.soft_warning_threshold, name
+                    ),
+                    value: Some(budget.soft_warning_threshold.to_string()),
+                });
+            }
+        }
+
+        errors
+    }
+
+    /// Check if the configuration is valid (no validation errors).
+    pub fn is_valid(&self, safety_caps: &SafetyCaps) -> bool {
+        self.validate(safety_caps).is_empty()
+    }
+}
+
+/// Safety caps — hard upper bounds for configuration values.
+///
+/// These are the absolute maximum values that any enforcement
+/// configuration is allowed to use. They prevent configuration
+/// errors from creating dangerously permissive settings.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SafetyCaps {
+    /// Maximum allowed parallel tasks.
+    pub max_parallel_tasks_cap: u64,
+
+    /// Maximum tool calls across entire execution.
+    pub max_tool_calls_cap: u64,
+
+    /// Maximum allowed retries per node.
+    pub max_retries_cap: u64,
+
+    /// Maximum timeout in seconds.
+    pub max_timeout_secs_cap: u64,
+
+    /// Maximum LLM tokens per request.
+    pub max_tokens_cap: u64,
+
+    /// Maximum concurrent tool executions.
+    pub max_concurrent_tools_cap: u64,
+
+    /// Maximum budget hard limit for any resource.
+    pub max_budget_cap: u64,
+}
+
+impl Default for SafetyCaps {
+    fn default() -> Self {
+        Self {
+            max_parallel_tasks_cap: 10,
+            max_tool_calls_cap: 1000,
+            max_retries_cap: 5,
+            max_timeout_secs_cap: 3600,
+            max_tokens_cap: 200_000,
+            max_concurrent_tools_cap: 20,
+            max_budget_cap: 1_000_000,
+        }
+    }
+}
+
+/// A single configuration validation error.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ConfigValidationError {
+    /// The field that failed validation.
+    pub field: String,
+    /// Human-readable error message.
+    pub message: String,
+    /// The invalid value, if representable.
+    pub value: Option<String>,
 }
 
 /// A resource budget with soft warning threshold and hard limit.

--- a/engine/src/enforcement/domain/mod.rs
+++ b/engine/src/enforcement/domain/mod.rs
@@ -18,5 +18,5 @@ pub mod config;
 pub mod error;
 pub mod event;
 
-pub use config::{EnforcementConfig, EnforcementPresetProfile, ExecutionLimits, ResourceBudget, ToolPolicy, ToolRiskLevel};
+pub use config::{ConfigValidationError, EnforcementConfig, EnforcementPresetProfile, ExecutionLimits, ResourceBudget, SafetyCaps, ToolPolicy, ToolRiskLevel};
 pub use error::EnforcementError;

--- a/engine/src/enforcement/infrastructure/default_policy_repository.rs
+++ b/engine/src/enforcement/infrastructure/default_policy_repository.rs
@@ -1,0 +1,247 @@
+//! Default implementation of `EnforcementPolicyRepository`.
+//!
+//! @canonical .pi/architecture/modules/enforcement.md#infrastructure
+//! Implements: ISSUE-ENFORCEMENT-1 — Default policy repository
+//! Issue: #58
+//!
+//! The default repository loads enforcement configuration from the global
+//! configuration and provides in-memory storage for runtime policy overrides.
+//! No external persistence is required — the default config is sufficient
+//! for most use cases.
+
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use crate::enforcement::domain::{EnforcementConfig, EnforcementError, ToolPolicy};
+
+use super::repository::EnforcementPolicyRepository;
+
+/// Default in-memory implementation of `EnforcementPolicyRepository`.
+///
+/// Loads configuration from the provided `EnforcementConfig` at construction
+/// time. Stores runtime tool policy overrides in memory. No external
+/// persistence is used.
+pub struct DefaultPolicyRepository {
+    /// The base enforcement configuration.
+    config: RwLock<EnforcementConfig>,
+
+    /// Runtime tool policy overrides (applied on top of base config).
+    tool_overrides: RwLock<HashMap<String, ToolPolicy>>,
+}
+
+impl DefaultPolicyRepository {
+    /// Create a new `DefaultPolicyRepository` from an `EnforcementConfig`.
+    pub fn new(config: EnforcementConfig) -> Self {
+        Self {
+            config: RwLock::new(config),
+            tool_overrides: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Create a new `DefaultPolicyRepository` using the Standard preset.
+    pub fn default() -> Self {
+        Self::new(EnforcementConfig::standard())
+    }
+}
+
+#[async_trait]
+impl EnforcementPolicyRepository for DefaultPolicyRepository {
+    async fn load_config(&self, _execution_id: &str) -> Result<EnforcementConfig, EnforcementError> {
+        let config = self.config.read().map_err(|e| {
+            EnforcementError::InvalidState {
+                detail: format!("Failed to read config: {}", e),
+            }
+        })?;
+        Ok(config.clone())
+    }
+
+    async fn save_config(
+        &self,
+        _execution_id: &str,
+        config: &EnforcementConfig,
+    ) -> Result<(), EnforcementError> {
+        let mut current = self.config.write().map_err(|e| {
+            EnforcementError::InvalidState {
+                detail: format!("Failed to write config: {}", e),
+            }
+        })?;
+        *current = config.clone();
+        Ok(())
+    }
+
+    async fn load_tool_policy(
+        &self,
+        tool: &str,
+    ) -> Result<Option<ToolPolicy>, EnforcementError> {
+        // Check runtime overrides first
+        {
+            let overrides = self.tool_overrides.read().map_err(|e| {
+                EnforcementError::InvalidState {
+                    detail: format!("Failed to read overrides: {}", e),
+                }
+            })?;
+            if let Some(policy) = overrides.get(tool) {
+                return Ok(Some(policy.clone()));
+            }
+        }
+
+        // Fall back to base config tool policies
+        let config = self.config.read().map_err(|e| {
+            EnforcementError::InvalidState {
+                detail: format!("Failed to read config: {}", e),
+            }
+        })?;
+        Ok(config.tool_policies.get(tool).cloned())
+    }
+
+    async fn save_tool_policy(
+        &self,
+        tool: &str,
+        policy: &ToolPolicy,
+    ) -> Result<(), EnforcementError> {
+        let mut overrides = self.tool_overrides.write().map_err(|e| {
+            EnforcementError::InvalidState {
+                detail: format!("Failed to write overrides: {}", e),
+            }
+        })?;
+        overrides.insert(tool.to_string(), policy.clone());
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::enforcement::domain::{ToolRiskLevel, ResourceBudget};
+    use std::collections::HashMap;
+
+    fn create_test_config() -> EnforcementConfig {
+        let mut budgets = HashMap::new();
+        budgets.insert(
+            "tokens".to_string(),
+            ResourceBudget {
+                resource: "tokens".to_string(),
+                soft_warning_threshold: 0.8,
+                hard_limit: 100_000,
+                current_usage: 0,
+            },
+        );
+
+        let mut tool_policies = HashMap::new();
+        tool_policies.insert(
+            "bash".to_string(),
+            ToolPolicy {
+                allowed: true,
+                risk_level: ToolRiskLevel::High,
+                requires_confirmation: true,
+                dry_run: false,
+                max_calls: Some(100),
+                budget_key: Some("tool_calls".to_string()),
+            },
+        );
+
+        EnforcementConfig {
+            budgets,
+            tool_policies,
+            ..EnforcementConfig::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_load_default_config() {
+        let repo = DefaultPolicyRepository::new(create_test_config());
+        let config = repo.load_config("test-execution").await.unwrap();
+        assert!(config.budgets.contains_key("tokens"));
+        assert!(config.tool_policies.contains_key("bash"));
+    }
+
+    #[tokio::test]
+    async fn test_save_and_load_config() {
+        let repo = DefaultPolicyRepository::new(EnforcementConfig::standard());
+        let strict_config = EnforcementConfig::strict();
+        repo.save_config("test", &strict_config).await.unwrap();
+        let loaded = repo.load_config("test").await.unwrap();
+        assert_eq!(loaded.preset, crate::enforcement::domain::EnforcementPresetProfile::Strict);
+    }
+
+    #[tokio::test]
+    async fn test_load_tool_policy_from_config() {
+        let config = create_test_config();
+        let repo = DefaultPolicyRepository::new(config);
+        let policy = repo.load_tool_policy("bash").await.unwrap();
+        assert!(policy.is_some());
+        assert!(policy.unwrap().allowed);
+    }
+
+    #[tokio::test]
+    async fn test_load_tool_policy_not_found() {
+        let repo = DefaultPolicyRepository::new(EnforcementConfig::standard());
+        let policy = repo.load_tool_policy("nonexistent_tool").await.unwrap();
+        assert!(policy.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_save_and_load_tool_policy_override() {
+        let repo = DefaultPolicyRepository::new(create_test_config());
+
+        // Override bash to be blocked
+        let blocked = ToolPolicy {
+            allowed: false,
+            ..ToolPolicy::default()
+        };
+        repo.save_tool_policy("bash", &blocked).await.unwrap();
+
+        // Should return the override
+        let policy = repo.load_tool_policy("bash").await.unwrap().unwrap();
+        assert!(!policy.allowed);
+    }
+
+    #[tokio::test]
+    async fn test_tool_policy_override_precedes_config() {
+        let config = create_test_config();
+        let repo = DefaultPolicyRepository::new(config);
+
+        // Config says bash is allowed
+        let policy = repo.load_tool_policy("bash").await.unwrap().unwrap();
+        assert!(policy.allowed);
+
+        // Override to blocked
+        let blocked = ToolPolicy {
+            allowed: false,
+            ..ToolPolicy::default()
+        };
+        repo.save_tool_policy("bash", &blocked).await.unwrap();
+
+        // Now returns blocked (override wins)
+        let policy = repo.load_tool_policy("bash").await.unwrap().unwrap();
+        assert!(!policy.allowed);
+    }
+
+    #[tokio::test]
+    async fn test_multiple_tool_overrides() {
+        let repo = DefaultPolicyRepository::new(EnforcementConfig::standard());
+
+        let bash_policy = ToolPolicy {
+            allowed: false,
+            ..ToolPolicy::default()
+        };
+        let write_policy = ToolPolicy {
+            dry_run: true,
+            ..ToolPolicy::default()
+        };
+
+        repo.save_tool_policy("bash", &bash_policy).await.unwrap();
+        repo.save_tool_policy("write", &write_policy).await.unwrap();
+
+        assert!(!repo.load_tool_policy("bash").await.unwrap().unwrap().allowed);
+        assert!(repo.load_tool_policy("write").await.unwrap().unwrap().dry_run);
+    }
+
+    #[tokio::test]
+    async fn test_default_repository() {
+        let repo = DefaultPolicyRepository::default();
+        let config = repo.load_config("test").await.unwrap();
+        assert_eq!(config.preset, crate::enforcement::domain::EnforcementPresetProfile::Standard);
+    }
+}

--- a/engine/src/enforcement/infrastructure/mod.rs
+++ b/engine/src/enforcement/infrastructure/mod.rs
@@ -12,4 +12,8 @@
 //! and persisting enforcement policies and budgets. The default
 //! implementation loads from the global `Config` object.
 
+pub mod default_policy_repository;
 pub mod repository;
+
+pub use default_policy_repository::*;
+pub use repository::*;


### PR DESCRIPTION
Closes #58

Implement the EnforcementConfig domain entity with three preset profiles (Standard, Strict, Maximum), builder methods, safety caps validation, and a default policy repository.

### Files Changed
- src/enforcement/domain/config.rs: preset builders, builder methods, SafetyCaps validation
- src/enforcement/application/config_service_impl.rs: ConfigBuilder with merge/validate
- src/enforcement/infrastructure/default_policy_repository.rs: DefaultPolicyRepository

Relates to #56