### PR TITLE
[Issue #153] Implement Claude and OpenAI classifiers

### DIFF
--- a/engine/.pi/.guardian-pipeline-state.json
+++ b/engine/.pi/.guardian-pipeline-state.json
@@ -49,7 +49,7 @@
       }
     }
   ],
-  "currentItemIndex": 1,
+  "currentItemIndex": 2,
   "currentStepIndex": 0,
   "status": "running",
   "retryCount": 0,
@@ -89,9 +89,45 @@
           "reason": ""
         }
       ]
+    },
+    {
+      "item": "issue-planningpipeline",
+      "status": "done",
+      "stepResults": [
+        {
+          "step": "implement",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "implement",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "validate",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "validate",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "create-mr",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "merge",
+          "status": "passed",
+          "reason": ""
+        }
+      ]
     }
   ],
   "mergeOnValid": true,
   "createdAt": "2026-06-14T15:30:26.730Z",
-  "updatedAt": "2026-06-14T15:42:14.236Z"
+  "updatedAt": "2026-06-14T15:55:34.589Z"
 }

--- a/engine/src/planning/domain/claude_classifier.rs
+++ b/engine/src/planning/domain/claude_classifier.rs
@@ -1,0 +1,322 @@
+//! ClaudeClassifier — Anthropic Messages API implementation of the Classifier trait.
+//!
+//! @canonical .pi/architecture/modules/planning-pipeline.md#claude
+//! Implements: Classifier Trait — ClaudeClassifier via Anthropic Messages API
+//! Issue: issue-classifier-trait
+//!
+//! Uses Anthropic's Claude API (Messages endpoint) to classify user intent
+//! against available templates. Supports configurable model selection,
+//! API endpoint, and authentication via API key.
+//!
+//! # Prompt Structure
+//!
+//! The classifier builds a structured prompt that lists all available templates
+//! with their metadata and asks Claude to rank them by relevance to the user's
+//! intent. The response is parsed from JSON embedded in the Claude output.
+//!
+//! # Security
+//!
+//! - API key is provided at construction time, not hardcoded
+//! - Structured prompts prevent prompt injection (no raw intent in system prompt)
+//! - Token limits are respected to prevent budget overruns
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+use crate::budget_tracking::domain::LlmBudget;
+use crate::planning::domain::classification::{
+    ClassificationResult, ClassifiedTemplate, Classifier,
+};
+use crate::planning::domain::error::PlanningError;
+use crate::planning::domain::intent::UserIntent;
+
+/// Configuration for the Claude classifier.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClaudeClassifierConfig {
+    /// The Anthropic API endpoint (default: https://api.anthropic.com/v1/messages).
+    pub api_url: String,
+
+    /// Claude model to use (default: claude-sonnet-4-20250514).
+    pub model: String,
+
+    /// Maximum tokens in the response.
+    pub max_tokens: u32,
+
+    /// Request timeout in seconds.
+    pub timeout_secs: u64,
+
+    /// Temperature for classification (lower = more deterministic).
+    pub temperature: f64,
+}
+
+impl Default for ClaudeClassifierConfig {
+    fn default() -> Self {
+        Self {
+            api_url: "https://api.anthropic.com/v1/messages".to_string(),
+            model: "claude-sonnet-4-20250514".to_string(),
+            max_tokens: 1024,
+            timeout_secs: 30,
+            temperature: 0.1,
+        }
+    }
+}
+
+/// Classifier using Anthropic's Claude Messages API.
+///
+/// Communicates with the Claude API to classify user intent against
+/// available templates. Returns a ranked list of alternatives with
+/// confidence scores and reasoning.
+///
+/// # API Key
+///
+/// The API key is provided at construction and sent as the
+/// `x-api-key` header. Store the key securely (e.g., environment
+/// variable, secret manager).
+pub struct ClaudeClassifier {
+    /// API key for authentication.
+    api_key: String,
+
+    /// Configuration for the classifier.
+    config: ClaudeClassifierConfig,
+
+    /// HTTP client for API calls.
+    client: reqwest::Client,
+}
+
+impl ClaudeClassifier {
+    /// Create a new ClaudeClassifier.
+    ///
+    /// # Arguments
+    ///
+    /// * `api_key` — Anthropic API key (from environment or secret store).
+    /// * `config` — Optional configuration overrides (defaults used if None).
+    pub fn new(api_key: String, config: Option<ClaudeClassifierConfig>) -> Self {
+        let config = config.unwrap_or_default();
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(config.timeout_secs))
+            .build()
+            .expect("Failed to create HTTP client");
+
+        Self {
+            api_key,
+            config,
+            client,
+        }
+    }
+
+    /// Build the system prompt for classification.
+    fn build_system_prompt(&self, available_templates: &[String]) -> String {
+        let template_list = available_templates
+            .iter()
+            .enumerate()
+            .map(|(i, t)| format!("{}. {}", i + 1, t))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        format!(
+            r#"You are a template classifier. Your task is to match user intent to the most relevant template.
+
+Available templates:
+{}
+
+Respond with a JSON object containing:
+- "rankings": an array of objects, each with:
+  - "template_id": the template ID
+  - "confidence": a float from 0.0 to 1.0 indicating match confidence
+  - "reasoning": brief explanation of why this template matches
+
+Rules:
+- Return ALL templates ranked by confidence (highest to lowest)
+- If no template matches well, set all confidences to 0.0
+- Be strict: only high confidences (≥ 0.7) for clear matches
+- Output ONLY valid JSON, no other text"#,
+            template_list
+        )
+    }
+
+    /// Build the user message for classification.
+    fn build_user_message(&self, intent: &UserIntent) -> String {
+        let mut msg = format!("User intent: {}", intent.input);
+
+        if intent.has_clarifications() {
+            msg.push_str("\n\nClarification history:");
+            for pair in &intent.clarifications {
+                msg.push_str(&format!("\nQ: {}\nA: {}", pair.question, pair.answer));
+            }
+        }
+
+        msg
+    }
+
+    /// Parse the Claude API response into ranked alternatives.
+    pub(crate) fn parse_response(&self, response_body: &str) -> Result<Vec<ClassifiedTemplate>, PlanningError> {
+        // Try to extract JSON from the response (may be wrapped in markdown code blocks)
+        let json_str = if let Some(start) = response_body.find('{') {
+            if let Some(end) = response_body.rfind('}') {
+                &response_body[start..=end]
+            } else {
+                response_body
+            }
+        } else {
+            response_body
+        };
+
+        #[derive(Deserialize)]
+        struct ApiRanking {
+            template_id: String,
+            confidence: f64,
+            reasoning: String,
+        }
+
+        #[derive(Deserialize)]
+        struct ApiResponse {
+            rankings: Vec<ApiRanking>,
+        }
+
+        let parsed: ApiResponse = serde_json::from_str(json_str).map_err(|e| {
+            PlanningError::ClassificationError {
+                detail: format!("Failed to parse Claude response: {} (raw: {})", e, response_body.chars().take(200).collect::<String>()),
+            }
+        })?;
+
+        let templates: Vec<ClassifiedTemplate> = parsed
+            .rankings
+            .into_iter()
+            .map(|r| ClassifiedTemplate {
+                template_id: r.template_id,
+                confidence: r.confidence.clamp(0.0, 1.0),
+                reasoning: r.reasoning,
+                from_override: false,
+            })
+            .collect();
+
+        if templates.is_empty() {
+            return Err(PlanningError::ClassificationError {
+                detail: "Claude returned empty rankings".to_string(),
+            });
+        }
+
+        Ok(templates)
+    }
+}
+
+#[async_trait]
+impl Classifier for ClaudeClassifier {
+    async fn classify_with_alternatives(
+        &self,
+        intent: &UserIntent,
+        _budget: &LlmBudget,
+        available_templates: &[String],
+    ) -> Result<ClassificationResult, PlanningError> {
+        if available_templates.is_empty() {
+            return Ok(ClassificationResult {
+                alternatives: vec![],
+                requires_clarification: false,
+                needs_generator: true,
+                reasoning: "No templates available to classify against".to_string(),
+                llm_calls_used: 0,
+                llm_tokens_used: 0,
+            });
+        }
+
+        let system_prompt = self.build_system_prompt(available_templates);
+        let user_message = self.build_user_message(intent);
+
+        // Build the request body for Anthropic Messages API
+        let body = serde_json::json!({
+            "model": self.config.model,
+            "max_tokens": self.config.max_tokens,
+            "temperature": self.config.temperature,
+            "system": system_prompt,
+            "messages": [
+                {"role": "user", "content": user_message}
+            ]
+        });
+
+        // Make the API call
+        let body_bytes = serde_json::to_vec(&body).map_err(|e| {
+            PlanningError::ClassificationError {
+                detail: format!("Failed to serialize request: {}", e),
+            }
+        })?;
+
+        let response = self
+            .client
+            .post(&self.config.api_url)
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", "2023-06-01")
+            .header("content-type", "application/json")
+            .body(body_bytes)
+            .send()
+            .await
+            .map_err(|e| PlanningError::ClassificationError {
+                detail: format!("Claude API request failed: {}", e),
+            })?;
+
+        let status = response.status();
+        let response_text = response.text().await.map_err(|e| {
+            PlanningError::ClassificationError {
+                detail: format!("Failed to read Claude response body: {}", e),
+            }
+        })?;
+
+        if !status.is_success() {
+            return Err(PlanningError::ClassificationError {
+                detail: format!(
+                    "Claude API returned {}: {}",
+                    status.as_u16(),
+                    response_text.chars().take(200).collect::<String>()
+                ),
+            });
+        }
+
+        // Parse the Anthropic Messages API response
+        #[derive(Deserialize)]
+        struct AnthropicMessage {
+            content: Vec<AnthropicContent>,
+        }
+
+        #[derive(Deserialize)]
+        struct AnthropicContent {
+            #[serde(rename = "type")]
+            content_type: String,
+            text: Option<String>,
+        }
+
+        let message: AnthropicMessage = serde_json::from_str(&response_text).map_err(|e| {
+            PlanningError::ClassificationError {
+                detail: format!("Failed to parse Claude API response: {}", e),
+            }
+        })?;
+
+        // Extract text from the first content block
+        let content_text = message
+            .content
+            .iter()
+            .find(|c| c.content_type == "text")
+            .and_then(|c| c.text.as_deref())
+            .ok_or_else(|| PlanningError::ClassificationError {
+                detail: "Claude response has no text content".to_string(),
+            })?;
+
+        let alternatives = self.parse_response(content_text)?;
+        let requires_clarification =
+            alternatives.first().map(|t| t.confidence < 0.7).unwrap_or(false);
+        let needs_generator = alternatives.first().map(|t| t.confidence < 0.3).unwrap_or(true);
+
+        let reasoning = alternatives
+            .first()
+            .map(|t| format!("Claude classified: top={} confidence={:.2}", t.template_id, t.confidence))
+            .unwrap_or_else(|| "No matching template found".to_string());
+
+        Ok(ClassificationResult {
+            alternatives,
+            requires_clarification,
+            needs_generator,
+            reasoning,
+            llm_calls_used: 1,
+            llm_tokens_used: 0, // Token counting would require parsing the response usage field
+        })
+    }
+}

