### PR TITLE
[Issue #79] Implement ExecutionState: serializable execution snapshots

### DIFF
--- a/engine/.pi/.guardian-pipeline-state.json
+++ b/engine/.pi/.guardian-pipeline-state.json
@@ -49,12 +49,49 @@
       }
     }
   ],
-  "currentItemIndex": 0,
+  "currentItemIndex": 1,
   "currentStepIndex": 0,
   "status": "running",
   "retryCount": 0,
-  "results": [],
+  "results": [
+    {
+      "item": "issue-contract-freeze",
+      "status": "done",
+      "stepResults": [
+        {
+          "step": "implement",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "implement",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "validate",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "validate",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "create-mr",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "merge",
+          "status": "passed",
+          "reason": ""
+        }
+      ]
+    }
+  ],
   "mergeOnValid": true,
   "createdAt": "2026-06-14T09:35:09.620Z",
-  "updatedAt": "2026-06-14T09:35:09.620Z"
+  "updatedAt": "2026-06-14T09:40:54.055Z"
 }

--- a/engine/src/state_persistence/application/mod.rs
+++ b/engine/src/state_persistence/application/mod.rs
@@ -1,4 +1,5 @@
-//! Application layer interfaces for the State Persistence bounded context.
+//! Application layer interfaces and implementations for the State Persistence
+//! bounded context.
 //!
 //! @canonical .pi/architecture/modules/state-persistence.md
 //! Implements: Contract Freeze — service traits, DTOs, factory interfaces
@@ -8,6 +9,7 @@
 //! - Service traits (use cases / application services)
 //! - Input/Output DTOs with validation
 //! - Factory interfaces for constructing StateManager instances
+//! - Concrete implementations of all service and factory traits
 //!
 //! # Contract (Frozen)
 //! - All service methods are async (return `impl Future`)
@@ -18,7 +20,11 @@
 pub mod dto;
 pub mod factory;
 pub mod service;
+pub mod state_manager_factory_impl;
+pub mod state_manager_service_impl;
 
 pub use dto::*;
 pub use factory::*;
 pub use service::*;
+pub use state_manager_factory_impl::*;
+pub use state_manager_service_impl::*;

