### PR TITLE
feat: implement ExecutionPolicyService #115 — retry decisions, backoff, validation

### DIFF
--- a/engine/src/dag_engine/application/service.rs
+++ b/engine/src/dag_engine/application/service.rs
@@ -142,3 +142,127 @@ pub struct ImpactLevelResult {
     /// Human-readable summary of why this impact level was assigned.
     pub summary: String,
 }
+
+/// Policy evaluation service for retry, backoff, and fallback decisions.
+///
+/// The ExecutionPolicyService evaluates ExecutionPolicy configurations
+/// during node execution. It answers questions like:
+/// - Should this node be retried given the failure type?
+/// - How long should we wait before retrying?
+/// - Is there a fallback node to execute?
+/// - Is the policy configuration valid?
+///
+/// # Contract (Frozen)
+/// - Retry decisions are purely based on policy + failure type
+/// - Backoff uses exponential: backoff_ms * multiplier^attempt
+/// - Fallback is only considered after max_retries exhausted
+/// - All policy validation must pass for execution to proceed
+#[async_trait]
+pub trait ExecutionPolicyService: Send + Sync {
+    /// Determine if a node should be retried after a failure.
+    ///
+    /// Checks:
+    /// 1. Is the failure type in the policy's `retry_on` list?
+    /// 2. Have we exhausted `max_retries`?
+    ///
+    /// Returns a RetryDecision with the outcome and reason.
+    async fn should_retry(
+        &self,
+        input: ShouldRetryInput,
+    ) -> Result<RetryDecision, DagError>;
+
+    /// Compute the backoff delay before retrying.
+    ///
+    /// Uses exponential backoff:
+    /// `delay = min(backoff_ms * multiplier^attempt, max_backoff_ms)`
+    async fn compute_backoff(
+        &self,
+        input: ComputeBackoffInput,
+    ) -> Result<ComputeBackoffOutput, DagError>;
+
+    /// Validate an ExecutionPolicy configuration.
+    ///
+    /// Checks:
+    /// - max_retries <= 255 (always true for u8, checked for semantics)
+    /// - backoff_ms > 0
+    /// - backoff_multiplier >= 1.0
+    /// - max_backoff_ms >= backoff_ms
+    async fn validate_policy(
+        &self,
+        input: ValidatePolicyInput,
+    ) -> Result<ValidatePolicyOutput, DagError>;
+}
+
+// ---------------------------------------------------------------------------
+// ExecutionPolicyService DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for a retry decision.
+#[derive(Debug, Clone)]
+pub struct ShouldRetryInput {
+    /// The execution policy governing this node.
+    pub policy: crate::dag_engine::domain::ExecutionPolicy,
+    /// The type of failure that occurred.
+    pub failure_type: crate::dag_engine::domain::FailureType,
+    /// The number of retries already attempted.
+    pub retries_attempted: u8,
+}
+
+/// Decision about whether to retry a failed node.
+#[derive(Debug, Clone)]
+pub enum RetryDecision {
+    /// Retry the node with the specified strategy.
+    Retry {
+        /// The retry strategy to apply.
+        strategy: crate::dag_engine::domain::RetryStrategy,
+        /// Next attempt number (1-indexed).
+        attempt: u8,
+        /// Reason for the retry decision.
+        reason: String,
+    },
+    /// Do not retry; consider fallback or permanent failure.
+    NoRetry {
+        /// Reason the node will not be retried.
+        reason: String,
+        /// If true, attempt to execute the fallback node (if configured).
+        use_fallback: bool,
+    },
+}
+
+/// Input for computing backoff delay.
+#[derive(Debug, Clone)]
+pub struct ComputeBackoffInput {
+    /// The execution policy containing backoff configuration.
+    pub policy: crate::dag_engine::domain::ExecutionPolicy,
+    /// The current retry attempt number (1-indexed).
+    pub attempt: u8,
+}
+
+/// Output from computing backoff delay.
+#[derive(Debug, Clone)]
+pub struct ComputeBackoffOutput {
+    /// The backoff delay in milliseconds.
+    pub delay_ms: u64,
+    /// The effective multiplier used.
+    pub multiplier: f64,
+    /// Human-readable explanation of the computation.
+    pub explanation: String,
+}
+
+/// Input for validating an ExecutionPolicy.
+#[derive(Debug, Clone)]
+pub struct ValidatePolicyInput {
+    /// The execution policy to validate.
+    pub policy: crate::dag_engine::domain::ExecutionPolicy,
+}
+
+/// Output from validating an ExecutionPolicy.
+#[derive(Debug, Clone)]
+pub struct ValidatePolicyOutput {
+    /// Whether the policy is valid.
+    pub is_valid: bool,
+    /// List of validation errors (empty if valid).
+    pub errors: Vec<String>,
+    /// List of validation warnings.
+    pub warnings: Vec<String>,
+}

