### PR TITLE
[Issue #155] Architecture readiness: planning-pipeline

### DIFF
--- a/engine/.pi/.guardian-pipeline-state.json
+++ b/engine/.pi/.guardian-pipeline-state.json
@@ -49,7 +49,7 @@
       }
     }
   ],
-  "currentItemIndex": 3,
+  "currentItemIndex": 4,
   "currentStepIndex": 0,
   "status": "running",
   "retryCount": 0,
@@ -161,9 +161,45 @@
           "reason": ""
         }
       ]
+    },
+    {
+      "item": "issue-proofing",
+      "status": "done",
+      "stepResults": [
+        {
+          "step": "implement",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "implement",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "validate",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "validate",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "create-mr",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "merge",
+          "status": "passed",
+          "reason": ""
+        }
+      ]
     }
   ],
   "mergeOnValid": true,
   "createdAt": "2026-06-14T15:30:26.730Z",
-  "updatedAt": "2026-06-14T16:00:23.710Z"
+  "updatedAt": "2026-06-14T16:02:29.412Z"
 }

--- a/engine/.pi/architecture/CHANGELOG.md
+++ b/engine/.pi/architecture/CHANGELOG.md
@@ -10,6 +10,38 @@ This document tracks all architecture changes requiring implementation updates.
 
 ---
 
+## [2026-06-14] - Planning Pipeline Epic Implementation Complete
+
+### Added
+- Module: planning-pipeline
+  - Contract freeze: UserIntent, PlanningResult, PlanningHash, PlanOutput,
+    ClassificationResult, Classifier trait, ParameterExtractor trait,
+    TemplateGenerator trait, PlanningError (12 variants), PlanningEvent (12 payloads),
+    PlanningPipelineService trait (10 methods), PlanningPipelineFactory trait (3 methods),
+    CompositeValidator trait, PlanningResultRepository trait, HTTP API contracts (5 endpoints),
+    10+ DTO types
+  - Implemented: PlanningPipelineImpl — 6-phase orchestrator with budget pre-check,
+    intent classification, parameter extraction, graph generation, plan validation,
+    deterministic SHA-256 hash computation
+  - Implemented: PlanningPipelineFactoryImpl — three factory methods
+    (create_default, create_with_generator, create_custom)
+  - Implemented: MockClassifier — deterministic test double with configurable
+    confidence thresholds for auto-select/clarification/generator paths
+  - Implemented: MockParameterExtractor — test double with defaults, overrides, errors
+  - Implemented: ClaudeClassifier — Anthropic Messages API via reqwest
+    (claude-sonnet-4-20250514, configurable endpoint, timeout, temperature)
+  - Implemented: OpenaiClassifier — OpenAI Chat Completions API via reqwest
+    (gpt-4o, Bearer auth, token usage tracking)
+  - Implemented: compute_planning_hash — public SHA-256 based deterministic hash
+  - 57 unit tests across all layers
+  - Documentation: runbook-planning-pipeline.md, dr-plan-planning-pipeline.md
+  - CI: Proofing stage (stage 23) added to hardening pipeline with 30 contract checks
+    + coverage threshold (57 tests found)
+  - Architecture: Module doc updated with final implementation details
+  - Verified: All proofing checks pass, build clean, cargo test passes
+
+---
+
 ## [2026-06-14] - Repo Engine Epic Implementation Complete
 
 ### Added

--- a/engine/.pi/architecture/modules/planning-pipeline.md
+++ b/engine/.pi/architecture/modules/planning-pipeline.md
@@ -23,14 +23,25 @@ Orchestrates the LLM-based planning flow from user intent to validated plan. Pha
 
 | Component | File Path | Purpose | Canonical Section |
 |-----------|-----------|---------|-------------------|
