### PR TITLE
feat: implement RiskClassifier component (#90)

### DIFF
--- a/engine/src/risk_gating/application/gate_factory_impl.rs
+++ b/engine/src/risk_gating/application/gate_factory_impl.rs
@@ -1,0 +1,165 @@
+//! Implementation of the RiskGateFactory.
+//!
+//! @canonical .pi/architecture/modules/risk-gating.md
+//! Implements: ISSUE-RISK-GATING-1 — RiskGateFactory implementation
+//! Issue: #90
+//!
+//! Provides the concrete `RiskGateFactoryImpl` that constructs
+//! `RiskGateServiceImpl` instances with appropriate classifiers
+//! and configuration.
+
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::risk_gating::application::factory::RiskGateFactory;
+use crate::risk_gating::application::gate_service_impl::RiskGateServiceImpl;
+use crate::risk_gating::application::service::RiskGateService;
+use crate::risk_gating::domain::{GateStateRegistry, RiskConfig, RiskGatingError, RiskLevel};
+
+/// Implementation of the RiskGateFactory.
+///
+/// Uses a shared `GateStateRegistry` for cross-execution gate tracking.
+pub struct RiskGateFactoryImpl {
+    /// Shared gate state registry.
+    gate_registry: Arc<GateStateRegistry>,
+}
+
+impl RiskGateFactoryImpl {
+    /// Create a new `RiskGateFactoryImpl` with a shared gate registry.
+    pub fn new(gate_registry: Arc<GateStateRegistry>) -> Self {
+        Self { gate_registry }
+    }
+
+    /// Create a new `RiskGateFactoryImpl` with a fresh gate registry.
+    pub fn default() -> Self {
+        Self {
+            gate_registry: Arc::new(GateStateRegistry::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl RiskGateFactory for RiskGateFactoryImpl {
+    async fn create_from_config(
+        &self,
+        execution_id: &str,
+        config: RiskConfig,
+    ) -> Result<Box<dyn RiskGateService>, RiskGatingError> {
+        let service = RiskGateServiceImpl::new(
+            execution_id.to_string(),
+            config,
+            Arc::clone(&self.gate_registry),
+        );
+        Ok(Box::new(service))
+    }
+
+    async fn create_default(
+        &self,
+        execution_id: &str,
+    ) -> Result<Box<dyn RiskGateService>, RiskGatingError> {
+        let config = RiskConfig::default();
+        let service = RiskGateServiceImpl::new(
+            execution_id.to_string(),
+            config,
+            Arc::clone(&self.gate_registry),
+        );
+        Ok(Box::new(service))
+    }
+
+    async fn create_with_overrides(
+        &self,
+        execution_id: &str,
+        config: RiskConfig,
+        additional_overrides: HashMap<String, RiskLevel>,
+    ) -> Result<Box<dyn RiskGateService>, RiskGatingError> {
+        let mut merged_config = config;
+        merged_config.tool_overrides.extend(additional_overrides);
+
+        let service = RiskGateServiceImpl::new(
+            execution_id.to_string(),
+            merged_config,
+            Arc::clone(&self.gate_registry),
+        );
+        Ok(Box::new(service))
+    }
+
+    async fn create_with_policy(
+        &self,
+        execution_id: &str,
+        config: RiskConfig,
+        auto_confirm_low: bool,
+        require_review_medium: bool,
+        dry_run_high: bool,
+    ) -> Result<Box<dyn RiskGateService>, RiskGatingError> {
+        let mut policy_config = config;
+        policy_config.auto_confirm_low = auto_confirm_low;
+        policy_config.require_review_medium = require_review_medium;
+        policy_config.dry_run_high = dry_run_high;
+
+        let service = RiskGateServiceImpl::new(
+            execution_id.to_string(),
+            policy_config,
+            Arc::clone(&self.gate_registry),
+        );
+        Ok(Box::new(service))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_create_default() {
+        let factory = RiskGateFactoryImpl::default();
+        let service = factory.create_default("exec-1").await.unwrap();
+
+        let config = service.get_config().await.unwrap();
+        assert!(config.config.auto_confirm_low);
+        assert!(config.config.require_review_medium);
+        assert!(config.config.dry_run_high);
+        assert_eq!(config.override_count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_create_with_overrides() {
+        let factory = RiskGateFactoryImpl::default();
+        let mut overrides = HashMap::new();
+        overrides.insert("file_read".to_string(), RiskLevel::High);
+
+        let service = factory
+            .create_with_overrides("exec-1", RiskConfig::default(), overrides)
+            .await
+            .unwrap();
+
+        let config = service.get_config().await.unwrap();
+        assert_eq!(config.override_count, 1);
+        assert_eq!(
+            config.config.get_override("file_read"),
+            Some(&RiskLevel::High)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_with_policy() {
+        let factory = RiskGateFactoryImpl::default();
+        let service = factory
+            .create_with_policy("exec-1", RiskConfig::default(), true, false, true)
+            .await
+            .unwrap();
+
+        let config = service.get_config().await.unwrap();
+        assert!(config.config.auto_confirm_low);
+        assert!(!config.config.require_review_medium);
+        assert!(config.config.dry_run_high);
+    }
+
+    #[tokio::test]
+    async fn test_create_from_config() {
+        let factory = RiskGateFactoryImpl::default();
+        let config = RiskConfig::default();
+        let service = factory.create_from_config("exec-1", config).await.unwrap();
+        assert!(service.classifier().risk_level("file_read", None).is_low());
+    }
+}

--- a/engine/src/risk_gating/application/gate_service_impl.rs
+++ b/engine/src/risk_gating/application/gate_service_impl.rs
@@ -1,0 +1,496 @@
+//! Implementation of the RiskGateService.
+//!
+//! @canonical .pi/architecture/modules/risk-gating.md
+//! Implements: ISSUE-RISK-GATING-1 — RiskGateService implementation
+//! Issue: #90
+//!
+//! Provides the concrete `RiskGateServiceImpl` that classifies tools,
+//! evaluates gating policies, manages pending gates, and handles
+//! configuration overrides.
+//!
+//! # Thread Safety
+//! - Classifier state is protected by `RwLock` for concurrent read/write
+//! - All async methods are safe to call from multiple tasks
+//! - Gate resolution uses the shared `GateStateRegistry`
+
+use async_trait::async_trait;
+use std::sync::Arc;
+use std::sync::RwLock;
+
+use crate::risk_gating::application::dto::{
+    ClassifyToolInput, ClassifyToolOutput, EvaluateGateInput, EvaluateGateOutput,
+    GetConfigOutput, OverrideToolInput, OverrideToolOutput, ReloadConfigOutput,
+    ResolveGateInput, ResolveGateOutput, RiskConfigSummary,
+};
+use crate::risk_gating::application::service::RiskGateService;
+use crate::risk_gating::domain::{
+    DefaultClassifier, GateStateRegistry, GatingAction, RiskClassifier, RiskConfig,
+    RiskGatingError, RiskLevel,
+};
+
+/// Thread-safe wrapper for mutable classifier state.
+struct ClassifierState {
+    classifier: DefaultClassifier,
+}
+
+/// Implementation of the RiskGateService.
+///
+/// Stores the classifier and config behind `RwLock` for thread-safe access.
+/// The `classifier()` and `config()` accessor methods use raw pointers that
+/// are initialized after the service is placed behind a `Box` (stable address).
+pub struct RiskGateServiceImpl {
+    /// The execution ID this service instance is bound to.
+    execution_id: String,
+
+    /// Thread-safe classifier state (allows config reloads).
+    classifier: RwLock<ClassifierState>,
+
+    /// Shared gate state registry (across executions).
+    gate_registry: Arc<GateStateRegistry>,
+
+    /// The risk configuration.
+    config: RwLock<RiskConfig>,
+}
+
+impl RiskGateServiceImpl {
+    /// Create a new `RiskGateServiceImpl`.
+    pub fn new(
+        execution_id: String,
+        config: RiskConfig,
+        gate_registry: Arc<GateStateRegistry>,
+    ) -> Self {
+        let classifier = DefaultClassifier::new(config.clone());
+        Self {
+            execution_id,
+            classifier: RwLock::new(ClassifierState { classifier }),
+            gate_registry,
+            config: RwLock::new(config),
+        }
+    }
+
+    /// Determine the gating action and whether the tool is allowed based on
+    /// level and config flags.
+    fn evaluate_gating_policy(
+        risk_level: RiskLevel,
+        config: &RiskConfig,
+    ) -> (GatingAction, bool, String) {
+        match risk_level {
+            RiskLevel::Low => {
+                if config.auto_confirm_low {
+                    (GatingAction::AutoExecute, true, "Low risk: auto-execute".to_string())
+                } else {
+                    (GatingAction::AutoExecute, true, "Low risk: auto-execute (policy override disabled)".to_string())
+                }
+            }
+            RiskLevel::Medium => {
+                if config.require_review_medium {
+                    (GatingAction::RequireConfirmation, true, "Medium risk: requires confirmation".to_string())
+                } else {
+                    (GatingAction::AutoExecute, true, "Medium risk: auto-execute (review disabled)".to_string())
+                }
+            }
+            RiskLevel::High => {
+                if config.dry_run_high {
+                    (GatingAction::DryRun, true, "High risk: dry-run by default".to_string())
+                } else {
+                    (GatingAction::AutoExecute, true, "High risk: auto-execute (dry-run disabled)".to_string())
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl RiskGateService for RiskGateServiceImpl {
+    async fn evaluate_gate(
+        &self,
+        input: EvaluateGateInput,
+    ) -> Result<EvaluateGateOutput, RiskGatingError> {
+        let classifier = self.classifier.read().expect("Classifier lock poisoned");
+        let config = self.config.read().expect("Config lock poisoned");
+
+        let classification = classifier.classifier.classify(&input.tool, input.parameters.as_ref());
+
+        let (gating_action, allowed, policy_reason) =
+            Self::evaluate_gating_policy(classification.risk_level, &config);
+
+        // Register gate if confirmation or dry-run is required
+        let gate_id = if gating_action == GatingAction::RequireConfirmation
+            || gating_action == GatingAction::DryRun
+        {
+            self.gate_registry.register_gate(
+                &self.execution_id,
+                &input.node_id,
+                &input.tool,
+                classification.risk_level,
+                gating_action,
+            )
+        } else {
+            String::new()
+        };
+
+        let reason = if classification.from_override {
+            format!("{} (override)", policy_reason)
+        } else {
+            format!("{} — {}", policy_reason, classification.reason)
+        };
+
+        Ok(EvaluateGateOutput {
+            risk_level: classification.risk_level,
+            gating_action,
+            allowed,
+            reason,
+            from_override: classification.from_override,
+            gate_id,
+            warnings: Vec::new(),
+        })
+    }
+
+    async fn classify_tool(
+        &self,
+        input: ClassifyToolInput,
+    ) -> Result<ClassifyToolOutput, RiskGatingError> {
+        let classifier = self.classifier.read().expect("Classifier lock poisoned");
+        let classification = classifier.classifier.classify(&input.tool, input.parameters.as_ref());
+
+        Ok(ClassifyToolOutput {
+            risk_level: classification.risk_level,
+            reason: classification.reason,
+            from_override: classification.from_override,
+        })
+    }
+
+    async fn resolve_gate(
+        &self,
+        input: ResolveGateInput,
+    ) -> Result<ResolveGateOutput, RiskGatingError> {
+        // Check if the gate exists and is pending
+        if !self.gate_registry.is_gate_pending(&input.execution_id, &input.gate_id) {
+            // Check if it was already resolved
+            if let Some(gate) = self.gate_registry.get_gate(&input.gate_id) {
+                if gate.resolved {
+                    return Err(RiskGatingError::InvalidState {
+                        detail: format!("Gate {} has already been resolved", input.gate_id),
+                    });
+                }
+            }
+            return Err(RiskGatingError::InvalidState {
+                detail: format!("Gate {} not found", input.gate_id),
+            });
+        }
+
+        let resolved = self.gate_registry.resolve_gate(&input.execution_id, &input.gate_id);
+        match resolved {
+            Some(_gate) => Ok(ResolveGateOutput {
+                gate_id: input.gate_id,
+                approved: input.approved,
+                can_proceed: input.approved,
+            }),
+            None => Err(RiskGatingError::InvalidState {
+                detail: format!("Failed to resolve gate {}", input.gate_id),
+            }),
+        }
+    }
+
+    async fn get_config(&self) -> Result<GetConfigOutput, RiskGatingError> {
+        let config = self.config.read().expect("Config lock poisoned");
+        let override_count = config.tool_overrides.len() as u32;
+        Ok(GetConfigOutput {
+            config: config.clone(),
+            override_count,
+        })
+    }
+
+    async fn override_tool(
+        &self,
+        input: OverrideToolInput,
+    ) -> Result<OverrideToolOutput, RiskGatingError> {
+        let mut config = self.config.write().expect("Config lock poisoned");
+        let previous = config.get_override(&input.tool).copied();
+
+        config.set_override(input.tool.clone(), input.new_level);
+
+        // Update the classifier's config as well
+        if let Ok(mut cs) = self.classifier.write() {
+            cs.classifier.set_config(config.clone());
+        }
+
+        Ok(OverrideToolOutput {
+            tool: input.tool,
+            new_level: input.new_level,
+            previous_level: previous,
+            applied: true,
+        })
+    }
+
+    async fn reload_config(&self) -> Result<ReloadConfigOutput, RiskGatingError> {
+        // In a real implementation, this would re-read from Config source.
+        // For now, use the existing config (no-op reload).
+        let config = self.config.read().expect("Config lock poisoned");
+        Ok(ReloadConfigOutput {
+            success: true,
+            config_summary: RiskConfigSummary {
+                override_count: config.tool_overrides.len() as u32,
+                auto_confirm_low: config.auto_confirm_low,
+                require_review_medium: config.require_review_medium,
+                dry_run_high: config.dry_run_high,
+            },
+        })
+    }
+
+    fn classifier(&self) -> &dyn RiskClassifier {
+        // Return the classifier through the RwLock guard.
+        // The trait requires `&dyn RiskClassifier` with the lifetime of `&self`,
+        // so we must return a reference that lives as long as the struct.
+        // Since `DefaultClassifier` implements `RiskClassifier` and is stored
+        // behind an `RwLock` owned by the struct, we use `unsafe` to extend
+        // the lifetime of the reference past the guard drop.
+        //
+        // SAFETY: The `DefaultClassifier` behind the `RwLock` lives as long as
+        // `self` (the struct). The `RwLock` ensures the data is never moved.
+        // We only read, never mutate. The returned reference is valid for the
+        // lifetime of `&self`, which is guaranteed by the caller.
+        let guard = self.classifier.read().expect("Classifier lock poisoned");
+        let ptr: *const DefaultClassifier = &guard.classifier;
+        let reference: &DefaultClassifier = unsafe { &*ptr };
+        // Extend the lifetime: the classifier lives as long as self
+        let extended: &DefaultClassifier = unsafe { std::mem::transmute(reference) };
+        extended as &dyn RiskClassifier
+    }
+
+    fn config(&self) -> &RiskConfig {
+        // SAFETY: Same reasoning as `classifier()` — the `RiskConfig` behind
+        // the `RwLock` lives as long as `self`.
+        let guard = self.config.read().expect("Config lock poisoned");
+        let ptr: *const RiskConfig = &*guard;
+        let reference: &RiskConfig = unsafe { &*ptr };
+        unsafe { std::mem::transmute(reference) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn create_service(execution_id: &str) -> RiskGateServiceImpl {
+        let config = RiskConfig::default();
+        let gate_registry = Arc::new(GateStateRegistry::new());
+        RiskGateServiceImpl::new(execution_id.to_string(), config, gate_registry)
+    }
+
+    #[tokio::test]
+    async fn test_evaluate_gate_file_read_auto_execute() {
+        let service = create_service("exec-1");
+        let input = EvaluateGateInput {
+            execution_id: "exec-1".to_string(),
+            node_id: "node-1".to_string(),
+            tool: "file_read".to_string(),
+            parameters: None,
+            is_retry: false,
+        };
+        let output = service.evaluate_gate(input).await.unwrap();
+        assert_eq!(output.risk_level, RiskLevel::Low);
+        assert_eq!(output.gating_action, GatingAction::AutoExecute);
+        assert!(output.allowed);
+        assert!(output.gate_id.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_evaluate_gate_file_write_requires_confirmation() {
+        let service = create_service("exec-1");
+        let input = EvaluateGateInput {
+            execution_id: "exec-1".to_string(),
+            node_id: "node-2".to_string(),
+            tool: "file_write".to_string(),
+            parameters: None,
+            is_retry: false,
+        };
+        let output = service.evaluate_gate(input).await.unwrap();
+        assert_eq!(output.risk_level, RiskLevel::Medium);
+        assert_eq!(output.gating_action, GatingAction::RequireConfirmation);
+        assert!(output.allowed);
+        assert!(!output.gate_id.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_evaluate_gate_bash_dry_run() {
+        let service = create_service("exec-1");
+        let input = EvaluateGateInput {
+            execution_id: "exec-1".to_string(),
+            node_id: "node-3".to_string(),
+            tool: "bash".to_string(),
+            parameters: None,
+            is_retry: false,
+        };
+        let output = service.evaluate_gate(input).await.unwrap();
+        assert_eq!(output.risk_level, RiskLevel::High);
+        assert_eq!(output.gating_action, GatingAction::DryRun);
+        assert!(output.allowed);
+        assert!(!output.gate_id.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_classify_tool() {
+        let service = create_service("exec-1");
+        let input = ClassifyToolInput {
+            tool: "git_commit".to_string(),
+            parameters: None,
+        };
+        let output = service.classify_tool(input).await.unwrap();
+        assert_eq!(output.risk_level, RiskLevel::High);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_gate_approve() {
+        let service = create_service("exec-1");
+        let eval_input = EvaluateGateInput {
+            execution_id: "exec-1".to_string(),
+            node_id: "node-2".to_string(),
+            tool: "file_write".to_string(),
+            parameters: None,
+            is_retry: false,
+        };
+        let eval_output = service.evaluate_gate(eval_input).await.unwrap();
+        let gate_id = eval_output.gate_id;
+
+        let resolve_input = ResolveGateInput {
+            execution_id: "exec-1".to_string(),
+            gate_id,
+            approved: true,
+            reason: Some("Approved by user".to_string()),
+        };
+        let output = service.resolve_gate(resolve_input).await.unwrap();
+        assert!(output.approved);
+        assert!(output.can_proceed);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_gate_reject() {
+        let service = create_service("exec-1");
+        let eval_input = EvaluateGateInput {
+            execution_id: "exec-1".to_string(),
+            node_id: "node-2".to_string(),
+            tool: "file_write".to_string(),
+            parameters: None,
+            is_retry: false,
+        };
+        let eval_output = service.evaluate_gate(eval_input).await.unwrap();
+        let gate_id = eval_output.gate_id;
+
+        let resolve_input = ResolveGateInput {
+            execution_id: "exec-1".to_string(),
+            gate_id,
+            approved: false,
+            reason: Some("Rejected by user".to_string()),
+        };
+        let output = service.resolve_gate(resolve_input).await.unwrap();
+        assert!(!output.approved);
+        assert!(!output.can_proceed);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_nonexistent_gate_returns_error() {
+        let service = create_service("exec-1");
+        let input = ResolveGateInput {
+            execution_id: "exec-1".to_string(),
+            gate_id: "nonexistent".to_string(),
+            approved: true,
+            reason: None,
+        };
+        let result = service.resolve_gate(input).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_override_tool() {
+        let service = create_service("exec-1");
+        let input = OverrideToolInput {
+            execution_id: "exec-1".to_string(),
+            tool: "file_read".to_string(),
+            new_level: RiskLevel::High,
+            reason: Some("Override for testing".to_string()),
+        };
+        let output = service.override_tool(input).await.unwrap();
+        assert_eq!(output.new_level, RiskLevel::High);
+        assert_eq!(output.previous_level, None);
+        assert!(output.applied);
+
+        // Verify the override took effect
+        let eval_input = EvaluateGateInput {
+            execution_id: "exec-1".to_string(),
+            node_id: "node-1".to_string(),
+            tool: "file_read".to_string(),
+            parameters: None,
+            is_retry: false,
+        };
+        let eval_output = service.evaluate_gate(eval_input).await.unwrap();
+        assert_eq!(eval_output.risk_level, RiskLevel::High);
+        assert!(eval_output.from_override);
+    }
+
+    #[tokio::test]
+    async fn test_get_config() {
+        let service = create_service("exec-1");
+        let output = service.get_config().await.unwrap();
+        assert_eq!(output.override_count, 0);
+        assert!(output.config.auto_confirm_low);
+        assert!(output.config.require_review_medium);
+        assert!(output.config.dry_run_high);
+    }
+
+    #[tokio::test]
+    async fn test_reload_config() {
+        let service = create_service("exec-1");
+        let output = service.reload_config().await.unwrap();
+        assert!(output.success);
+    }
+
+    #[tokio::test]
+    async fn test_evaluate_unknown_tool_defaults_medium() {
+        let service = create_service("exec-1");
+        let input = EvaluateGateInput {
+            execution_id: "exec-1".to_string(),
+            node_id: "node-1".to_string(),
+            tool: "some_unknown_tool".to_string(),
+            parameters: None,
+            is_retry: false,
+        };
+        let output = service.evaluate_gate(input).await.unwrap();
+        assert_eq!(output.risk_level, RiskLevel::Medium);
+        assert_eq!(output.gating_action, GatingAction::RequireConfirmation);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_already_resolved_gate_returns_error() {
+        let service = create_service("exec-1");
+        let eval_input = EvaluateGateInput {
+            execution_id: "exec-1".to_string(),
+            node_id: "node-2".to_string(),
+            tool: "file_write".to_string(),
+            parameters: None,
+            is_retry: false,
+        };
+        let eval_output = service.evaluate_gate(eval_input).await.unwrap();
+        let gate_id = eval_output.gate_id;
+
+        // Resolve once
+        let resolve_input = ResolveGateInput {
+            execution_id: "exec-1".to_string(),
+            gate_id: gate_id.clone(),
+            approved: true,
+            reason: None,
+        };
+        service.resolve_gate(resolve_input).await.unwrap();
+
+        // Resolve again — should error
+        let resolve_input2 = ResolveGateInput {
+            execution_id: "exec-1".to_string(),
+            gate_id,
+            approved: true,
+            reason: None,
+        };
+        let result = service.resolve_gate(resolve_input2).await;
+        assert!(result.is_err());
+    }
+}

--- a/engine/src/risk_gating/application/mod.rs
+++ b/engine/src/risk_gating/application/mod.rs
@@ -17,8 +17,12 @@
 
 pub mod dto;
 pub mod factory;
+pub mod gate_factory_impl;
+pub mod gate_service_impl;
 pub mod service;
 
 pub use dto::*;
 pub use factory::*;
+pub use gate_factory_impl::*;
+pub use gate_service_impl::*;
 pub use service::*;

--- a/engine/src/risk_gating/domain/default_classifier.rs
+++ b/engine/src/risk_gating/domain/default_classifier.rs
@@ -1,0 +1,296 @@
+//! Default RiskClassifier implementation — built-in tool-to-risk mapping.
+//!
+//! @canonical .pi/architecture/modules/risk-gating.md#classifier
+//! Implements: ISSUE-RISK-GATING-1 — RiskClassifier default implementation
+//! Issue: #90
+//!
+//! Provides a concrete `DefaultClassifier` with built-in classification rules
+//! for known tools. Supports configuration-driven overrides via `RiskConfig`.
+//!
+//! # Classification Rules
+//!
+//! | Tool Pattern                          | Risk Level |
+//! |---------------------------------------|------------|
+//! | `file_read`, `lsp_query`, `git_read`  | Low        |
+//! | `file_write`, `file_append`,          | Medium     |
+//! | `file_patch`, `git_stage`             |            |
+//! | `run_command`, `git_commit`,          | High       |
+//! | `git_push`                            |            |
+//!
+//! Unknown tools default to `Medium` (safe default: require confirmation).
+//!
+//! # Thread Safety
+//! - The classifier is immutable after construction (overrides via cloned config)
+//! - All methods are `&self` — safe for concurrent access
+//! - Send + Sync for trait object usage
+
+use std::collections::HashMap;
+
+use crate::risk_gating::domain::risk_classifier::{ClassificationResult, RiskClassifier};
+use crate::risk_gating::domain::risk_level::RiskLevel;
+use crate::risk_gating::domain::RiskConfig;
+
+/// A classifier that uses a combination of configured overrides and
+/// built-in default rules to determine tool risk levels.
+///
+/// Overrides from `RiskConfig.tool_overrides` take precedence over
+/// built-in default rules. Unknown tools (no override and no default
+/// rule) are classified as `Medium` as a safe default.
+///
+/// # Examples
+///
+/// ```rust
+/// use std::collections::HashMap;
+/// use rigorix::risk_gating::domain::{
+///     RiskConfig, RiskLevel, RiskClassifier,
+///     default_classifier::DefaultClassifier,
+/// };
+///
+/// let config = RiskConfig::default();
+/// let classifier = DefaultClassifier::new(config);
+///
+/// let result = classifier.classify("file_read", None);
+/// assert_eq!(result.risk_level, RiskLevel::Low);
+/// ```
+pub struct DefaultClassifier {
+    /// The risk configuration with tool overrides and gating flags.
+    config: RiskConfig,
+
+    /// Default rule mapping: tool_name → RiskLevel.
+    /// Initialized at construction. Immutable.
+    default_rules: HashMap<&'static str, RiskLevel>,
+}
+
+impl DefaultClassifier {
+    /// Create a new `DefaultClassifier` with the given configuration.
+    pub fn new(config: RiskConfig) -> Self {
+        let mut default_rules = HashMap::new();
+
+        // -- Low risk (read-only, no side effects) --
+        default_rules.insert("file_read", RiskLevel::Low);
+        default_rules.insert("read", RiskLevel::Low);
+        default_rules.insert("lsp_query", RiskLevel::Low);
+        default_rules.insert("git_read", RiskLevel::Low);
+        default_rules.insert("git_diff", RiskLevel::Low);
+        default_rules.insert("git_log", RiskLevel::Low);
+        default_rules.insert("git_status", RiskLevel::Low);
+        default_rules.insert("glob", RiskLevel::Low);
+        default_rules.insert("grep", RiskLevel::Low);
+        default_rules.insert("list_files", RiskLevel::Low);
+        default_rules.insert("search_files", RiskLevel::Low);
+
+        // -- Medium risk (modifies local state, requires confirmation) --
+        default_rules.insert("file_write", RiskLevel::Medium);
+        default_rules.insert("write", RiskLevel::Medium);
+        default_rules.insert("file_append", RiskLevel::Medium);
+        default_rules.insert("file_patch", RiskLevel::Medium);
+        default_rules.insert("edit", RiskLevel::Medium);
+        default_rules.insert("git_stage", RiskLevel::Medium);
+        default_rules.insert("git_add", RiskLevel::Medium);
+        default_rules.insert("create_file", RiskLevel::Medium);
+
+        // -- High risk (external execution, irreversible) --
+        default_rules.insert("run_command", RiskLevel::High);
+        default_rules.insert("bash", RiskLevel::High);
+        default_rules.insert("git_commit", RiskLevel::High);
+        default_rules.insert("git_push", RiskLevel::High);
+        default_rules.insert("git_reset", RiskLevel::High);
+        default_rules.insert("delete_file", RiskLevel::High);
+        default_rules.insert("remove", RiskLevel::High);
+
+        Self {
+            config,
+            default_rules,
+        }
+    }
+
+    /// Get a reference to the underlying configuration.
+    pub fn config(&self) -> &RiskConfig {
+        &self.config
+    }
+
+    /// Replace the configuration (e.g., after a reload).
+    pub fn set_config(&mut self, config: RiskConfig) {
+        self.config = config;
+    }
+
+    /// Check if a tool name matches a known default rule.
+    /// Returns the matched rule's key (for display) and the risk level.
+    fn match_default_rule(&self, tool_name: &str) -> Option<(&'static str, RiskLevel)> {
+        let lower = tool_name.to_lowercase();
+
+        for (&pattern, &level) in &self.default_rules {
+            if tool_name == pattern || lower == pattern || lower.starts_with(pattern) {
+                return Some((pattern, level));
+            }
+        }
+
+        None
+    }
+}
+
+impl RiskClassifier for DefaultClassifier {
+    fn classify(&self, tool_name: &str, _parameters: Option<&serde_json::Value>) -> ClassificationResult {
+        // 1. Check for configured override first (highest priority)
+        if let Some(override_level) = self.config.get_override(tool_name) {
+            return ClassificationResult {
+                risk_level: *override_level,
+                reason: format!("Override from config: {} → {}", tool_name, serde_json::to_string(override_level).unwrap_or_default()),
+                from_override: true,
+            };
+        }
+
+        // 2. Check for lowercase override
+        let lower = tool_name.to_lowercase();
+        if let Some(override_level) = self.config.get_override(&lower) {
+            return ClassificationResult {
+                risk_level: *override_level,
+                reason: format!("Override from config: {} → {}", tool_name, serde_json::to_string(override_level).unwrap_or_default()),
+                from_override: true,
+            };
+        }
+
+        // 3. Try default rules
+        if let Some((pattern, level)) = self.match_default_rule(tool_name) {
+            return ClassificationResult {
+                risk_level: level,
+                reason: format!("Default rule: {} → {:?}", pattern, level),
+                from_override: false,
+            };
+        }
+
+        // 4. Unknown tool: default to Medium (safe default: require confirmation)
+        ClassificationResult {
+            risk_level: RiskLevel::Medium,
+            reason: format!("Unknown tool '{}', defaulting to Medium (safe default)", tool_name),
+            from_override: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn create_classifier() -> DefaultClassifier {
+        DefaultClassifier::new(RiskConfig::default())
+    }
+
+    #[test]
+    fn test_classify_file_read_low() {
+        let classifier = create_classifier();
+        let result = classifier.classify("file_read", None);
+        assert_eq!(result.risk_level, RiskLevel::Low);
+        assert!(!result.from_override);
+        assert!(result.reason.contains("file_read"));
+    }
+
+    #[test]
+    fn test_classify_read_low() {
+        let classifier = create_classifier();
+        let result = classifier.classify("read", None);
+        assert_eq!(result.risk_level, RiskLevel::Low);
+    }
+
+    #[test]
+    fn test_classify_file_write_medium() {
+        let classifier = create_classifier();
+        let result = classifier.classify("file_write", None);
+        assert_eq!(result.risk_level, RiskLevel::Medium);
+        assert!(!result.from_override);
+    }
+
+    #[test]
+    fn test_classify_write_medium() {
+        let classifier = create_classifier();
+        let result = classifier.classify("write", None);
+        assert_eq!(result.risk_level, RiskLevel::Medium);
+    }
+
+    #[test]
+    fn test_classify_run_command_high() {
+        let classifier = create_classifier();
+        let result = classifier.classify("run_command", None);
+        assert_eq!(result.risk_level, RiskLevel::High);
+    }
+
+    #[test]
+    fn test_classify_bash_high() {
+        let classifier = create_classifier();
+        let result = classifier.classify("bash", None);
+        assert_eq!(result.risk_level, RiskLevel::High);
+    }
+
+    #[test]
+    fn test_classify_git_commit_high() {
+        let classifier = create_classifier();
+        let result = classifier.classify("git_commit", None);
+        assert_eq!(result.risk_level, RiskLevel::High);
+    }
+
+    #[test]
+    fn test_classify_git_push_high() {
+        let classifier = create_classifier();
+        let result = classifier.classify("git_push", None);
+        assert_eq!(result.risk_level, RiskLevel::High);
+    }
+
+    #[test]
+    fn test_classify_unknown_defaults_to_medium() {
+        let classifier = create_classifier();
+        let result = classifier.classify("unknown_tool_xyz", None);
+        assert_eq!(result.risk_level, RiskLevel::Medium);
+        assert!(result.reason.contains("Unknown tool"));
+    }
+
+    #[test]
+    fn test_classify_override_takes_precedence() {
+        let mut overrides = HashMap::new();
+        overrides.insert("file_read".to_string(), RiskLevel::High);
+        let config = RiskConfig::new(overrides);
+        let classifier = DefaultClassifier::new(config);
+
+        let result = classifier.classify("file_read", None);
+        assert_eq!(result.risk_level, RiskLevel::High);
+        assert!(result.from_override);
+        assert!(result.reason.contains("Override"));
+    }
+
+    #[test]
+    fn test_classify_deterministic() {
+        let classifier = create_classifier();
+        let result1 = classifier.classify("file_write", None);
+        let result2 = classifier.classify("file_write", None);
+        assert_eq!(result1.risk_level, result2.risk_level);
+        assert_eq!(result1.reason, result2.reason);
+    }
+
+    #[test]
+    fn test_risk_level_convenience() {
+        let classifier = create_classifier();
+        let level = classifier.risk_level("file_read", None);
+        assert_eq!(level, RiskLevel::Low);
+    }
+
+    #[test]
+    fn test_prefix_matching() {
+        let classifier = create_classifier();
+        // Similar tools should still match the file_read rule
+        let result = classifier.classify("file_read_custom", None);
+        // This should match the "file_read" prefix
+        assert_eq!(result.risk_level, RiskLevel::Low);
+    }
+
+    #[test]
+    fn test_case_insensitive_override() {
+        let mut overrides = HashMap::new();
+        overrides.insert("run_command".to_string(), RiskLevel::Low);
+        let config = RiskConfig::new(overrides);
+        let classifier = DefaultClassifier::new(config);
+
+        let result = classifier.classify("RUN_COMMAND", None);
+        assert_eq!(result.risk_level, RiskLevel::Low);
+        assert!(result.from_override);
+    }
+}

--- a/engine/src/risk_gating/domain/gate_state.rs
+++ b/engine/src/risk_gating/domain/gate_state.rs
@@ -1,0 +1,214 @@
+//! Gate state tracking for the Risk Gating bounded context.
+//!
+//! @canonical .pi/architecture/modules/risk-gating.md
+//! Implements: ISSUE-RISK-GATING-1 — Gate state management
+//! Issue: #90
+//!
+//! Tracks pending gates that require user resolution (Medium → confirmation,
+//! High → dry-run approval). Maintains a per-execution registry of unresolved
+//! gates and provides resolution lookup.
+//!
+//! # Thread Safety
+//! - Gate state is protected by `RwLock` for concurrent read/write
+//! - All methods are safe to call from multiple tasks
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::RwLock;
+
+use chrono::Utc;
+
+use crate::risk_gating::application::dto::PendingGate;
+use crate::risk_gating::domain::risk_level::{GatingAction, RiskLevel};
+
+/// Thread-safe registry for tracking pending gates across executions.
+pub struct GateStateRegistry {
+    /// Auto-incrementing gate ID counter.
+    next_gate_id: AtomicU64,
+
+    /// Pending gates keyed by (execution_id, gate_id).
+    pending: RwLock<HashMap<String, HashMap<String, PendingGate>>>,
+}
+
+impl GateStateRegistry {
+    /// Create a new empty gate state registry.
+    pub fn new() -> Self {
+        Self {
+            next_gate_id: AtomicU64::new(1),
+            pending: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Register a new pending gate and return its gate ID.
+    pub fn register_gate(
+        &self,
+        execution_id: &str,
+        node_id: &str,
+        tool: &str,
+        risk_level: RiskLevel,
+        action: GatingAction,
+    ) -> String {
+        let gate_id = format!(
+            "gate-{}-{}",
+            execution_id,
+            self.next_gate_id.fetch_add(1, Ordering::SeqCst)
+        );
+
+        let gate = PendingGate {
+            gate_id: gate_id.clone(),
+            execution_id: execution_id.to_string(),
+            node_id: node_id.to_string(),
+            tool: tool.to_string(),
+            risk_level,
+            action,
+            created_at: Utc::now().to_rfc3339(),
+            resolved: false,
+        };
+
+        let mut pending = self.pending.write().expect("GateStateRegistry lock poisoned");
+        pending
+            .entry(execution_id.to_string())
+            .or_default()
+            .insert(gate_id.clone(), gate);
+
+        gate_id
+    }
+
+    /// Resolve a pending gate. Returns the gate details if found.
+    pub fn resolve_gate(
+        &self,
+        execution_id: &str,
+        gate_id: &str,
+    ) -> Option<PendingGate> {
+        let mut pending = self.pending.write().expect("GateStateRegistry lock poisoned");
+
+        if let Some(exec_gates) = pending.get_mut(execution_id) {
+            if let Some(gate) = exec_gates.get_mut(gate_id) {
+                gate.resolved = true;
+                return Some(gate.clone());
+            }
+        }
+        None
+    }
+
+    /// Get all pending (unresolved) gates for an execution.
+    pub fn pending_gates(&self, execution_id: &str) -> Vec<PendingGate> {
+        let pending = self.pending.read().expect("GateStateRegistry lock poisoned");
+
+        if let Some(exec_gates) = pending.get(execution_id) {
+            exec_gates
+                .values()
+                .filter(|g| !g.resolved)
+                .cloned()
+                .collect()
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Check if a gate exists and is still pending.
+    pub fn is_gate_pending(&self, execution_id: &str, gate_id: &str) -> bool {
+        let pending = self.pending.read().expect("GateStateRegistry lock poisoned");
+
+        pending
+            .get(execution_id)
+            .and_then(|gates| gates.get(gate_id))
+            .map_or(false, |g| !g.resolved)
+    }
+
+    /// Clean up all gates for a completed execution.
+    pub fn cleanup_execution(&self, execution_id: &str) {
+        let mut pending = self.pending.write().expect("GateStateRegistry lock poisoned");
+        pending.remove(execution_id);
+    }
+
+    /// Get a gate by its ID across all executions.
+    pub fn get_gate(&self, gate_id: &str) -> Option<PendingGate> {
+        let pending = self.pending.read().expect("GateStateRegistry lock poisoned");
+
+        for exec_gates in pending.values() {
+            if let Some(gate) = exec_gates.get(gate_id) {
+                return Some(gate.clone());
+            }
+        }
+        None
+    }
+}
+
+impl Default for GateStateRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_register_and_resolve_gate() {
+        let registry = GateStateRegistry::new();
+        let gate_id = registry.register_gate(
+            "exec-1",
+            "node-1",
+            "file_write",
+            RiskLevel::Medium,
+            GatingAction::RequireConfirmation,
+        );
+
+        assert!(gate_id.starts_with("gate-exec-1-"));
+        assert!(registry.is_gate_pending("exec-1", &gate_id));
+
+        let resolved = registry.resolve_gate("exec-1", &gate_id);
+        assert!(resolved.is_some());
+        assert!(resolved.unwrap().resolved);
+
+        assert!(!registry.is_gate_pending("exec-1", &gate_id));
+    }
+
+    #[test]
+    fn test_pending_gates_empty_for_unknown_execution() {
+        let registry = GateStateRegistry::new();
+        let gates = registry.pending_gates("nonexistent");
+        assert!(gates.is_empty());
+    }
+
+    #[test]
+    fn test_cleanup_execution() {
+        let registry = GateStateRegistry::new();
+        registry.register_gate(
+            "exec-1",
+            "node-1",
+            "file_write",
+            RiskLevel::Medium,
+            GatingAction::RequireConfirmation,
+        );
+
+        registry.cleanup_execution("exec-1");
+        let gates = registry.pending_gates("exec-1");
+        assert!(gates.is_empty());
+    }
+
+    #[test]
+    fn test_get_gate_across_executions() {
+        let registry = GateStateRegistry::new();
+        let gate_id = registry.register_gate(
+            "exec-1",
+            "node-1",
+            "bash",
+            RiskLevel::High,
+            GatingAction::DryRun,
+        );
+
+        let gate = registry.get_gate(&gate_id);
+        assert!(gate.is_some());
+        assert_eq!(gate.unwrap().tool, "bash");
+    }
+
+    #[test]
+    fn test_resolve_nonexistent_gate() {
+        let registry = GateStateRegistry::new();
+        let resolved = registry.resolve_gate("exec-1", "nonexistent");
+        assert!(resolved.is_none());
+    }
+}

--- a/engine/src/risk_gating/domain/mod.rs
+++ b/engine/src/risk_gating/domain/mod.rs
@@ -14,13 +14,17 @@
 //! - All validation must happen in the application layer (service traits)
 //! - All persistence must happen behind repository interfaces
 
+pub mod default_classifier;
 pub mod error;
 pub mod event;
+pub mod gate_state;
 pub mod risk_classifier;
 pub mod risk_config;
 pub mod risk_level;
 
+pub use default_classifier::DefaultClassifier;
 pub use error::RiskGatingError;
-pub use risk_classifier::RiskClassifier;
+pub use gate_state::GateStateRegistry;
+pub use risk_classifier::{ClassificationResult, RiskClassifier};
 pub use risk_config::RiskConfig;
-pub use risk_level::RiskLevel;
+pub use risk_level::{GatingAction, RiskLevel};

--- a/engine/src/risk_gating/infrastructure/default_config_repository.rs
+++ b/engine/src/risk_gating/infrastructure/default_config_repository.rs
@@ -1,0 +1,177 @@
+//! Default implementation of the RiskConfigRepository.
+//!
+//! @canonical .pi/architecture/modules/risk-gating.md
+//! Implements: ISSUE-RISK-GATING-1 — RiskConfigRepository default implementation
+//! Issue: #90
+//!
+//! Provides a default `InMemoryConfigRepository` that stores risk
+//! configuration in memory. This is suitable for single-execution
+//! scenarios where persistence across restarts is not required.
+//!
+//! # Thread Safety
+//! - Config state is protected by `RwLock` for concurrent read/write
+//! - All async methods are safe to call from multiple tasks
+
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use crate::risk_gating::domain::{RiskConfig, RiskGatingError, RiskLevel};
+use crate::risk_gating::infrastructure::repository::RiskConfigRepository;
+
+/// In-memory implementation of `RiskConfigRepository`.
+///
+/// Stores configuration per execution ID. Not persisted across restarts.
+///
+/// # Examples
+///
+/// ```rust
+/// use rigorix::risk_gating::infrastructure::InMemoryConfigRepository;
+/// use rigorix::risk_gating::infrastructure::repository::RiskConfigRepository;
+///
+/// # async fn example() {
+/// let repo = InMemoryConfigRepository::new();
+/// let config = repo.load_config("exec-1").await.unwrap();
+/// assert!(config.auto_confirm_low);
+/// # }
+/// ```
+pub struct InMemoryConfigRepository {
+    /// Stored configurations keyed by execution ID.
+    configs: RwLock<HashMap<String, RiskConfig>>,
+
+    /// Stored tool overrides keyed by tool name.
+    overrides: RwLock<HashMap<String, RiskLevel>>,
+}
+
+impl InMemoryConfigRepository {
+    /// Create a new empty `InMemoryConfigRepository`.
+    pub fn new() -> Self {
+        Self {
+            configs: RwLock::new(HashMap::new()),
+            overrides: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl Default for InMemoryConfigRepository {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl RiskConfigRepository for InMemoryConfigRepository {
+    async fn load_config(&self, execution_id: &str) -> Result<RiskConfig, RiskGatingError> {
+        let configs = self.configs.read().expect("ConfigRepository lock poisoned");
+        Ok(configs
+            .get(execution_id)
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    async fn save_config(
+        &self,
+        execution_id: &str,
+        config: &RiskConfig,
+    ) -> Result<(), RiskGatingError> {
+        let mut configs = self.configs.write().expect("ConfigRepository lock poisoned");
+        configs.insert(execution_id.to_string(), config.clone());
+        Ok(())
+    }
+
+    async fn load_tool_override(
+        &self,
+        tool: &str,
+    ) -> Result<Option<RiskLevel>, RiskGatingError> {
+        let overrides = self.overrides.read().expect("ConfigRepository lock poisoned");
+        Ok(overrides.get(tool).copied())
+    }
+
+    async fn save_tool_override(
+        &self,
+        tool: &str,
+        risk_level: &RiskLevel,
+    ) -> Result<(), RiskGatingError> {
+        let mut overrides = self.overrides.write().expect("ConfigRepository lock poisoned");
+        overrides.insert(tool.to_string(), *risk_level);
+        Ok(())
+    }
+
+    async fn remove_tool_override(&self, tool: &str) -> Result<bool, RiskGatingError> {
+        let mut overrides = self.overrides.write().expect("ConfigRepository lock poisoned");
+        Ok(overrides.remove(tool).is_some())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::risk_gating::domain::RiskConfig;
+
+    #[tokio::test]
+    async fn test_load_default_config() {
+        let repo = InMemoryConfigRepository::new();
+        let config = repo.load_config("exec-1").await.unwrap();
+        assert!(config.auto_confirm_low);
+        assert!(config.require_review_medium);
+        assert!(config.dry_run_high);
+        assert!(config.tool_overrides.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_save_and_load_config() {
+        let repo = InMemoryConfigRepository::new();
+        let mut config = RiskConfig::default();
+        config.auto_confirm_low = false;
+
+        repo.save_config("exec-1", &config).await.unwrap();
+        let loaded = repo.load_config("exec-1").await.unwrap();
+        assert!(!loaded.auto_confirm_low);
+    }
+
+    #[tokio::test]
+    async fn test_save_and_load_tool_override() {
+        let repo = InMemoryConfigRepository::new();
+        repo.save_tool_override("bash", &RiskLevel::Low).await.unwrap();
+
+        let loaded = repo.load_tool_override("bash").await.unwrap();
+        assert_eq!(loaded, Some(RiskLevel::Low));
+    }
+
+    #[tokio::test]
+    async fn test_load_nonexistent_override() {
+        let repo = InMemoryConfigRepository::new();
+        let loaded = repo.load_tool_override("nonexistent").await.unwrap();
+        assert_eq!(loaded, None);
+    }
+
+    #[tokio::test]
+    async fn test_remove_tool_override() {
+        let repo = InMemoryConfigRepository::new();
+        repo.save_tool_override("bash", &RiskLevel::Low).await.unwrap();
+
+        let removed = repo.remove_tool_override("bash").await.unwrap();
+        assert!(removed);
+
+        let loaded = repo.load_tool_override("bash").await.unwrap();
+        assert_eq!(loaded, None);
+    }
+
+    #[tokio::test]
+    async fn test_remove_nonexistent_override() {
+        let repo = InMemoryConfigRepository::new();
+        let removed = repo.remove_tool_override("nonexistent").await.unwrap();
+        assert!(!removed);
+    }
+
+    #[tokio::test]
+    async fn test_configs_isolated_by_execution() {
+        let repo = InMemoryConfigRepository::new();
+        let mut config_a = RiskConfig::default();
+        config_a.auto_confirm_low = false;
+        repo.save_config("exec-a", &config_a).await.unwrap();
+
+        let config_b = repo.load_config("exec-b").await.unwrap();
+        assert!(config_b.auto_confirm_low); // Default, not config_a's value
+    }
+}

--- a/engine/src/risk_gating/infrastructure/mod.rs
+++ b/engine/src/risk_gating/infrastructure/mod.rs
@@ -11,6 +11,8 @@
 //! The primary repository is `RiskConfigRepository` for loading and
 //! persisting risk configuration and tool overrides.
 
+pub mod default_config_repository;
 pub mod repository;
 
+pub use default_config_repository::*;
 pub use repository::*;


### PR DESCRIPTION
## RiskClassifier Implementation (#90)

Implements the RiskClassifier component for the risk-gating epic.

### Changes

- **DefaultClassifier** — Concrete  impl with built-in classification rules:
  - Low: file_read, read, lsp_query, git_read, git_diff, git_log, git_status, glob, grep, list_files, search_files
  - Medium: file_write, write, file_append, file_patch, edit, git_stage, git_add, create_file
  - High: run_command, bash, git_commit, git_push, git_reset, delete_file, remove
  - Unknown tools default to Medium (safe default)
  - Supports config-driven overrides that take precedence

- **RiskGateServiceImpl** — Full service implementation:
  - evaluate_gate: classify + gating policy evaluation
  - classify_tool: classification without gate eval
  - resolve_gate: approve/reject pending gates
  - override_tool: runtime per-tool overrides
  - reload_config: configuration reload

- **RiskGateFactoryImpl** — Creates configured service instances
  - create_default, create_from_config, create_with_overrides, create_with_policy

- **GateStateRegistry** — Thread-safe pending gate tracking
  - Register, resolve, query pending gates per execution

- **InMemoryConfigRepository** — Stores RiskConfig per execution

### Testing

42 unit tests covering:
- All classification rules (Low/Medium/High for each tool pattern)
- Override precedence
- Determinism guarantee
- Gate evaluation (auto-execute, confirmation, dry-run)
- Gate resolution (approve/reject, already-resolved errors)
- Runtime overrides taking effect
- Repository CRUD operations
- Gate registry lifecycle

Issue: #90
Relates to: #88