--- a/engine/src/dag_engine/application/service_impl.rs
+++ b/engine/src/dag_engine/application/service_impl.rs
@@ -27,7 +27,11 @@ use super::dto::{
     ConstructGraphOutput, GetGraphInput, GetGraphOutput, GetNodeInput, GetNodeOutput,
     ListNodesInput, ListNodesOutput, SealGraphInput, SealGraphOutput,
 };
-use super::service::{DagGraphService, DagPlanningService, ImpactLevelResult};
+use super::service::{
+    ComputeBackoffInput, ComputeBackoffOutput, DagGraphService, DagPlanningService,
+    ExecutionPolicyService, ImpactLevelResult, RetryDecision, ShouldRetryInput,
+    ValidatePolicyInput, ValidatePolicyOutput,
+};
 
 /// In-memory implementation of DagGraphService.
 ///
@@ -300,6 +304,145 @@ impl DagPlanningService for DagPlanningServiceImpl {
         Ok(ImpactLevelResult {
             impact_level: diff.impact_level,
             summary,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ExecutionPolicyServiceImpl
+// ---------------------------------------------------------------------------
+
+/// Implementation of ExecutionPolicyService.
+///
+/// Provides retry decision logic, backoff computation, and policy
+/// validation. All decisions are stateless (pure functions on
+/// ExecutionPolicy + failure context).
+pub struct ExecutionPolicyServiceImpl;
+
+impl ExecutionPolicyServiceImpl {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl ExecutionPolicyService for ExecutionPolicyServiceImpl {
+    async fn should_retry(
+        &self,
+        input: ShouldRetryInput,
+    ) -> Result<RetryDecision, DagError> {
+        let policy = input.policy;
+
+        // Check if the failure type is in the retry_on list
+        let is_retriable = policy
+            .retry_on
+            .iter()
+            .any(|ft| *ft == input.failure_type);
+
+        if !is_retriable {
+            return Ok(RetryDecision::NoRetry {
+                reason: format!(
+                    "Failure type {:?} is not configured for retry in this policy",
+                    input.failure_type
+                ),
+                use_fallback: policy.fallback_node.is_some(),
+            });
+        }
+
+        // Check if retries are exhausted
+        if input.retries_attempted >= policy.max_retries {
+            return Ok(RetryDecision::NoRetry {
+                reason: format!(
+                    "Max retries ({}) exhausted after {} attempt(s)",
+                    policy.max_retries, input.retries_attempted
+                ),
+                use_fallback: policy.fallback_node.is_some(),
+            });
+        }
+
+        // Retry with the configured strategy
+        let next_attempt = input.retries_attempted + 1;
+        let reason = format!(
+            "Retrying (attempt {}/{}) with {:?} strategy after {:?}",
+            next_attempt, policy.max_retries, policy.retry_strategy, input.failure_type
+        );
+
+        Ok(RetryDecision::Retry {
+            strategy: policy.retry_strategy,
+            attempt: next_attempt,
+            reason,
+        })
+    }
+
+    async fn compute_backoff(
+        &self,
+        input: ComputeBackoffInput,
+    ) -> Result<ComputeBackoffOutput, DagError> {
+        let base = input.policy.backoff_ms as f64;
+        let multiplier = input.policy.backoff_multiplier;
+        let max_ms = input.policy.max_backoff_ms;
+
+        // Exponential backoff: base * multiplier^(attempt-1)
+        let exponent = (input.attempt as f64) - 1.0;
+        let raw_delay = base * multiplier.powf(exponent);
+        let delay_ms = (raw_delay.round() as u64).min(max_ms);
+
+        let explanation = format!(
+            "Backoff: {}ms * {}^{} = {}ms (capped at {}ms)",
+            base as u64, multiplier, input.attempt, delay_ms, max_ms
+        );
+
+        Ok(ComputeBackoffOutput {
+            delay_ms,
+            multiplier,
+            explanation,
+        })
+    }
+
+    async fn validate_policy(
+        &self,
+        input: ValidatePolicyInput,
+    ) -> Result<ValidatePolicyOutput, DagError> {
+        let mut errors = Vec::new();
+        let mut warnings = Vec::new();
+
+        // backoff_ms must be > 0
+        if input.policy.backoff_ms == 0 {
+            errors.push("backoff_ms must be greater than 0".to_string());
+        }
+
+        // backoff_multiplier must be >= 1.0
+        if input.policy.backoff_multiplier < 1.0 {
+            errors.push(
+                "backoff_multiplier must be >= 1.0 (would cause decreasing backoff)".to_string(),
+            );
+        }
+
+        // max_backoff_ms must be >= backoff_ms
+        if input.policy.max_backoff_ms < input.policy.backoff_ms {
+            errors.push(
+                "max_backoff_ms must be >= backoff_ms".to_string(),
+            );
+        }
+
+        // Warn if max_retries is 0 (no retries at all)
+        if input.policy.max_retries == 0 {
+            warnings.push(
+                "max_retries is 0: node will not be retried on failure".to_string(),
+            );
+        }
+
+        // Warn if retry_on is empty (nothing will trigger a retry)
+        if input.policy.retry_on.is_empty() {
+            warnings.push(
+                "retry_on is empty: no failure type will trigger a retry".to_string(),
+            );
+        }
+
+        Ok(ValidatePolicyOutput {
+            is_valid: errors.is_empty(),
+            errors,
+            warnings,
         })
     }
 }

--- a/engine/src/dag_engine/tests.rs
+++ b/engine/src/dag_engine/tests.rs
@@ -22,8 +22,13 @@ use crate::dag_engine::domain::{
     TaskGraph, TaskNode, ValidationRule,
 };
 use crate::dag_engine::application::dto::*;
-use crate::dag_engine::application::service::*;
-use crate::dag_engine::application::service_impl::*;
+use crate::dag_engine::application::service::{
+    ComputeBackoffInput, DagGraphService, DagPlanningService, ExecutionPolicyService,
+    RetryDecision, ShouldRetryInput, ValidatePolicyInput,
+};
+use crate::dag_engine::application::service_impl::{
+    DagGraphServiceImpl, DagPlanningServiceImpl, ExecutionPolicyServiceImpl,
+};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -738,6 +743,304 @@ fn test_taskgraph_serde_roundtrip() {
     assert_eq!(deserialized.node_count(), 2);
     // ExecutionState is skipped during serialization, so it will be default
     assert!(deserialized.execution_state.in_degree.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// ExecutionPolicyService — Should Retry
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_should_retry_retriable_failure() {
+    let service = ExecutionPolicyServiceImpl::new();
+    let policy = ExecutionPolicy::default();
+
+    let decision = service.should_retry(ShouldRetryInput {
+        policy,
+        failure_type: FailureType::Transient,
+        retries_attempted: 0,
+    }).await.unwrap();
+
+    match decision {
+        RetryDecision::Retry { strategy, attempt, .. } => {
+            assert_eq!(strategy, RetryStrategy::SameOperation);
+            assert_eq!(attempt, 1);
+        }
+        _ => panic!("Expected Retry, got NoRetry"),
+    }
+}
+
+#[tokio::test]
+async fn test_should_retry_non_retriable_failure() {
+    let service = ExecutionPolicyServiceImpl::new();
+    let policy = ExecutionPolicy::default();
+
+    let decision = service.should_retry(ShouldRetryInput {
+        policy,
+        failure_type: FailureType::Permanent,
+        retries_attempted: 0,
+    }).await.unwrap();
+
+    match decision {
+        RetryDecision::NoRetry { use_fallback, .. } => {
+            assert!(!use_fallback, "No fallback configured");
+        }
+        _ => panic!("Expected NoRetry, got Retry"),
+    }
+}
+
+#[tokio::test]
+async fn test_should_retry_exhausted_retries() {
+    let service = ExecutionPolicyServiceImpl::new();
+    // max_retries = 3 by default
+    let policy = ExecutionPolicy::default();
+
+    // After 3 attempts, no more retries
+    let decision = service.should_retry(ShouldRetryInput {
+        policy: policy.clone(),
+        failure_type: FailureType::Transient,
+        retries_attempted: 3,
+    }).await.unwrap();
+
+    match decision {
+        RetryDecision::NoRetry { reason, .. } => {
+            assert!(reason.contains("exhausted"));
+        }
+        _ => panic!("Expected NoRetry after exhausting retries"),
+    }
+}
+
+#[tokio::test]
+async fn test_should_retry_with_custom_policy() {
+    let service = ExecutionPolicyServiceImpl::new();
+    let policy = ExecutionPolicy {
+        max_retries: 5,
+        retry_on: vec![FailureType::Transient, FailureType::MissingDependency],
+        ..ExecutionPolicy::default()
+    };
+
+    // MissingDependency is retriable
+    let decision = service.should_retry(ShouldRetryInput {
+        policy,
+        failure_type: FailureType::MissingDependency,
+        retries_attempted: 0,
+    }).await.unwrap();
+
+    match decision {
+        RetryDecision::Retry { attempt, .. } => {
+            assert_eq!(attempt, 1);
+        }
+        _ => panic!("Expected Retry"),
+    }
+}
+
+#[tokio::test]
+async fn test_should_retry_max_retries_zero() {
+    let service = ExecutionPolicyServiceImpl::new();
+    let policy = ExecutionPolicy {
+        max_retries: 0,
+        ..ExecutionPolicy::default()
+    };
+
+    let decision = service.should_retry(ShouldRetryInput {
+        policy,
+        failure_type: FailureType::Transient,
+        retries_attempted: 0,
+    }).await.unwrap();
+
+    match decision {
+        RetryDecision::NoRetry { reason, .. } => {
+            assert!(reason.contains("exhausted") || reason.contains("0"));
+        }
+        _ => panic!("Expected NoRetry with max_retries=0"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ExecutionPolicyService — Backoff Computation
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_compute_backoff_first_attempt() {
+    let service = ExecutionPolicyServiceImpl::new();
+    let policy = ExecutionPolicy::default();
+
+    let output = service.compute_backoff(ComputeBackoffInput {
+        policy,
+        attempt: 1,
+    }).await.unwrap();
+
+    // First attempt: 100ms * 2.0^0 = 100ms
+    assert_eq!(output.delay_ms, 100);
+    assert!(output.explanation.contains("100ms"));
+}
+
+#[tokio::test]
+async fn test_compute_backoff_second_attempt() {
+    let service = ExecutionPolicyServiceImpl::new();
+    let policy = ExecutionPolicy::default();
+
+    let output = service.compute_backoff(ComputeBackoffInput {
+        policy,
+        attempt: 2,
+    }).await.unwrap();
+
+    // Second attempt: 100ms * 2.0^1 = 200ms
+    assert_eq!(output.delay_ms, 200);
+}
+
+#[tokio::test]
+async fn test_compute_backoff_third_attempt() {
+    let service = ExecutionPolicyServiceImpl::new();
+    let policy = ExecutionPolicy::default();
+
+    let output = service.compute_backoff(ComputeBackoffInput {
+        policy,
+        attempt: 3,
+    }).await.unwrap();
+
+    // Third attempt: 100ms * 2.0^2 = 400ms
+    assert_eq!(output.delay_ms, 400);
+}
+
+#[tokio::test]
+async fn test_compute_backoff_capped_at_max() {
+    let service = ExecutionPolicyServiceImpl::new();
+    let policy = ExecutionPolicy {
+        backoff_ms: 100,
+        backoff_multiplier: 10.0,
+        max_backoff_ms: 5000,
+        ..ExecutionPolicy::default()
+    };
+
+    let output = service.compute_backoff(ComputeBackoffInput {
+        policy,
+        attempt: 5, // 100 * 10^4 = 1,000,000 → capped at 5,000
+    }).await.unwrap();
+
+    assert_eq!(output.delay_ms, 5000);
+}
+
+#[tokio::test]
+async fn test_compute_backoff_custom_policy() {
+    let service = ExecutionPolicyServiceImpl::new();
+    let policy = ExecutionPolicy {
+        backoff_ms: 1000,
+        backoff_multiplier: 3.0,
+        max_backoff_ms: 60_000,
+        ..ExecutionPolicy::default()
+    };
+
+    let output = service.compute_backoff(ComputeBackoffInput {
+        policy,
+        attempt: 3, // 1000 * 3.0^2 = 9000ms
+    }).await.unwrap();
+
+    assert_eq!(output.delay_ms, 9000);
+}
+
+// ---------------------------------------------------------------------------
+// ExecutionPolicyService — Policy Validation
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_validate_policy_default_valid() {
+    let service = ExecutionPolicyServiceImpl::new();
+    let policy = ExecutionPolicy::default();
+
+    let output = service.validate_policy(ValidatePolicyInput {
+        policy,
+    }).await.unwrap();
+
+    assert!(output.is_valid);
+    assert!(output.errors.is_empty());
+}
+
+#[tokio::test]
+async fn test_validate_policy_zero_backoff() {
+    let service = ExecutionPolicyServiceImpl::new();
+    let policy = ExecutionPolicy {
+        backoff_ms: 0,
+        ..ExecutionPolicy::default()
+    };
+
+    let output = service.validate_policy(ValidatePolicyInput {
+        policy,
+    }).await.unwrap();
+
+    assert!(!output.is_valid);
+    assert!(output.errors.iter().any(|e| e.contains("backoff_ms")));
+}
+
+#[tokio::test]
+async fn test_validate_policy_multiplier_less_than_one() {
+    let service = ExecutionPolicyServiceImpl::new();
+    let policy = ExecutionPolicy {
+        backoff_multiplier: 0.5,
+        ..ExecutionPolicy::default()
+    };
+
+    let output = service.validate_policy(ValidatePolicyInput {
+        policy,
+    }).await.unwrap();
+
+    assert!(!output.is_valid);
+    assert!(output.errors.iter().any(|e| e.contains("multiplier")));
+}
+
+#[tokio::test]
+async fn test_validate_policy_max_less_than_base() {
+    let service = ExecutionPolicyServiceImpl::new();
+    let policy = ExecutionPolicy {
+        backoff_ms: 1000,
+        max_backoff_ms: 500,
+        ..ExecutionPolicy::default()
+    };
+
+    let output = service.validate_policy(ValidatePolicyInput {
+        policy,
+    }).await.unwrap();
+
+    assert!(!output.is_valid);
+    assert!(output.errors.iter().any(|e| e.contains("max_backoff")));
+}
+
+#[tokio::test]
+async fn test_validate_policy_multiple_errors() {
+    let service = ExecutionPolicyServiceImpl::new();
+    let policy = ExecutionPolicy {
+        backoff_ms: 0,
+        backoff_multiplier: 0.5,
+        max_backoff_ms: 0,
+        ..ExecutionPolicy::default()
+    };
+
+    let output = service.validate_policy(ValidatePolicyInput {
+        policy,
+    }).await.unwrap();
+
+    assert!(!output.is_valid);
+    assert!(output.errors.len() >= 2);
+}
+
+#[tokio::test]
+async fn test_validate_policy_warnings() {
+    let service = ExecutionPolicyServiceImpl::new();
+
+    // max_retries = 0 should warn
+    let policy = ExecutionPolicy {
+        max_retries: 0,
+        ..ExecutionPolicy::default()
+    };
+    let output = service.validate_policy(ValidatePolicyInput { policy }).await.unwrap();
+    assert!(output.warnings.iter().any(|w| w.contains("max_retries")));
+
+    // empty retry_on should warn
+    let policy = ExecutionPolicy {
+        retry_on: vec![],
+        ..ExecutionPolicy::default()
+    };
+    let output = service.validate_policy(ValidatePolicyInput { policy }).await.unwrap();
+    assert!(output.warnings.iter().any(|w| w.contains("retry_on")));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements the ExecutionPolicyService for per-node retry decisions, exponential backoff computation, and policy validation.

### Features
- **should_retry**: Checks failure type against retry_on list and max_retries
- **compute_backoff**: Exponential backoff with configurable multiplier and capping
- **validate_policy**: Validates backoff_ms > 0, multiplier >= 1.0, max_backoff_ms >= backoff_ms

### Tests
16 new tests covering all retry scenarios, backoff computations (1st, 2nd, 3rd attempts, capping), and policy validation (single errors, multiple errors, warnings).

Closes #115