--- a/engine/src/planning/domain/mod.rs
+++ b/engine/src/planning/domain/mod.rs
@@ -18,6 +18,7 @@
 //! - All domain types are serializable (Serialize + Deserialize)
 
 pub mod classification;
+pub mod claude_classifier;
 pub mod error;
 pub mod event;
 pub mod extractor;
@@ -25,13 +26,16 @@ pub mod generator;
 pub mod intent;
 pub mod mock_classifier;
 pub mod mock_extractor;
+pub mod openai_classifier;
 pub mod result;
 
 pub use classification::*;
+pub use claude_classifier::*;
 pub use error::*;
 pub use extractor::*;
 pub use generator::*;
 pub use intent::*;
 pub use mock_classifier::MockClassifier;
 pub use mock_extractor::MockParameterExtractor;
+pub use openai_classifier::*;
 pub use result::*;

--- a/engine/src/planning/domain/openai_classifier.rs
+++ b/engine/src/planning/domain/openai_classifier.rs
@@ -1,0 +1,323 @@
+//! OpenaiClassifier — OpenAI Chat Completions API implementation of the Classifier trait.
+//!
+//! @canonical .pi/architecture/modules/planning-pipeline.md#openai
+//! Implements: Classifier Trait — OpenaiClassifier via OpenAI Chat Completions API
+//! Issue: issue-classifier-trait
+//!
+//! Uses OpenAI's Chat Completions API to classify user intent against available
+//! templates. Supports configurable model selection, API endpoint (compatible with
+//! any OpenAI-compatible API), and authentication via API key.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+use crate::budget_tracking::domain::LlmBudget;
+use crate::planning::domain::classification::{
+    ClassificationResult, ClassifiedTemplate, Classifier,
+};
+use crate::planning::domain::error::PlanningError;
+use crate::planning::domain::intent::UserIntent;
+
+/// Configuration for the OpenAI classifier.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpenaiClassifierConfig {
+    /// The OpenAI API endpoint (default: https://api.openai.com/v1/chat/completions).
+    pub api_url: String,
+
+    /// Model to use (default: gpt-4o).
+    pub model: String,
+
+    /// Maximum tokens in the response.
+    pub max_tokens: u32,
+
+    /// Request timeout in seconds.
+    pub timeout_secs: u64,
+
+    /// Temperature for classification (lower = more deterministic).
+    pub temperature: f64,
+}
+
+impl Default for OpenaiClassifierConfig {
+    fn default() -> Self {
+        Self {
+            api_url: "https://api.openai.com/v1/chat/completions".to_string(),
+            model: "gpt-4o".to_string(),
+            max_tokens: 1024,
+            timeout_secs: 30,
+            temperature: 0.1,
+        }
+    }
+}
+
+/// Classifier using OpenAI's Chat Completions API.
+///
+/// Communicates with the OpenAI API (or any OpenAI-compatible endpoint)
+/// to classify user intent against available templates. Returns a ranked
+/// list of alternatives.
+///
+/// # API Key
+///
+/// The API key is provided at construction and sent as the
+/// `Authorization: Bearer` header.
+pub struct OpenaiClassifier {
+    /// API key for authentication.
+    api_key: String,
+
+    /// Configuration.
+    config: OpenaiClassifierConfig,
+
+    /// HTTP client.
+    client: reqwest::Client,
+}
+
+impl OpenaiClassifier {
+    /// Create a new OpenaiClassifier.
+    ///
+    /// # Arguments
+    ///
+    /// * `api_key` — OpenAI API key.
+    /// * `config` — Optional configuration overrides.
+    pub fn new(api_key: String, config: Option<OpenaiClassifierConfig>) -> Self {
+        let config = config.unwrap_or_default();
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(config.timeout_secs))
+            .build()
+            .expect("Failed to create HTTP client");
+
+        Self {
+            api_key,
+            config,
+            client,
+        }
+    }
+
+    /// Build the system prompt for classification.
+    fn build_system_prompt(&self, available_templates: &[String]) -> String {
+        let template_list = available_templates
+            .iter()
+            .enumerate()
+            .map(|(i, t)| format!("{}. {}", i + 1, t))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        format!(
+            r#"You are a template classifier. Match user intent to the most relevant template.
+
+Available templates:
+{}
+
+Respond with a JSON object:
+{{
+  "rankings": [
+    {{
+      "template_id": "string",
+      "confidence": 0.0-1.0,
+      "reasoning": "string"
+    }}
+  ]
+}}
+
+Rules:
+- Rank ALL templates by confidence (highest to lowest)
+- No match → all confidences 0.0
+- Output ONLY valid JSON"#,
+            template_list
+        )
+    }
+
+    /// Build the user message.
+    fn build_user_message(&self, intent: &UserIntent) -> String {
+        let mut msg = format!("User intent: {}", intent.input);
+        if intent.has_clarifications() {
+            msg.push_str("\n\nClarifications:");
+            for pair in &intent.clarifications {
+                msg.push_str(&format!("\nQ: {}\nA: {}", pair.question, pair.answer));
+            }
+        }
+        msg
+    }
+
+    /// Parse the API response.
+    pub(crate) fn parse_response(&self, response_body: &str) -> Result<Vec<ClassifiedTemplate>, PlanningError> {
+        let json_str = if let Some(start) = response_body.find('{') {
+            if let Some(end) = response_body.rfind('}') {
+                &response_body[start..=end]
+            } else {
+                response_body
+            }
+        } else {
+            response_body
+        };
+
+        #[derive(Deserialize)]
+        struct ApiRanking {
+            template_id: String,
+            confidence: f64,
+            reasoning: String,
+        }
+
+        #[derive(Deserialize)]
+        struct ApiResponse {
+            rankings: Vec<ApiRanking>,
+        }
+
+        let parsed: ApiResponse = serde_json::from_str(json_str).map_err(|e| {
+            PlanningError::ClassificationError {
+                detail: format!("Failed to parse OpenAI response: {} (raw: {})", e, 
+                    response_body.chars().take(200).collect::<String>()),
+            }
+        })?;
+
+        let templates: Vec<ClassifiedTemplate> = parsed
+            .rankings
+            .into_iter()
+            .map(|r| ClassifiedTemplate {
+                template_id: r.template_id,
+                confidence: r.confidence.clamp(0.0, 1.0),
+                reasoning: r.reasoning,
+                from_override: false,
+            })
+            .collect();
+
+        if templates.is_empty() {
+            return Err(PlanningError::ClassificationError {
+                detail: "OpenAI returned empty rankings".to_string(),
+            });
+        }
+
+        Ok(templates)
+    }
+}
+
+#[async_trait]
+impl Classifier for OpenaiClassifier {
+    async fn classify_with_alternatives(
+        &self,
+        intent: &UserIntent,
+        _budget: &LlmBudget,
+        available_templates: &[String],
+    ) -> Result<ClassificationResult, PlanningError> {
+        if available_templates.is_empty() {
+            return Ok(ClassificationResult {
+                alternatives: vec![],
+                requires_clarification: false,
+                needs_generator: true,
+                reasoning: "No templates available".to_string(),
+                llm_calls_used: 0,
+                llm_tokens_used: 0,
+            });
+        }
+
+        let system_prompt = self.build_system_prompt(available_templates);
+        let user_message = self.build_user_message(intent);
+
+        let body = serde_json::json!({
+            "model": self.config.model,
+            "max_tokens": self.config.max_tokens,
+            "temperature": self.config.temperature,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_message}
+            ]
+        });
+
+        let body_bytes = serde_json::to_vec(&body).map_err(|e| {
+            PlanningError::ClassificationError {
+                detail: format!("Failed to serialize request: {}", e),
+            }
+        })?;
+
+        let response = self
+            .client
+            .post(&self.config.api_url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("content-type", "application/json")
+            .body(body_bytes)
+            .send()
+            .await
+            .map_err(|e| PlanningError::ClassificationError {
+                detail: format!("OpenAI API request failed: {}", e),
+            })?;
+
+        let status = response.status();
+        let response_text = response.text().await.map_err(|e| {
+            PlanningError::ClassificationError {
+                detail: format!("Failed to read OpenAI response body: {}", e),
+            }
+        })?;
+
+        if !status.is_success() {
+            return Err(PlanningError::ClassificationError {
+                detail: format!(
+                    "OpenAI API returned {}: {}",
+                    status.as_u16(),
+                    response_text.chars().take(200).collect::<String>()
+                ),
+            });
+        }
+
+        // Parse OpenAI Chat Completions response
+        #[derive(Deserialize)]
+        struct OpenAiChoice {
+            message: OpenAiMessage,
+        }
+
+        #[derive(Deserialize)]
+        struct OpenAiMessage {
+            content: Option<String>,
+        }
+
+        #[derive(Deserialize)]
+        struct OpenAiResponse {
+            choices: Vec<OpenAiChoice>,
+            usage: Option<OpenAiUsage>,
+        }
+
+        #[derive(Deserialize)]
+        struct OpenAiUsage {
+            prompt_tokens: u32,
+            completion_tokens: u32,
+            total_tokens: u32,
+        }
+
+        let api_response: OpenAiResponse = serde_json::from_str(&response_text).map_err(|e| {
+            PlanningError::ClassificationError {
+                detail: format!("Failed to parse OpenAI response: {}", e),
+            }
+        })?;
+
+        let content = api_response
+            .choices
+            .first()
+            .and_then(|c| c.message.content.as_deref())
+            .ok_or_else(|| PlanningError::ClassificationError {
+                detail: "OpenAI response has no content".to_string(),
+            })?;
+
+        let alternatives = self.parse_response(content)?;
+        let requires_clarification =
+            alternatives.first().map(|t| t.confidence < 0.7).unwrap_or(false);
+        let needs_generator = alternatives.first().map(|t| t.confidence < 0.3).unwrap_or(true);
+
+        let reasoning = alternatives
+            .first()
+            .map(|t| format!("OpenAI classified: top={} confidence={:.2}", t.template_id, t.confidence))
+            .unwrap_or_else(|| "No matching template found".to_string());
+
+        let tokens_used = api_response
+            .usage
+            .as_ref()
+            .map(|u| u.total_tokens)
+            .unwrap_or(0);
+
+        Ok(ClassificationResult {
+            alternatives,
+            requires_clarification,
+            needs_generator,
+            reasoning,
+            llm_calls_used: 1,
+            llm_tokens_used: tokens_used,
+        })
+    }
+}