--- a/engine/src/state_persistence/application/state_manager_factory_impl.rs
+++ b/engine/src/state_persistence/application/state_manager_factory_impl.rs
@@ -1,0 +1,95 @@
+//! Implementation of the StateManagerFactory.
+//!
+//! @canonical .pi/architecture/modules/state-persistence.md#application
+//! Implements: ISSUE-STATE-PERSISTENCE-1 — FileSystemStateManagerFactory
+//! Issue: #79
+//!
+//! Provides the concrete `FileSystemStateManagerFactory` that constructs
+//! `FileSystemStateManager` instances backed by `FileSystemStateRepository`.
+
+use async_trait::async_trait;
+use std::path::PathBuf;
+
+use crate::state_persistence::application::factory::{
+    CreateStateManagerConfig, StateManagerFactory,
+};
+use crate::state_persistence::application::service::StateManagerService;
+use crate::state_persistence::application::state_manager_service_impl::FileSystemStateManager;
+use crate::state_persistence::domain::StateError;
+use crate::state_persistence::infrastructure::FileSystemStateRepository;
+
+/// Factory for constructing `FileSystemStateManager` instances.
+///
+/// Creates state managers backed by the local filesystem using atomic
+/// write-rename for crash safety.
+pub struct FileSystemStateManagerFactory;
+
+#[async_trait]
+impl StateManagerFactory for FileSystemStateManagerFactory {
+    async fn create(
+        &self,
+        state_dir: PathBuf,
+        config: CreateStateManagerConfig,
+    ) -> Result<Box<dyn StateManagerService>, StateError> {
+        // Create repository with the state directory
+        let repo = if config.create_dir_if_missing {
+            FileSystemStateRepository::new(state_dir).await?
+        } else {
+            FileSystemStateRepository::new(state_dir).await?
+        };
+
+        let manager = FileSystemStateManager::new(Box::new(repo));
+        Ok(Box::new(manager))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    use crate::state_persistence::domain::ExecutionStatus;
+    use crate::state_persistence::application::dto::SaveStateInput;
+    use crate::state_persistence::domain::ExecutionState;
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn test_factory_create_default() {
+        let dir = TempDir::new().unwrap();
+        let factory = FileSystemStateManagerFactory;
+
+        let manager = factory
+            .create(dir.path().to_path_buf(), CreateStateManagerConfig::default())
+            .await
+            .unwrap();
+
+        // Verify we can use the manager
+        let execution_id = Uuid::new_v4();
+        let state = ExecutionState::new(execution_id, "hash".to_string());
+        let output = manager
+            .save_state(SaveStateInput { state })
+            .await
+            .unwrap();
+        assert_eq!(output.status, ExecutionStatus::Pending);
+    }
+
+    #[tokio::test]
+    async fn test_factory_creates_directory() {
+        let dir = TempDir::new().unwrap();
+        let nested_path = dir.path().join("nested").join("state").join("dir");
+        let factory = FileSystemStateManagerFactory;
+
+        let result = factory
+            .create(
+                nested_path.clone(),
+                CreateStateManagerConfig {
+                    create_dir_if_missing: true,
+                    ..Default::default()
+                },
+            )
+            .await;
+
+        assert!(result.is_ok());
+        assert!(nested_path.exists());
+    }
+}

--- a/engine/src/state_persistence/application/state_manager_service_impl.rs
+++ b/engine/src/state_persistence/application/state_manager_service_impl.rs
@@ -1,0 +1,426 @@
+//! Implementation of the StateManagerService.
+//!
+//! @canonical .pi/architecture/modules/state-persistence.md#application
+//! Implements: ISSUE-STATE-PERSISTENCE-1 — FileSystemStateManager
+//! Issue: #79
+//!
+//! Provides the concrete `FileSystemStateManager` that persists execution
+//! state using atomic write-rename, manages node state transitions, and
+//! lists available executions.
+//!
+//! # Thread Safety
+//! - Repository backed by atomic file operations (safe from multiple processes)
+//! - All async methods are safe to call from multiple tasks
+//! - File operations use tokio::fs for non-blocking I/O
+
+use async_trait::async_trait;
+use chrono::Utc;
+use uuid::Uuid;
+
+use crate::state_persistence::application::dto::{
+    ExecutionSummary, ListExecutionsInput, ListExecutionsOutput, LoadStateInput, LoadStateOutput,
+    NodeStateChangedInput, NodeStateChangedOutput, SaveStateInput, SaveStateOutput,
+};
+use crate::state_persistence::application::service::StateManagerService;
+use crate::state_persistence::domain::StateError;
+use crate::state_persistence::infrastructure::repository::StateRepository;
+
+/// Concrete implementation of `StateManagerService` backed by a `StateRepository`.
+///
+/// Manages the full lifecycle of execution state:
+/// - Save state at each phase (Pending → Running → Completed/Failed/Cancelled)
+/// - Load state for recovery or inspection
+/// - Update individual node states with atomic load-modify-save
+/// - List available executions
+pub struct FileSystemStateManager {
+    /// The repository used for state persistence.
+    repository: Box<dyn StateRepository>,
+}
+
+impl FileSystemStateManager {
+    /// Create a new `FileSystemStateManager` with the given repository.
+    pub fn new(repository: Box<dyn StateRepository>) -> Self {
+        Self { repository }
+    }
+}
+
+#[async_trait]
+impl StateManagerService for FileSystemStateManager {
+    async fn save_state(&self, input: SaveStateInput) -> Result<SaveStateOutput, StateError> {
+        let state = input.state;
+        let execution_id = state.execution_id;
+        let status = state.status;
+        let node_count = state.node_states.len() as u32;
+
+        self.repository.save(&state).await?;
+
+        Ok(SaveStateOutput {
+            execution_id,
+            status,
+            node_count,
+            saved_at: Utc::now(),
+        })
+    }
+
+    async fn load_state(&self, input: LoadStateInput) -> Result<LoadStateOutput, StateError> {
+        let state = self.repository.load(input.execution_id).await?;
+
+        Ok(LoadStateOutput {
+            state,
+            loaded_at: Utc::now(),
+        })
+    }
+
+    async fn update_node_state(
+        &self,
+        input: NodeStateChangedInput,
+    ) -> Result<NodeStateChangedOutput, StateError> {
+        // Load current state
+        let mut state = self.repository.load(input.execution_id).await?;
+
+        // Apply the state transition based on new_status
+        let node_id = input.node_id;
+
+        match input.new_status {
+            crate::state_persistence::domain::NodeStatus::InProgress => {
+                state.node_started(node_id)?;
+            }
+            crate::state_persistence::domain::NodeStatus::Completed => {
+                state.node_completed(
+                    node_id,
+                    input.output,
+                    input.duration_ms.unwrap_or(0),
+                )?;
+            }
+            crate::state_persistence::domain::NodeStatus::Failed => {
+                state.node_failed(node_id, input.error.unwrap_or_default())?;
+            }
+            crate::state_persistence::domain::NodeStatus::Skipped => {
+                state.node_skipped(node_id, input.error)?;
+            }
+            crate::state_persistence::domain::NodeStatus::Pending => {
+                // Only allow resetting to Pending via increment_retry
+                state.increment_retry(node_id)?;
+            }
+        }
+
+        // Get the updated node state before saving
+        let node_state = state
+            .node_states
+            .get(&node_id)
+            .ok_or_else(|| StateError::NodeNotFound {
+                node_id: node_id.to_string(),
+                execution_id: input.execution_id.to_string(),
+            })?
+            .clone();
+
+        // Save the updated state
+        self.repository.save(&state).await?;
+
+        Ok(NodeStateChangedOutput {
+            execution_id: input.execution_id,
+            node_id,
+            node_state,
+            updated_at: Utc::now(),
+        })
+    }
+
+    async fn list_executions(&self, input: ListExecutionsInput) -> Result<ListExecutionsOutput, StateError> {
+        let all_ids = self.repository.list_ids().await?;
+        let total_count = all_ids.len() as u32;
+
+        let limit = input.limit.unwrap_or(50) as usize;
+        let offset = input.offset.unwrap_or(0) as usize;
+
+        let mut executions = Vec::new();
+
+        for id in all_ids.iter().skip(offset).take(limit) {
+            match self.repository.load(*id).await {
+                Ok(state) => {
+                    let summary = ExecutionSummary::from(&state);
+
+                    // Apply status filter if specified
+                    if let Some(ref filter) = input.status_filter {
+                        if state.status != *filter {
+                            continue;
+                        }
+                    }
+
+                    executions.push(summary);
+                }
+                Err(_) => {
+                    // Skip corrupted states in listings
+                    continue;
+                }
+            }
+        }
+
+        Ok(ListExecutionsOutput {
+            executions,
+            total_count,
+            limit: limit as u32,
+            offset: offset as u32,
+        })
+    }
+
+    async fn delete_state(&self, execution_id: Uuid) -> Result<(), StateError> {
+        self.repository.delete(execution_id).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use tempfile::TempDir;
+
+    use crate::state_persistence::domain::{ExecutionState, ExecutionStatus, NodeStatus};
+    use crate::state_persistence::infrastructure::FileSystemStateRepository;
+
+    async fn create_manager() -> (FileSystemStateManager, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let repo = FileSystemStateRepository::new(dir.path().to_path_buf())
+            .await
+            .unwrap();
+        let manager = FileSystemStateManager::new(Box::new(repo));
+        (manager, dir)
+    }
+
+    fn create_save_input(execution_id: Uuid, _status: ExecutionStatus) -> SaveStateInput {
+        let state = ExecutionState::new(execution_id, "hash_123".to_string());
+        SaveStateInput { state }
+    }
+
+    #[tokio::test]
+    async fn test_save_and_load_state() {
+        let (manager, _dir) = create_manager().await;
+        let execution_id = Uuid::new_v4();
+        let save_input = create_save_input(execution_id, ExecutionStatus::Pending);
+
+        let save_output = manager.save_state(save_input).await.unwrap();
+        assert_eq!(save_output.execution_id, execution_id);
+        assert_eq!(save_output.status, ExecutionStatus::Pending);
+
+        let load_input = LoadStateInput { execution_id };
+        let load_output = manager.load_state(load_input).await.unwrap();
+        assert_eq!(load_output.state.execution_id, execution_id);
+        assert_eq!(load_output.state.status, ExecutionStatus::Pending);
+    }
+
+    #[tokio::test]
+    async fn test_load_nonexistent_returns_error() {
+        let (manager, _dir) = create_manager().await;
+        let execution_id = Uuid::new_v4();
+
+        let result = manager
+            .load_state(LoadStateInput { execution_id })
+            .await;
+        assert!(matches!(result, Err(StateError::StateNotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_update_node_state_to_in_progress() {
+        let (manager, _dir) = create_manager().await;
+        let execution_id = Uuid::new_v4();
+        let node_id = Uuid::new_v4();
+
+        // Save initial state with node
+        let mut state = ExecutionState::new(execution_id, "hash".to_string());
+        state.status = ExecutionStatus::Running;
+        state.init_node_states(&[node_id]);
+        manager
+            .save_state(SaveStateInput { state })
+            .await
+            .unwrap();
+
+        // Update node to in progress
+        let output = manager
+            .update_node_state(NodeStateChangedInput {
+                execution_id,
+                node_id,
+                new_status: NodeStatus::InProgress,
+                output: None,
+                error: None,
+                duration_ms: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(output.node_state.status, NodeStatus::InProgress);
+    }
+
+    #[tokio::test]
+    async fn test_update_node_state_to_completed() {
+        let (manager, _dir) = create_manager().await;
+        let execution_id = Uuid::new_v4();
+        let node_id = Uuid::new_v4();
+
+        let mut state = ExecutionState::new(execution_id, "hash".to_string());
+        state.status = ExecutionStatus::Running;
+        state.init_node_states(&[node_id]);
+        // Transition to in progress first
+        state.node_started(node_id).unwrap();
+        manager
+            .save_state(SaveStateInput { state })
+            .await
+            .unwrap();
+
+        let output = manager
+            .update_node_state(NodeStateChangedInput {
+                execution_id,
+                node_id,
+                new_status: NodeStatus::Completed,
+                output: Some("done".to_string()),
+                error: None,
+                duration_ms: Some(500),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(output.node_state.status, NodeStatus::Completed);
+        assert_eq!(output.node_state.output, Some("done".to_string()));
+        assert_eq!(output.node_state.duration_ms, Some(500));
+    }
+
+    #[tokio::test]
+    async fn test_update_node_state_to_failed() {
+        let (manager, _dir) = create_manager().await;
+        let execution_id = Uuid::new_v4();
+        let node_id = Uuid::new_v4();
+
+        let mut state = ExecutionState::new(execution_id, "hash".to_string());
+        state.status = ExecutionStatus::Running;
+        state.init_node_states(&[node_id]);
+        state.node_started(node_id).unwrap();
+        manager
+            .save_state(SaveStateInput { state })
+            .await
+            .unwrap();
+
+        let output = manager
+            .update_node_state(NodeStateChangedInput {
+                execution_id,
+                node_id,
+                new_status: NodeStatus::Failed,
+                output: None,
+                error: Some("error occurred".to_string()),
+                duration_ms: Some(300),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(output.node_state.status, NodeStatus::Failed);
+        assert_eq!(output.node_state.error, Some("error occurred".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_delete_removes_state() {
+        let (manager, _dir) = create_manager().await;
+        let execution_id = Uuid::new_v4();
+
+        manager
+            .save_state(create_save_input(execution_id, ExecutionStatus::Pending))
+            .await
+            .unwrap();
+
+        assert!(manager
+            .load_state(LoadStateInput { execution_id })
+            .await
+            .is_ok());
+
+        manager.delete_state(execution_id).await.unwrap();
+
+        let result = manager
+            .load_state(LoadStateInput { execution_id })
+            .await;
+        assert!(matches!(result, Err(StateError::StateNotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_list_executions() {
+        let (manager, _dir) = create_manager().await;
+        let id1 = Uuid::new_v4();
+        let id2 = Uuid::new_v4();
+
+        // List should be empty initially
+        let list = manager
+            .list_executions(ListExecutionsInput::default())
+            .await
+            .unwrap();
+        assert!(list.executions.is_empty());
+
+        // Save two states
+        manager
+            .save_state(create_save_input(id1, ExecutionStatus::Running))
+            .await
+            .unwrap();
+        manager
+            .save_state(create_save_input(id2, ExecutionStatus::Completed))
+            .await
+            .unwrap();
+
+        let list = manager
+            .list_executions(ListExecutionsInput::default())
+            .await
+            .unwrap();
+        assert_eq!(list.total_count, 2);
+    }
+
+    #[tokio::test]
+    async fn test_list_executions_status_filter() {
+        let (manager, _dir) = create_manager().await;
+        let id1 = Uuid::new_v4();
+        let id2 = Uuid::new_v4();
+
+        let mut state1 = ExecutionState::new(id1, "hash".to_string());
+        state1.status = ExecutionStatus::Running;
+
+        let mut state2 = ExecutionState::new(id2, "hash".to_string());
+        state2.status = ExecutionStatus::Completed;
+
+        manager
+            .save_state(SaveStateInput { state: state1 })
+            .await
+            .unwrap();
+        manager
+            .save_state(SaveStateInput { state: state2 })
+            .await
+            .unwrap();
+
+        let list = manager
+            .list_executions(ListExecutionsInput {
+                limit: Some(50),
+                status_filter: Some(ExecutionStatus::Running),
+                offset: Some(0),
+            })
+            .await
+            .unwrap();
+        assert_eq!(list.executions.len(), 1);
+        assert_eq!(list.executions[0].status, ExecutionStatus::Running);
+    }
+
+    #[tokio::test]
+    async fn test_list_executions_pagination() {
+        let (manager, _dir) = create_manager().await;
+        let ids: Vec<Uuid> = (0..5).map(|_| Uuid::new_v4()).collect();
+
+        for id in &ids {
+            manager
+                .save_state(create_save_input(*id, ExecutionStatus::Pending))
+                .await
+                .unwrap();
+        }
+
+        // Get first 2 with offset 0
+        let list = manager
+            .list_executions(ListExecutionsInput {
+                limit: Some(2),
+                status_filter: None,
+                offset: Some(0),
+            })
+            .await
+            .unwrap();
+        assert_eq!(list.executions.len(), 2);
+        assert_eq!(list.total_count, 5);
+    }
+}

--- a/engine/src/state_persistence/infrastructure/filesystem_state_repository.rs
+++ b/engine/src/state_persistence/infrastructure/filesystem_state_repository.rs
@@ -1,0 +1,401 @@
+//! Filesystem implementation of `StateRepository`.
+//!
+//! @canonical .pi/architecture/modules/state-persistence.md#infrastructure
+//! Implements: ISSUE-STATE-PERSISTENCE-1 — FileSystemStateRepository
+//! Issue: #79
+//!
+//! Provides a filesystem-backed `StateRepository` that stores execution state
+//! as JSON files using atomic write-rename for crash safety. Files are stored
+//! as `{state_dir}/{execution_id}.json`.
+//!
+//! # Atomic Write-Rename Pattern
+//! 1. Serialise state to `{execution_id}.json.tmp`
+//! 2. `fs::rename` to `{execution_id}.json`
+//!
+//! On POSIX, `rename(2)` is atomic — a power failure during write leaves
+//! the original file intact.
+
+use async_trait::async_trait;
+use std::path::PathBuf;
+use tokio::fs;
+use uuid::Uuid;
+
+use crate::state_persistence::domain::{ExecutionState, StateError};
+
+use super::repository::StateRepository;
+
+/// Filesystem-backed implementation of `StateRepository`.
+///
+/// Stores execution state as JSON files in a configurable directory.
+/// Uses atomic write-rename for crash safety.
+pub struct FileSystemStateRepository {
+    /// Directory where state files are stored.
+    state_dir: PathBuf,
+}
+
+impl FileSystemStateRepository {
+    /// Create a new `FileSystemStateRepository`.
+    ///
+    /// The state directory is created if it doesn't exist.
+    /// Returns `StateError::DirectoryError` if the directory cannot be created
+    /// or is not accessible.
+    pub async fn new(state_dir: impl Into<PathBuf>) -> Result<Self, StateError> {
+        let state_dir: PathBuf = state_dir.into();
+
+        if !state_dir.exists() {
+            fs::create_dir_all(&state_dir)
+                .await
+                .map_err(|e| StateError::DirectoryError {
+                    detail: format!("Failed to create state directory {:?}: {}", state_dir, e),
+                })?;
+        }
+
+        if !state_dir.is_dir() {
+            return Err(StateError::DirectoryError {
+                detail: format!("State path {:?} exists but is not a directory", state_dir),
+            });
+        }
+
+        Ok(Self { state_dir })
+    }
+
+    /// Get the path to the state file for an execution ID.
+    fn state_path(&self, execution_id: Uuid) -> PathBuf {
+        self.state_dir.join(format!("{}.json", execution_id))
+    }
+
+    /// Get the path to the temporary state file for an execution ID.
+    fn temp_path(&self, execution_id: Uuid) -> PathBuf {
+        self.state_dir.join(format!("{}.json.tmp", execution_id))
+    }
+}
+
+#[async_trait]
+impl StateRepository for FileSystemStateRepository {
+    async fn save(&self, state: &ExecutionState) -> Result<(), StateError> {
+        let path = self.state_path(state.execution_id);
+        let temp = self.temp_path(state.execution_id);
+
+        // Serialise to a JSON string first to catch serialisation errors
+        // before writing to disk.
+        let json = serde_json::to_string_pretty(state).map_err(|e| StateError::SerialisationError {
+            detail: format!("Failed to serialise execution state: {}", e),
+        })?;
+
+        // Write to temp file (atomic if we fail here, original is intact)
+        fs::write(&temp, &json)
+            .await
+            .map_err(|e| StateError::IoError {
+                detail: format!("Failed to write temp state file {:?}: {}", temp, e),
+            })?;
+
+        // Atomic rename (on POSIX, rename(2) is atomic)
+        fs::rename(&temp, &path)
+            .await
+            .map_err(|e| StateError::IoError {
+                detail: format!("Failed to rename temp state file {:?} to {:?}: {}", temp, path, e),
+            })?;
+
+        Ok(())
+    }
+
+    async fn load(&self, execution_id: Uuid) -> Result<ExecutionState, StateError> {
+        let path = self.state_path(execution_id);
+
+        if !path.exists() {
+            return Err(StateError::StateNotFound {
+                execution_id: execution_id.to_string(),
+            });
+        }
+
+        let data = fs::read_to_string(&path)
+            .await
+            .map_err(|e| StateError::IoError {
+                detail: format!("Failed to read state file {:?}: {}", path, e),
+            })?;
+
+        serde_json::from_str(&data).map_err(|e| StateError::CorruptedState {
+            path: path.to_string_lossy().to_string(),
+            detail: format!("Failed to deserialise execution state: {}", e),
+        })
+    }
+
+    async fn exists(&self, execution_id: Uuid) -> Result<bool, StateError> {
+        let path = self.state_path(execution_id);
+        Ok(path.exists())
+    }
+
+    async fn delete(&self, execution_id: Uuid) -> Result<(), StateError> {
+        let path = self.state_path(execution_id);
+
+        if path.exists() {
+            fs::remove_file(&path)
+                .await
+                .map_err(|e| StateError::IoError {
+                    detail: format!("Failed to delete state file {:?}: {}", path, e),
+                })?;
+        }
+
+        // Also clean up any leftover temp file
+        let temp = self.temp_path(execution_id);
+        if temp.exists() {
+            let _ = fs::remove_file(&temp).await;
+        }
+
+        Ok(())
+    }
+
+    async fn list_ids(&self) -> Result<Vec<Uuid>, StateError> {
+        let mut entries = fs::read_dir(&self.state_dir)
+            .await
+            .map_err(|e| StateError::IoError {
+                detail: format!("Failed to read state directory {:?}: {}", self.state_dir, e),
+            })?;
+
+        let mut ids = Vec::new();
+
+        while let Some(entry) = entries
+            .next_entry()
+            .await
+            .map_err(|e| StateError::IoError {
+                detail: format!("Failed to read directory entry: {}", e),
+            })?
+        {
+            let path = entry.path();
+
+            // Skip temp files and non-JSON files
+            if path.extension().map_or(true, |ext| ext != "json") {
+                continue;
+            }
+            if path
+                .file_name()
+                .map_or(true, |name| name.to_string_lossy().ends_with(".json.tmp"))
+            {
+                continue;
+            }
+
+            // Extract UUID from filename
+            if let Some(file_stem) = path.file_stem() {
+                if let Ok(uuid) = Uuid::parse_str(&file_stem.to_string_lossy()) {
+                    ids.push(uuid);
+                }
+            }
+        }
+
+        Ok(ids)
+    }
+
+    async fn count(&self) -> Result<u64, StateError> {
+        Ok(self.list_ids().await?.len() as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use indexmap::IndexMap;
+    use tempfile::TempDir;
+
+    use crate::state_persistence::domain::{ExecutionStatus, NodeState, NodeStatus};
+
+    fn create_test_state(execution_id: Uuid) -> ExecutionState {
+        let mut state = ExecutionState::new(execution_id, "test_hash_123".to_string());
+        state.status = ExecutionStatus::Running;
+
+        let mut node_states = IndexMap::new();
+        let node_id_1 = Uuid::new_v4();
+        let node_id_2 = Uuid::new_v4();
+
+        let mut node1 = NodeState::new(node_id_1);
+        node1.status = NodeStatus::Completed;
+        node1.output = Some("test output".to_string());
+        node1.duration_ms = Some(100);
+
+        let mut node2 = NodeState::new(node_id_2);
+        node2.status = NodeStatus::Pending;
+
+        node_states.insert(node_id_1, node1);
+        node_states.insert(node_id_2, node2);
+        state.node_states = node_states;
+
+        state
+    }
+
+    async fn create_repo() -> (FileSystemStateRepository, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let repo = FileSystemStateRepository::new(dir.path().to_path_buf())
+            .await
+            .unwrap();
+        (repo, dir)
+    }
+
+    #[tokio::test]
+    async fn test_save_and_load_roundtrip() {
+        let (repo, _dir) = create_repo().await;
+        let execution_id = Uuid::new_v4();
+        let state = create_test_state(execution_id);
+
+        repo.save(&state).await.unwrap();
+
+        let loaded = repo.load(execution_id).await.unwrap();
+        assert_eq!(loaded.execution_id, execution_id);
+        assert_eq!(loaded.status, ExecutionStatus::Running);
+        assert_eq!(loaded.symbol_graph_hash, "test_hash_123");
+        assert_eq!(loaded.node_states.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_load_nonexistent_returns_error() {
+        let (repo, _dir) = create_repo().await;
+        let execution_id = Uuid::new_v4();
+
+        let result = repo.load(execution_id).await;
+        assert!(matches!(result, Err(StateError::StateNotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_exists() {
+        let (repo, _dir) = create_repo().await;
+        let execution_id = Uuid::new_v4();
+        let state = create_test_state(execution_id);
+
+        assert!(!repo.exists(execution_id).await.unwrap());
+        repo.save(&state).await.unwrap();
+        assert!(repo.exists(execution_id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_delete_removes_file() {
+        let (repo, _dir) = create_repo().await;
+        let execution_id = Uuid::new_v4();
+        let state = create_test_state(execution_id);
+
+        repo.save(&state).await.unwrap();
+        assert!(repo.exists(execution_id).await.unwrap());
+
+        repo.delete(execution_id).await.unwrap();
+        assert!(!repo.exists(execution_id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_delete_nonexistent_is_idempotent() {
+        let (repo, _dir) = create_repo().await;
+        let execution_id = Uuid::new_v4();
+
+        // Should not error
+        repo.delete(execution_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_list_ids() {
+        let (repo, _dir) = create_repo().await;
+        let id1 = Uuid::new_v4();
+        let id2 = Uuid::new_v4();
+
+        assert!(repo.list_ids().await.unwrap().is_empty());
+
+        repo.save(&create_test_state(id1)).await.unwrap();
+        repo.save(&create_test_state(id2)).await.unwrap();
+
+        let ids = repo.list_ids().await.unwrap();
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&id1));
+        assert!(ids.contains(&id2));
+    }
+
+    #[tokio::test]
+    async fn test_count() {
+        let (repo, _dir) = create_repo().await;
+        let id1 = Uuid::new_v4();
+        let id2 = Uuid::new_v4();
+
+        assert_eq!(repo.count().await.unwrap(), 0);
+        repo.save(&create_test_state(id1)).await.unwrap();
+        assert_eq!(repo.count().await.unwrap(), 1);
+        repo.save(&create_test_state(id2)).await.unwrap();
+        assert_eq!(repo.count().await.unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_tmp_file_cleaned_on_success() {
+        let (repo, dir) = create_repo().await;
+        let execution_id = Uuid::new_v4();
+        let state = create_test_state(execution_id);
+
+        repo.save(&state).await.unwrap();
+
+        // Temp file should not exist after successful write
+        let temp_path = dir.path().join(format!("{}.json.tmp", execution_id));
+        assert!(!temp_path.exists());
+
+        // Real file should exist
+        let real_path = dir.path().join(format!("{}.json", execution_id));
+        assert!(real_path.exists());
+    }
+
+    #[tokio::test]
+    async fn test_serialisation_error_handling() {
+        let (repo, _dir) = create_repo().await;
+        let execution_id = Uuid::new_v4();
+        let state = create_test_state(execution_id);
+
+        // Verify the state round-trips correctly
+        repo.save(&state).await.unwrap();
+        let loaded = repo.load(state.execution_id).await.unwrap();
+
+        // Verify the state is semantically equal
+        assert_eq!(loaded.execution_id, state.execution_id);
+        assert_eq!(loaded.status, state.status);
+    }
+
+    #[tokio::test]
+    async fn test_overwrite_existing_state() {
+        let (repo, _dir) = create_repo().await;
+        let execution_id = Uuid::new_v4();
+
+        let mut state1 = create_test_state(execution_id);
+        state1.status = ExecutionStatus::Running;
+
+        let mut state2 = create_test_state(execution_id);
+        state2.status = ExecutionStatus::Completed;
+
+        repo.save(&state1).await.unwrap();
+        repo.save(&state2).await.unwrap();
+
+        let loaded = repo.load(execution_id).await.unwrap();
+        assert_eq!(loaded.status, ExecutionStatus::Completed);
+    }
+
+    #[tokio::test]
+    async fn test_creates_directory_automatically() {
+        let dir = TempDir::new().unwrap();
+        let nested = dir.path().join("deeply").join("nested").join("state");
+
+        // Should create the directory automatically
+        let repo = FileSystemStateRepository::new(nested.clone()).await;
+        assert!(repo.is_ok());
+        assert!(nested.exists());
+
+        // And we can use it
+        let repo = repo.unwrap();
+        let execution_id = Uuid::new_v4();
+        let state = create_test_state(execution_id);
+        repo.save(&state).await.unwrap();
+        assert!(repo.exists(execution_id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_rejects_file_path() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("not_a_dir");
+
+        // Create a file at that path
+        tokio::fs::write(&file_path, b"this is a file, not a directory")
+            .await
+            .unwrap();
+
+        let result = FileSystemStateRepository::new(file_path).await;
+        assert!(matches!(result, Err(StateError::DirectoryError { .. })));
+    }
+}

--- a/engine/src/state_persistence/infrastructure/mod.rs
+++ b/engine/src/state_persistence/infrastructure/mod.rs
@@ -1,4 +1,5 @@
-//! Infrastructure layer interfaces for the State Persistence bounded context.
+//! Infrastructure layer interfaces and implementations for the State
+//! Persistence bounded context.
 //!
 //! @canonical .pi/architecture/modules/state-persistence.md
 //! Implements: Contract Freeze — repository interfaces
@@ -11,7 +12,13 @@
 //! The primary repositories are:
 //! - `StateRepository` — for CRUD on execution state files
 //! - `GraphRepository` — for CRUD on execution graph records
+//!
+//! Implementations:
+//! - `FileSystemStateRepository` — filesystem-backed state storage
+//!   with atomic write-rename crash safety
 
+pub mod filesystem_state_repository;
 pub mod repository;
 
+pub use filesystem_state_repository::*;
 pub use repository::*;


### PR DESCRIPTION
## Issue Closeout

Closes #79

### Summary
Implemented the ExecutionState persistence layer: filesystem-backed state repository with atomic write-rename crash safety, state manager service, and factory.

### What Was Implemented

**Infrastructure:**
- FileSystemStateRepository — filesystem-backed StateRepository with atomic write-rename (write to .tmp, atomic rename), directory auto-creation, temp file cleanup, list/count/delete operations

**Application:**
- FileSystemStateManager — StateManagerService impl with save_state, load_state, update_node_state (transitions: Pending→InProgress→Completed/Failed/Skipped + retry), list_executions (with status filter and pagination), delete_state
- FileSystemStateManagerFactory — constructs FileSystemStateManager instances

### Tests
| File | Tests | Coverage |
|------|-------|----------|
| filesystem_state_repository.rs | 11 tests | save/load/roundtrip, nonexistent, exists, delete, idempotent delete, list_ids, count, tmp cleanup, overwrite, dir creation, file rejection |
| state_manager_service_impl.rs | 8 tests | save/load, nonexistent, node transitions (3), delete, list, status filter, pagination |
| state_manager_factory_impl.rs | 2 tests | default create, directory creation |

### Verification
- cargo build — success
- 391 tests passed, 0 failed