### PR TITLE
feat: complete RiskConfig domain entity with comprehensive tests (#92)

### DIFF
--- a/engine/src/risk_gating/domain/risk_config.rs
+++ b/engine/src/risk_gating/domain/risk_config.rs
@@ -110,4 +110,337 @@ impl RiskConfig {
         self.require_review_medium = other.require_review_medium;
         self.dry_run_high = other.dry_run_high;
     }
+
+    /// Create a strict configuration (all gates enabled).
+    pub fn strict() -> Self {
+        Self {
+            tool_overrides: HashMap::new(),
+            auto_confirm_low: true,
+            require_review_medium: true,
+            dry_run_high: true,
+        }
+    }
+
+    /// Create a permissive configuration (all gates disabled).
+    pub fn permissive() -> Self {
+        Self {
+            tool_overrides: HashMap::new(),
+            auto_confirm_low: false,
+            require_review_medium: false,
+            dry_run_high: false,
+        }
+    }
+
+    /// Create a custom configuration with all parameters.
+    pub fn custom(
+        tool_overrides: HashMap<String, RiskLevel>,
+        auto_confirm_low: bool,
+        require_review_medium: bool,
+        dry_run_high: bool,
+    ) -> Self {
+        Self {
+            tool_overrides,
+            auto_confirm_low,
+            require_review_medium,
+            dry_run_high,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // Default
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_default_config() {
+        let config = RiskConfig::default();
+        assert!(config.tool_overrides.is_empty());
+        assert!(config.auto_confirm_low);
+        assert!(config.require_review_medium);
+        assert!(config.dry_run_high);
+    }
+
+    // -----------------------------------------------------------------------
+    // Constructors
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_new_with_overrides() {
+        let mut overrides = HashMap::new();
+        overrides.insert("bash".to_string(), RiskLevel::Low);
+        let config = RiskConfig::new(overrides);
+
+        assert_eq!(config.tool_overrides.len(), 1);
+        assert_eq!(config.get_override("bash"), Some(&RiskLevel::Low));
+        assert!(config.auto_confirm_low);
+        assert!(config.require_review_medium);
+        assert!(config.dry_run_high);
+    }
+
+    #[test]
+    fn test_strict_config() {
+        let config = RiskConfig::strict();
+        assert!(config.auto_confirm_low);
+        assert!(config.require_review_medium);
+        assert!(config.dry_run_high);
+        assert!(config.tool_overrides.is_empty());
+    }
+
+    #[test]
+    fn test_permissive_config() {
+        let config = RiskConfig::permissive();
+        assert!(!config.auto_confirm_low);
+        assert!(!config.require_review_medium);
+        assert!(!config.dry_run_high);
+    }
+
+    #[test]
+    fn test_custom_config() {
+        let mut overrides = HashMap::new();
+        overrides.insert("run_command".to_string(), RiskLevel::High);
+        let config = RiskConfig::custom(overrides, false, true, false);
+
+        assert!(!config.auto_confirm_low);
+        assert!(config.require_review_medium);
+        assert!(!config.dry_run_high);
+        assert_eq!(config.tool_overrides.len(), 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Override management
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_get_override_exists() {
+        let mut overrides = HashMap::new();
+        overrides.insert("bash".to_string(), RiskLevel::High);
+        let config = RiskConfig::new(overrides);
+
+        assert_eq!(config.get_override("bash"), Some(&RiskLevel::High));
+    }
+
+    #[test]
+    fn test_get_override_not_found() {
+        let config = RiskConfig::default();
+        assert_eq!(config.get_override("nonexistent"), None);
+    }
+
+    #[test]
+    fn test_has_override_true() {
+        let mut overrides = HashMap::new();
+        overrides.insert("git_commit".to_string(), RiskLevel::High);
+        let config = RiskConfig::new(overrides);
+
+        assert!(config.has_override("git_commit"));
+    }
+
+    #[test]
+    fn test_has_override_false() {
+        let config = RiskConfig::default();
+        assert!(!config.has_override("git_commit"));
+    }
+
+    #[test]
+    fn test_set_override_new() {
+        let mut config = RiskConfig::default();
+        config.set_override("bash".to_string(), RiskLevel::Low);
+
+        assert!(config.has_override("bash"));
+        assert_eq!(config.get_override("bash"), Some(&RiskLevel::Low));
+    }
+
+    #[test]
+    fn test_set_override_update() {
+        let mut config = RiskConfig::default();
+        config.set_override("bash".to_string(), RiskLevel::Low);
+        config.set_override("bash".to_string(), RiskLevel::High);
+
+        assert_eq!(config.get_override("bash"), Some(&RiskLevel::High));
+    }
+
+    #[test]
+    fn test_remove_override_exists() {
+        let mut config = RiskConfig::default();
+        config.set_override("bash".to_string(), RiskLevel::High);
+
+        let removed = config.remove_override("bash");
+        assert_eq!(removed, Some(RiskLevel::High));
+        assert!(!config.has_override("bash"));
+    }
+
+    #[test]
+    fn test_remove_override_not_found() {
+        let mut config = RiskConfig::default();
+        let removed = config.remove_override("nonexistent");
+        assert_eq!(removed, None);
+    }
+
+    #[test]
+    fn test_multiple_overrides() {
+        let mut overrides = HashMap::new();
+        overrides.insert("bash".to_string(), RiskLevel::High);
+        overrides.insert("file_read".to_string(), RiskLevel::Low);
+        overrides.insert("file_write".to_string(), RiskLevel::Medium);
+        let config = RiskConfig::new(overrides);
+
+        assert_eq!(config.tool_overrides.len(), 3);
+        assert_eq!(config.get_override("bash"), Some(&RiskLevel::High));
+        assert_eq!(config.get_override("file_read"), Some(&RiskLevel::Low));
+        assert_eq!(config.get_override("file_write"), Some(&RiskLevel::Medium));
+    }
+
+    // -----------------------------------------------------------------------
+    // Merge
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_merge_combines_overrides() {
+        let mut base = RiskConfig::default();
+        base.set_override("bash".to_string(), RiskLevel::High);
+
+        let mut other = RiskConfig::default();
+        other.set_override("file_write".to_string(), RiskLevel::Low);
+        other.auto_confirm_low = false;
+
+        base.merge(other);
+
+        assert!(base.has_override("bash"));
+        assert!(base.has_override("file_write"));
+        assert!(!base.auto_confirm_low); // Overwritten by other
+    }
+
+    #[test]
+    fn test_merge_other_overrides_take_precedence() {
+        let mut base = RiskConfig::default();
+        base.set_override("bash".to_string(), RiskLevel::Low);
+
+        let mut other = RiskConfig::default();
+        other.set_override("bash".to_string(), RiskLevel::High);
+
+        base.merge(other);
+        assert_eq!(base.get_override("bash"), Some(&RiskLevel::High));
+    }
+
+    #[test]
+    fn test_merge_empty_other() {
+        let mut base = RiskConfig::default();
+        base.set_override("bash".to_string(), RiskLevel::High);
+
+        let other = RiskConfig::default();
+        base.merge(other);
+
+        assert_eq!(base.get_override("bash"), Some(&RiskLevel::High));
+        assert!(base.auto_confirm_low); // Not changed
+    }
+
+    // -----------------------------------------------------------------------
+    // Serialization
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        let mut overrides = HashMap::new();
+        overrides.insert("bash".to_string(), RiskLevel::High);
+        overrides.insert("file_read".to_string(), RiskLevel::Low);
+        let config = RiskConfig::custom(overrides, true, false, true);
+
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: RiskConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(config, deserialized);
+    }
+
+    #[test]
+    fn test_serialization_empty_overrides() {
+        let config = RiskConfig::default();
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: RiskConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(config, deserialized);
+    }
+
+    #[test]
+    fn test_deserialization_minimal() {
+        // All fields default
+        let json = r#"{"tool_overrides":{},"auto_confirm_low":true,"require_review_medium":true,"dry_run_high":true}"#;
+        let config: RiskConfig = serde_json::from_str(json).unwrap();
+        assert!(config.auto_confirm_low);
+        assert!(config.require_review_medium);
+        assert!(config.dry_run_high);
+    }
+
+    // -----------------------------------------------------------------------
+    // Clone and Debug
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_clone() {
+        let mut overrides = HashMap::new();
+        overrides.insert("bash".to_string(), RiskLevel::High);
+        let config = RiskConfig::new(overrides);
+        let cloned = config.clone();
+
+        assert_eq!(config, cloned);
+        // Verify independent
+        assert_eq!(config.get_override("bash"), cloned.get_override("bash"));
+    }
+
+    #[test]
+    fn test_debug() {
+        let config = RiskConfig::default();
+        let debug = format!("{:?}", config);
+        assert!(debug.contains("auto_confirm_low"));
+        assert!(debug.contains("require_review_medium"));
+        assert!(debug.contains("dry_run_high"));
+        assert!(debug.contains("tool_overrides"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Edge cases
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_empty_tool_name() {
+        let mut config = RiskConfig::default();
+        config.set_override(String::new(), RiskLevel::High);
+        assert!(config.has_override(""));
+        assert_eq!(config.get_override(""), Some(&RiskLevel::High));
+    }
+
+    #[test]
+    fn test_case_sensitive_tool_names() {
+        let mut config = RiskConfig::default();
+        config.set_override("Bash".to_string(), RiskLevel::Low);
+        config.set_override("bash".to_string(), RiskLevel::High);
+
+        // Different keys
+        assert_eq!(config.get_override("Bash"), Some(&RiskLevel::Low));
+        assert_eq!(config.get_override("bash"), Some(&RiskLevel::High));
+    }
+
+    #[test]
+    fn test_override_removal_restores_default() {
+        let mut config = RiskConfig::default();
+        config.set_override("bash".to_string(), RiskLevel::Low);
+        config.remove_override("bash");
+
+        // After removal, classifier will use default rules (not stored in config)
+        assert!(!config.has_override("bash"));
+    }
+
+    #[test]
+    fn test_many_overrides() {
+        let mut overrides = HashMap::new();
+        for i in 0..100 {
+            overrides.insert(format!("tool_{}", i), RiskLevel::Low);
+        }
+        let config = RiskConfig::new(overrides);
+        assert_eq!(config.tool_overrides.len(), 100);
+        assert!(config.has_override("tool_0"));
+        assert!(config.has_override("tool_99"));
+    }
 }


### PR DESCRIPTION
## RiskConfig Implementation (#92)

Completes the RiskConfig domain entity with builder methods and comprehensive test coverage.

### Changes
- Added `strict()` builder — all gates enabled
- Added `permissive()` builder — all gates disabled
- Added `custom()` builder — full parameter control
- 26 unit tests

### Test Coverage
- All constructors (default, new, strict, permissive, custom)
- Override management (get, has, set, update, remove)
- Merge semantics (combine, precedence, empty)
- JSON serialization round-trip
- Clone and Debug
- Edge cases (empty names, case sensitivity, 100 overrides)

Issue: #92
Relates to: #88