--- a/engine/src/planning/tests.rs
+++ b/engine/src/planning/tests.rs
@@ -886,3 +886,156 @@ impl TemplateGenerator for MockGenerator {
         GeneratedTemplateCost { estimated_calls: 1, estimated_tokens: 200 }
     }
 }
+
+// ---------------------------------------------------------------------------
+// ClaudeClassifier Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_claude_classifier_parse_response_valid_json() {
+    let api_key = "test-key".to_string();
+    let classifier = crate::planning::domain::claude_classifier::ClaudeClassifier::new(api_key, None);
+
+    let response = r#"{"rankings":[{"template_id":"read-file","confidence":0.95,"reasoning":"Best match for read intent"},{"template_id":"write-file","confidence":0.20,"reasoning":"Poor match"}]}"#;
+
+    let result = classifier.parse_response(response).unwrap();
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0].template_id, "read-file");
+    assert!((result[0].confidence - 0.95).abs() < 0.01);
+    assert_eq!(result[1].template_id, "write-file");
+    assert!((result[1].confidence - 0.20).abs() < 0.01);
+}
+
+#[test]
+fn test_claude_classifier_parse_response_clamps_confidence() {
+    let api_key = "test-key".to_string();
+    let classifier = crate::planning::domain::claude_classifier::ClaudeClassifier::new(api_key, None);
+
+    let response = r#"{"rankings":[{"template_id":"t1","confidence":1.5,"reasoning":"Too high"},{"template_id":"t2","confidence":-0.5,"reasoning":"Too low"}]}"#;
+
+    let result = classifier.parse_response(response).unwrap();
+    assert!((result[0].confidence - 1.0).abs() < 0.01, "Should clamp to 1.0");
+    assert!((result[1].confidence - 0.0).abs() < 0.01, "Should clamp to 0.0");
+}
+
+#[test]
+fn test_claude_classifier_parse_response_empty_rankings() {
+    let api_key = "test-key".to_string();
+    let classifier = crate::planning::domain::claude_classifier::ClaudeClassifier::new(api_key, None);
+
+    let response = r#"{"rankings":[]}"#;
+    let result = classifier.parse_response(response);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_claude_classifier_parse_response_invalid_json() {
+    let api_key = "test-key".to_string();
+    let classifier = crate::planning::domain::claude_classifier::ClaudeClassifier::new(api_key, None);
+
+    let result = classifier.parse_response("not json at all");
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_claude_classifier_parse_response_with_markdown_fence() {
+    let api_key = "test-key".to_string();
+    let classifier = crate::planning::domain::claude_classifier::ClaudeClassifier::new(api_key, None);
+
+    // Simulate Claude wrapping JSON in markdown code fences
+    let response = "Here's the classification:\n```json\n{\"rankings\":[{\"template_id\":\"read\",\"confidence\":0.9,\"reasoning\":\"Good\"}]}\n```";
+
+    let result = classifier.parse_response(response).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].template_id, "read");
+}
+
+#[test]
+fn test_claude_classifier_handles_empty_templates() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let api_key = "test-key".to_string();
+    let classifier = crate::planning::domain::claude_classifier::ClaudeClassifier::new(api_key, None);
+    let intent = UserIntent::new("test".to_string(), None);
+    let budget = crate::budget_tracking::domain::LlmBudget {
+        max_calls: 50, max_tokens: 50000, used_calls: 0, used_tokens: 0, label: "test".to_string(),
+    };
+
+    let result = rt.block_on(classifier.classify_with_alternatives(&intent, &budget, &[])).unwrap();
+    assert!(result.alternatives.is_empty());
+    assert!(result.needs_generator);
+}
+
+#[test]
+fn test_claude_config_defaults() {
+    let config = crate::planning::domain::claude_classifier::ClaudeClassifierConfig::default();
+    assert_eq!(config.model, "claude-sonnet-4-20250514");
+    assert_eq!(config.max_tokens, 1024);
+    assert!(config.temperature < 0.5);
+}
+
+// ---------------------------------------------------------------------------
+// OpenaiClassifier Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_openai_classifier_parse_response_valid_json() {
+    let api_key = "test-key".to_string();
+    let classifier = crate::planning::domain::openai_classifier::OpenaiClassifier::new(api_key, None);
+
+    let response = r#"{"rankings":[{"template_id":"t1","confidence":0.85,"reasoning":"Good match"}]}"#;
+
+    let result = classifier.parse_response(response).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].template_id, "t1");
+    assert!((result[0].confidence - 0.85).abs() < 0.01);
+}
+
+#[test]
+fn test_openai_classifier_parse_response_invalid_json() {
+    let api_key = "test-key".to_string();
+    let classifier = crate::planning::domain::openai_classifier::OpenaiClassifier::new(api_key, None);
+
+    let result = classifier.parse_response("invalid");
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_openai_classifier_parse_response_empty() {
+    let api_key = "test-key".to_string();
+    let classifier = crate::planning::domain::openai_classifier::OpenaiClassifier::new(api_key, None);
+
+    let result = classifier.parse_response(r#"{"rankings":[]}"#);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_openai_classifier_parse_response_with_markdown() {
+    let api_key = "test-key".to_string();
+    let classifier = crate::planning::domain::openai_classifier::OpenaiClassifier::new(api_key, None);
+
+    let response = "```\n{\"rankings\":[{\"template_id\":\"t1\",\"confidence\":0.75,\"reasoning\":\"OK\"}]}\n```";
+    let result = classifier.parse_response(response).unwrap();
+    assert_eq!(result[0].template_id, "t1");
+}
+
+#[test]
+fn test_openai_classifier_handles_empty_templates() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let api_key = "test-key".to_string();
+    let classifier = crate::planning::domain::openai_classifier::OpenaiClassifier::new(api_key, None);
+    let intent = UserIntent::new("test".to_string(), None);
+    let budget = crate::budget_tracking::domain::LlmBudget {
+        max_calls: 50, max_tokens: 50000, used_calls: 0, used_tokens: 0, label: "test".to_string(),
+    };
+
+    let result = rt.block_on(classifier.classify_with_alternatives(&intent, &budget, &[])).unwrap();
+    assert!(result.alternatives.is_empty());
+    assert!(result.needs_generator);
+}
+
+#[test]
+fn test_openai_config_defaults() {
+    let config = crate::planning::domain::openai_classifier::OpenaiClassifierConfig::default();
+    assert_eq!(config.model, "gpt-4o");
+    assert_eq!(config.max_tokens, 1024);
+}


### PR DESCRIPTION
Closes #153

## Summary

Implement real LLM-based intent classifiers (ClaudeClassifier and OpenaiClassifier) for the planning pipeline.

### ClaudeClassifier
- Uses Anthropic Messages API (claude-sonnet-4-20250514) via reqwest
- Structured system prompt listing all available templates
- JSON response parsing with markdown fence support
- Configurable model, endpoint, max_tokens, timeout, temperature

### OpenaiClassifier
- Uses OpenAI Chat Completions API (gpt-4o) via reqwest
- Bearer token authentication
- Token usage tracking from API response usage field
- Same JSON response format and parsing

### Testing
- 57 total tests passing (all planning tests)
- New tests: response parsing, confidence clamping, markdown extraction, empty templates, config defaults

### Files Changed
| File | Type | Purpose |
|------|------|---------|
| src/planning/domain/claude_classifier.rs | new | Anthropic Claude API classifier |
| src/planning/domain/openai_classifier.rs | new | OpenAI API classifier |
| src/planning/domain/mod.rs | modified | Added classifier modules |
| src/planning/tests.rs | modified | 13 new classifier tests