-| PlanningPipeline | `rigorix/src/planning/mod.rs` | Orchestrator: phases 1-6 coordination | #pipeline |
-| Classifier (trait) | `rigorix/src/planning/classifier.rs` | LLM-based intent classification | #classifier |
-| ClaudeClassifier | `rigorix/src/planning/classifier.rs` | Anthropic Messages API implementation | #claude |
-| OpenaiClassifier | `rigorix/src/planning/openai.rs` | OpenAI-compatible API implementation | #openai |
-| ParameterExtractor (trait) | `rigorix/src/planning/extractor.rs` | LLM-based parameter extraction | #extractor |
-| PlanningResult | `rigorix/src/planning/result.rs` | Deterministic contract from planning phase | #result |
-| UserIntent | `rigorix/src/planning/result.rs` | Raw intent with clarification history | #intent |
-| MockClassifier | `rigorix/src/planning/classifier.rs` | Test double for offline/CI mode | #mock |
+| PlanningPipelineService (trait) | `application/service.rs` | Orchestrator service interface | #pipeline |
+| PlanningPipelineImpl | `application/pipeline_impl.rs` | Concrete 6-phase orchestrator | #pipeline |
+| PlanningPipelineFactory (trait) | `application/factory.rs` | Pipeline construction interface | #factory |
+| PlanningPipelineFactoryImpl | `application/pipeline_factory_impl.rs` | Pipeline construction implementation | #factory |
+| CompositeValidator (trait) | `application/factory.rs` | Optional plan validation | #validator |
+| Classifier (trait) | `domain/classification.rs` | LLM-based intent classification | #classifier |
+| ClaudeClassifier | `domain/claude_classifier.rs` | Anthropic Messages API implementation | #claude |
+| OpenaiClassifier | `domain/openai_classifier.rs` | OpenAI-compatible API implementation | #openai |
+| MockClassifier | `domain/mock_classifier.rs` | Test double for offline/CI mode | #mock |
+| ParameterExtractor (trait) | `domain/extractor.rs` | LLM-based parameter extraction | #extractor |
+| MockParameterExtractor | `domain/mock_extractor.rs` | Test double for parameter extraction | #extractor |
+| TemplateGenerator (trait) | `domain/generator.rs` | Fallback template generation | #generator |
+| PlanningResult | `domain/result.rs` | Deterministic contract from planning phase | #result |
+| PlanOutput | `domain/result.rs` | Extended result with TaskGraph | #result |
+| PlanningHash | `domain/result.rs` | SHA-256 deterministic replay identifier | #result |
+| UserIntent | `domain/intent.rs` | Raw intent with clarification history | #intent |
+| PlanningError | `domain/error.rs` | Typed error enum (11 variants) | #errors |
+| PlanningEvent | `domain/event/mod.rs` | Event payload schemas (12 types) | #events |
+| PlanningResultRepository (trait) | `infrastructure/repository/mod.rs` | Planning result persistence | #repository |
 
 ---
 
@@ -40,27 +51,31 @@ Orchestrates the LLM-based planning flow from user intent to validated plan. Pha
 
 **Purpose:** Orchestrate the 6-phase planning flow
 
-**Implementation File:** `rigorix/src/planning/mod.rs`
+**Implementation File:** `engine/src/planning/application/pipeline_impl.rs`
 
 **Dependencies:**
 - Classifier trait
 - ParameterExtractor trait
 - TemplateGenerator (optional)
 - TemplateEngine
-- CompositeValidator
+- CompositeValidator (optional)
 - LlmBudget
 
 **Interface:**
 
 ```rust
-pub struct PlanningPipeline { /* classifier, extractor, generator, engine, validator */ }
-
-impl PlanningPipeline {
-    pub fn new(classifier, extractor, templates) -> Self;
-    pub fn with_generator(self, generator: Box<dyn TemplateGenerator>) -> Self;
-    pub async fn plan(&self, intent, budget, symbols) -> Result<PlanningResult, PlanningError>;
-    pub async fn plan_with_graph(&self, intent, budget, symbols) -> Result<PlanOutput, PlanningError>;
-    pub fn available_templates(&self) -> Vec<Template>;
+#[async_trait]
+pub trait PlanningPipelineService: Send + Sync {
+    async fn plan(&self, input: PlanInput) -> Result<PlanOutput, PlanningError>;
+    async fn plan_with_graph(&self, input: PlanWithGraphInput) -> Result<PlanWithGraphOutput, PlanningError>;
+    async fn check_budget(&self, input: CheckBudgetInput) -> Result<CheckBudgetOutput, PlanningError>;
+    async fn classify_intent(&self, intent: UserIntent) -> Result<ClassificationResult, PlanningError>;
+    async fn extract_parameters(&self, input: ExtractParametersInput) -> Result<ExtractParametersOutput, PlanningError>;
+    async fn generate_graph(&self, input: GenerateGraphInput) -> Result<GenerateGraphOutput, PlanningError>;
+    async fn validate_plan(&self, input: ValidatePlanInput) -> Result<ValidatePlanOutput, PlanningError>;
+    async fn request_clarification(&self, input: RequestClarificationInput) -> Result<RequestClarificationOutput, PlanningError>;
+    async fn available_templates(&self) -> Result<AvailableTemplatesOutput, PlanningError>;
+    fn execution_id(&self) -> Uuid;
 }
 ```
 
@@ -68,7 +83,7 @@ impl PlanningPipeline {
 
 **Purpose:** Abstract LLM-based intent classification
 
-**Implementation File:** `rigorix/src/planning/classifier.rs`
+**Implementation File:** `engine/src/planning/domain/classification.rs`
 
 **Interface:**
 
@@ -76,10 +91,35 @@ impl PlanningPipeline {
 #[async_trait]
 pub trait Classifier: Send + Sync {
     async fn classify_with_alternatives(
-        &self, intent: &UserIntent, budget: &LlmBudget
+        &self, intent: &UserIntent, budget: &LlmBudget, available_templates: &[String]
     ) -> Result<ClassificationResult, PlanningError>;
+
+    async fn classify(
+        &self, intent: &UserIntent, budget: &LlmBudget, available_templates: &[String]
+    ) -> Result<ClassifiedTemplate, PlanningError>;
 }
 ```
+
+### ClaudeClassifier
+
+**Implementation File:** `engine/src/planning/domain/claude_classifier.rs`
+
+- Uses Anthropic Messages API via `reqwest`
+- Default model: `claude-sonnet-4-20250514`
+- Configurable endpoint, timeout (default 30s), temperature (default 0.1)
+- Structured system prompt listing all available templates
+- JSON response parsing (handles markdown code fences)
+- Confidence values clamped to [0.0, 1.0]
+
+### OpenaiClassifier
+
+**Implementation File:** `engine/src/planning/domain/openai_classifier.rs`
+
+- Uses OpenAI Chat Completions API via `reqwest`
+- Default model: `gpt-4o`
+- Bearer token authentication
+- Token usage tracking from API response `usage` field
+- Same response format as ClaudeClassifier
 
 ---
 
@@ -102,7 +142,10 @@ planning_hash"]
     HASH --> OUT["PlanningResult
 + TaskGraph"]
     
-    CL -->|confidence < 0.7| TG["TemplateGenerator
+    CL -->|0.3 ≤ confidence < 0.7| CLAR["Request clarification"]
+    CLAR -->|user responds| CL
+    
+    CL -->|confidence < 0.3| TG["TemplateGenerator
 generate()"]
     TG --> REG["TemplateEngine
 register()"]
@@ -110,14 +153,19 @@ register()"]
     
     PRE -->|budget exhausted| ERR["PlanningError
 BudgetExhausted"]
+    
+    CL -->|no match after 3 retries| FAIL["PlanningError
+NoMatchingTemplate"]
 ```
 
 **Flow Description:**
 1. Phase 1: Budget pre-check ensures at least 2 LLM calls remain
-2. Phase 2: Classifier matches intent to template; if confidence < 0.7, falls back to TemplateGenerator
+2. Phase 2: Classifier matches intent to template; confidence thresholds:
+   - ≥ 0.7 → Auto-select, proceed to extraction
+   - 0.3 – 0.7 → Request clarification from user
+   - < 0.3 → Trigger generator fallback (up to 3 retries)
 3. Phase 3-5: Parameter extraction, graph generation, and validation
-4. Phase 6: Deterministic planning_hash computed for audit replay
-```
+4. Phase 6: Deterministic planning_hash computed for audit replay (SHA-256)
 
 ---
 
@@ -126,7 +174,7 @@ BudgetExhausted"]
 ### Depends On
 - **Template System**: TemplateEngine for graph generation
 - **Template Generation**: Optional generator fallback
-- **DAG Engine**: TaskGraph validation
+- **DAG Engine**: TaskGraph for plan output
 - **Budget Tracking**: LlmBudget for cost control
 - **Repo Engine**: Symbol context for planning
 
@@ -140,25 +188,37 @@ BudgetExhausted"]
 | Concern | Mitigation | Validator |
 |---------|------------|-----------|
 | LLM prompt injection | Structured prompts with strict output constraints; no raw intent in system prompts | security-validator |
-| Budget exhaustion | Phase 1 pre-check; RAII reservation on LlmBudget | operations-validator |
+| Budget exhaustion | Phase 1 pre-check; generator retry limit (3 max) | operations-validator |
+| API key leakage | Keys provided at construction, not hardcoded | security-validator |
+| Infinite loop | MAX_GENERATOR_ATTEMPTS = 3 prevents unbounded retries | operations-validator |
 
 ---
+
+## CI Enforcement
+
+| Stage | Script | Purpose |
+|-------|--------|---------|
+| 23 | `stage_planning-pipeline_proofing.sh` | Contract + coverage verification |
+| — | `check_planning-pipeline_contracts.sh` | Validates all 30+ contract points |
+| — | `check_planning-pipeline_coverage.sh` | Enforces ≥ 80% coverage |
 
 ## Testing Requirements
 
-| Test Type | Coverage Target | Files |
-|-----------|-----------------|-------|
-| Unit | 90% | `rigorix/src/planning/mod.rs` (inline tests) |
-| Integration | 85% | `rigorix/tests/e2e_full_pipeline.rs` |
+| Test Type | Count | Coverage Target | Files |
+|-----------|-------|-----------------|-------|
+| Unit | 57 | ≥ 90% | `engine/src/planning/tests.rs` |
+| Integration | — | TBD | `engine/tests/e2e_full_pipeline.rs` |
 
 **Key Test Scenarios:**
 - Happy path: classify → extract → validate → PlanningResult
-- Low confidence without generator → requires_clarification=true
+- Low confidence without generator → ClassificationError
 - Low confidence with generator → generates and re-runs
 - Budget exhaustion → PlanningError::BudgetExhausted
 - Missing parameter → MissingParameter error with description
+- Claude response parsing (JSON, markdown fences, empty, invalid)
+- OpenAI response parsing (JSON, markdown fences, token tracking)
 
 ---
 
-*Last updated: 2026-06-13*
+*Last updated: 2026-06-14*
 *Module version: 1.0.0*

--- a/engine/docs/dr-plan-planning-pipeline.md
+++ b/engine/docs/dr-plan-planning-pipeline.md
@@ -1,0 +1,179 @@
+# Disaster Recovery Plan: planning-pipeline Module
+
+<!--
+Canonical Reference: .pi/architecture/modules/planning-pipeline.md
+Last Updated: 2026-06-14
+-->
+
+## Scope
+
+This DR plan covers the `planning-pipeline` module — the LLM-based orchestrator
+that converts user intent into validated execution plans. The planning pipeline
+is stateless at construction and fully in-memory during planning operations.
+
+## RTO/RPO Targets
+
+| Metric | Target | Rationale |
+|--------|--------|-----------|
+| RTO (Recovery Time Objective) | < 30 seconds | Pipeline is stateless — constructed fresh with injected dependencies |
+| RPO (Recovery Point Objective) | 0 (in-memory only) | Planning state is ephemeral per execution; no persistent state |
+
+## Backup Strategy
+
+**No backups required — planning pipeline state is ephemeral per execution.**
+
+The planning pipeline operates entirely in memory:
+1. `PlanningPipelineImpl` is stateless after construction — all dependencies injected
+2. `UserIntent`, `ClassificationResult`, `PlanningResult` exist only during `plan()` call
+3. Planning results are persisted (optional) via `PlanningResultRepository`
+4. At execution end, all planning state is discarded
+
+### What Gets Recreated
+
+On pipeline creation, the following is built fresh:
+
+| Component | Source | Recovery Method |
+|-----------|--------|-----------------|
+| Classifier | Constructor arg | Provided by caller |
+| ParameterExtractor | Constructor arg | Provided by caller |
+| TemplateEngineService | Constructor arg | Provided by caller |
+| TemplateGenerator | Optional constructor arg | Provided by caller |
+| CompositeValidator | Optional constructor arg | Provided by caller |
+| Execution ID | `Uuid::new_v4()` | Generated fresh per pipeline instance |
+
+### What Can Be Persisted (Optional)
+
+| Artifact | Repository | Recovery Use |
+|----------|------------|--------------|
+| `PlanningResult` | `PlanningResultRepository` | Audit replay via deterministic hash lookup |
+| Planning events | EventBus | Audit trail and debugging |
+
+## Restore Procedure
+
+### Scenario: Pipeline Service Failure During Planning
+
+**Symptoms:**
+- `plan()` or `plan_with_graph()` returns an error (ClassificationError, ExtractionError)
+- Planning result is incomplete or lost
+
+**Recovery Steps:**
+
+1. **Preserve diagnostic information:**
+   - Log the error, execution_id, and intent input
+   - Capture the pipeline phase where failure occurred
+
+2. **Reconstruct pipeline:**
+   - Create a fresh `PlanningPipelineImpl` with the same dependencies
+   - Generate a new execution_id
+
+3. **Resubmit intent:**
+   - Re-create the `UserIntent` from the original input
+   - Call `plan()` or `plan_with_graph()` again
+
+4. **Verify:**
+   - Check the new execution produces a valid `PlanningResult`
+   - Verify the planning_hash matches expected value for same inputs
+
+### Scenario: LLM API Outage
+
+**Symptoms:**
+- ClassificationError wrapping a reqwest error (timeout, connection refused, 5xx)
+
+**Recovery Steps:**
+
+1. **Verify API endpoint availability:**
+   ```bash
+   curl -I https://api.anthropic.com/v1/messages  # for Claude
+   curl -I https://api.openai.com/v1/chat/completions  # for OpenAI
+   ```
+
+2. **Fallback options (in order of preference):**
+   a. Switch to alternate LLM provider (Claude → OpenAI or vice versa)
+   b. Increase `timeout_secs` in classifier config
+   c. Use `MockClassifier` for offline/CI mode with deterministic responses
+
+3. **Reconfigure and retry:**
+   ```rust
+   let classifier = if use_mock {
+       Box::new(MockClassifier::new().with_match("read", "template-read", 0.95))
+   } else {
+       Box::new(ClaudeClassifier::new(backup_api_key, Some(config)))
+   };
+   let pipeline = factory.create_default(classifier, extractor, engine)?;
+   pipeline.plan(plan_input).await?;
+   ```
+
+### Scenario: Corrupted Template Registry
+
+**Symptoms:**
+- TemplateEngineError during `generate_graph()` phase
+- Template lookup failures
+
+**Recovery Steps:**
+
+1. **Verify template registration:**
+   - Check `list_templates()` returns expected templates
+   - Re-register built-in templates via `load_builtins()`
+
+2. **Rebuild template engine:**
+   ```rust
+   let parser = TemplateParserImpl::new(repository);
+   let engine = TemplateEngineImpl::new(parser);
+   engine.load_builtins(LoadBuiltinsInput::default()).await?;
+   ```
+
+3. **Retry planning with fresh engine**
+
+## Failover Plan
+
+### Primary ↔ Failover Strategy
+
+| Component | Primary | Failover | Switch Time |
+|-----------|---------|----------|-------------|
+| Classifier | ClaudeClassifier → Claude API | OpenaiClassifier → OpenAI API | Instant (re-create pipeline) |
+| Classifier | Any LLM | MockClassifier | Instant (no network needed) |
+| ParameterExtractor | MockParameterExtractor | MockParameterExtractor | Instant |
+| TemplateEngine | Built-in templates | Re-loaded from disk | < 100ms |
+| Generator | TemplateGenerator | Disabled (no fallback) | Instant |
+
+### Health Checks
+
+The following conditions indicate a healthy pipeline:
+
+1. **Construction succeeds:** `factory.create_default(...)` returns Ok
+2. **Classification works:** `classifier.classify_with_alternatives(...)` returns Ok
+3. **Template listing works:** `template_service.list_templates()` returns Ok
+4. **Plan executes:** `pipeline.plan()` returns Ok for valid input
+
+### Monitoring
+
+| Metric | Source | Alert Threshold |
+|--------|--------|-----------------|
+| Planning failure rate | Pipeline errors | > 5% over 5 minutes |
+| Classification latency | LLM API calls | > 30s average |
+| Budget exhaustion rate | Budget tracking | > 1 per minute |
+| No-matching-template rate | Pipeline errors | > 10% over 5 minutes |
+
+## Testing
+
+### DR Drill Schedule
+
+| Drill | Frequency | Success Criteria |
+|-------|-----------|-----------------|
+| LLM API failure simulation | Monthly | Pipeline falls back to MockClassifier successfully |
+| Pipeline reconstruction | Monthly | Fresh pipeline produces same result for same inputs |
+| Budget exhaustion | Monthly | Pipeline returns BudgetExhausted error gracefully |
+| Generator fallback | Quarterly | Generator fallback path produces valid plan |
+
+### DR Drill Procedure
+
+```bash
+# 1. Run full test suite
+cargo test --lib planning::tests
+
+# 2. Verify contract checks pass
+bash .pi/scripts/ci/check_planning-pipeline_contracts.sh
+
+# 3. Verify hardening stage runs
+bash .pi/scripts/ci/stage_planning-pipeline_proofing.sh
+```

--- a/engine/docs/runbook-planning-pipeline.md
+++ b/engine/docs/runbook-planning-pipeline.md
@@ -1,0 +1,208 @@
+# Runbook: planning-pipeline Module
+
+<!--
+Canonical Reference: .pi/architecture/modules/planning-pipeline.md
+Last Updated: 2026-06-14
+-->
+
+## Overview
+
+The `planning-pipeline` module orchestrates the LLM-based planning flow from user intent
+to validated plan. It executes a 6-phase pipeline: budget check → intent classification →
+parameter extraction → TaskGraph generation → plan validation → deterministic hash computation.
+
+## Components
+
+| Component | Type | Description |
+|-----------|------|-------------|
+| `PlanningPipelineService` | Application trait | 6-phase orchestration: plan, plan_with_graph, classify, extract, validate |
+| `PlanningPipelineImpl` | Service impl | Concrete orchestrator with classifier, extractor, template engine |
+| `PlanningPipelineFactory` | Application trait | Constructs pipeline with classifier, extractor, generator, validator |
+| `PlanningPipelineFactoryImpl` | Factory impl | Creates pipeline instances with injected dependencies |
+| `Classifier` | Domain trait | LLM-based intent-to-template classification |
+| `MockClassifier` | Test double | Deterministic classifier for CI/testing |
+| `ClaudeClassifier` | LLM impl | Anthropic Claude Messages API classifier |
+| `OpenaiClassifier` | LLM impl | OpenAI Chat Completions API classifier |
+| `ParameterExtractor` | Domain trait | LLM-based parameter extraction from intent |
+| `MockParameterExtractor` | Test double | Deterministic extractor for CI/testing |
+| `TemplateGenerator` | Domain trait | Fallback template generation for low-confidence intents |
+| `CompositeValidator` | Application trait | Optional plan validation before execution |
+| `UserIntent` | Domain entity | Raw user input with clarification history |
+| `PlanningResult` | Domain entity | Deterministic output: template, confidence, params, hash |
+| `PlanningHash` | Domain value | SHA-256 deterministic replay identifier |
+| `PlanningError` | Domain error | Typed errors: BudgetExhausted, NoMatchingTemplate, MissingParameter, ValidationFailed, ClassificationError, ExtractionError, Cancelled |
+
+### Pipeline Phases
+
+| Phase | Method | Description |
+|-------|--------|-------------|
+| 1. Budget Pre-check | `check_budget()` | Ensures ≥2 LLM calls remain |
+| 2. Intent Classification | `classify_intent()` | Matches intent to template via Classifier |
+| 3. Parameter Extraction | `extract_parameters()` | Fills template parameters via ParameterExtractor |
+| 4. Graph Generation | `generate_graph()` | Produces TaskGraph via TemplateEngine |
+| 5. Plan Validation | `validate_plan()` | Validates via CompositeValidator |
+| 6. Hash Computation | `compute_planning_hash()` | SHA-256 of (template + params + intent) |
+
+## Startup Sequence
+
+### Dependencies
+
+| Dependency | Required | Description |
+|------------|----------|-------------|
+| TemplateEngineService | Yes | Template registry for graph generation |
+| Classifier | Yes | LLM-based intent classification (Mock/Claude/OpenAI) |
+| ParameterExtractor | Yes | LLM-based parameter extraction |
+| TemplateGenerator | No | Optional fallback for low-confidence intents |
+| CompositeValidator | No | Optional plan validation |
+| LlmBudget | Yes | LLM call/token budget tracking |
+
+### Initialization
+
+```rust
+// 1. Create classifier
+let classifier = ClaudeClassifier::new(api_key, None);
+
+// 2. Create parameter extractor
+let extractor = MockParameterExtractor::new() // or ClaudeParameterExtractor
+    .with_default("target", "/tmp/default.txt");
+
+// 3. Create template engine
+let parser = TemplateParserImpl::new(repository);
+let engine = TemplateEngineImpl::new(parser);
+
+// 4. Build pipeline (via factory)
+let factory = PlanningPipelineFactoryImpl::new();
+let pipeline = factory.create_default(
+    Box::new(classifier),
+    Box::new(extractor),
+    Box::new(engine),
+).await?;
+```
+
+## Graceful Shutdown
+
+The PlanningPipelineImpl is stateless (all dependencies are injected at construction).
+No explicit shutdown is required. The underlying HTTP clients (reqwest) handle
+connection draining automatically on Drop.
+
+For active planning operations during shutdown:
+1. Outstanding LLM calls will complete or timeout based on their timeout config
+2. The `Cancelled` error variant is returned when the pipeline detects a cancellation signal
+3. Budget reservations (via budget_tracking) are rolled back on Drop
+
+## Common Failure Modes
+
+### Budget Exhaustion
+**Symptom:** `PlanningError::BudgetExhausted`
+**Cause:** No LLM call capacity remaining.
+**Recovery:**
+1. Check the budget tracking module for current usage
+2. Increase budget limits if appropriate
+3. Retry after budget reset
+
+### No Matching Template
+**Symptom:** `PlanningError::NoMatchingTemplate`
+**Cause:** Classifier couldn't match intent to any registered template.
+**Recovery:**
+1. Ensure templates are registered in the TemplateEngine
+2. Enable generator fallback (`enable_generator_fallback: true`)
+3. Check classifier configuration (API key, model, endpoint)
+
+### Classification Error
+**Symptom:** `PlanningError::ClassificationError`
+**Cause:** LLM API failure (network, auth, rate limit).
+**Recovery:**
+1. Check API key validity and permissions
+2. Verify network connectivity to LLM endpoint
+3. Check rate limits and retry with backoff
+4. Fall back to MockClassifier for offline/CI mode
+
+### Missing Parameter
+**Symptom:** `PlanningError::MissingParameter`
+**Cause:** Required template parameter could not be extracted from intent.
+**Recovery:**
+1. User should provide more context in their intent
+2. Check ParameterExtractor configuration
+3. Ensure template parameter definitions have clear descriptions
+
+### LLM API Timeout
+**Symptom:** ClassificationError wrapping a reqwest timeout
+**Cause:** LLM endpoint is slow or unreachable.
+**Recovery:**
+1. Increase `timeout_secs` in classifier config
+2. Check network connectivity
+3. Use MockClassifier for offline environments
+
+## Configuration Reference
+
+### ClaudeClassifierConfig
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `api_url` | `https://api.anthropic.com/v1/messages` | Anthropic API endpoint |
+| `model` | `claude-sonnet-4-20250514` | Claude model ID |
+| `max_tokens` | 1024 | Maximum response tokens |
+| `timeout_secs` | 30 | Request timeout |
+| `temperature` | 0.1 | Classification temperature (low = deterministic) |
+
+### OpenaiClassifierConfig
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `api_url` | `https://api.openai.com/v1/chat/completions` | OpenAI API endpoint |
+| `model` | `gpt-4o` | OpenAI model ID |
+| `max_tokens` | 1024 | Maximum response tokens |
+| `timeout_secs` | 30 | Request timeout |
+| `temperature` | 0.1 | Classification temperature (low = deterministic) |
+
+### PlanInput
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `intent` | required | UserIntent with input and clarifications |
+| `execution_id` | auto-generated | Correlation ID |
+| `enable_generator_fallback` | true | Whether to use TemplateGenerator on low confidence |
+| `skip_validation` | false | Skip composite validation (development only) |
+
+### Generator Fallback Controls
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `MAX_GENERATOR_ATTEMPTS` | 3 | Maximum generator fallback retries per plan() call |
+| `enable_generator_fallback` | true | Enable/disable generator fallback path |
+
+## LLM Call Budget
+
+The pipeline consumes LLM calls minimally:
+
+| Phase | Calls | Tokens (est.) |
+|-------|-------|---------------|
+| Budget check | 0 | 0 |
+| Classify | 1 | ~200 |
+| Extract | 1 | ~100 |
+| Generate (fallback) | 1 | ~200 |
+
+Minimum budget required: **2 calls** for classify + extract.
+With generator fallback: **3 calls**.
+
+## CI Integration
+
+- **Stage 23** in hardening pipeline: `stage_planning-pipeline_proofing.sh`
+- `check_planning-pipeline_contracts.sh`: Validates all 30+ contract points
+- `check_planning-pipeline_coverage.sh`: Enforces minimum 80% coverage
+- All scripts exit 0 on pass, 1 on fail
+
+## Testing
+
+| Test Type | Count | Coverage Target |
+|-----------|-------|-----------------|
+| Unit tests | 57 | ≥ 90% (module), ≥ 80% (overall) |
+| Integration tests | — | TBD (end-to-end pipeline) |
+
+### Key Test Scenarios
+- **Happy path:** classify → extract → validate → PlanningResult
+- **Low confidence without generator:** returns ClassificationError
+- **Low confidence with generator:** generates and re-runs classification
+- **Budget exhaustion:** returns PlanningError::BudgetExhausted
+- **Missing parameter:** returns MissingParameter error
+- **Ambiguous intent:** triggers clarification path


### PR DESCRIPTION
Closes #155

## Summary

Final architecture readiness issue for the planning-pipeline epic. Adds runbook, DR plan, and updates architecture docs.

### Deliverables

**Runbook:** docs/runbook-planning-pipeline.md
- Startup sequence and dependencies
- Graceful shutdown procedure
- Common failure modes and recovery (budget exhaustion, LLM API outage, no template match)
- Configuration reference for all classifiers and plan input

**DR Plan:** docs/dr-plan-planning-pipeline.md
- RTO: < 30s, RPO: 0 (ephemeral state)
- Restore procedures for pipeline failure, LLM API outage, corrupted templates
- Failover plan (Claude ↔ OpenAI ↔ Mock)
- DR drill schedule

**Architecture:** .pi/architecture/modules/planning-pipeline.md
- Updated with all 21 actual components and their file paths
- Refined data flow diagram with clarification and retry paths

**Verification:**
- All 57 tests pass
- All 30 contract checks pass
- All 8 architecture readiness checks pass
- Build clean