### PR TITLE
fix: complete is_retriable() coverage for all domain errors (H-06)

### DIFF
--- a/engine/src/risk_gating/domain/error.rs
+++ b/engine/src/risk_gating/domain/error.rs
@@ -55,3 +55,10 @@ pub enum RiskGatingError {
         detail: String,
     },
 }
+
+impl RiskGatingError {
+    /// Returns `true` if this error is transient and the operation may succeed on retry.
+    pub fn is_retriable(&self) -> bool {
+        matches!(self, RiskGatingError::ClassificationError { .. })
+    }
+}

--- a/engine/src/template_generation/domain/generator.rs
+++ b/engine/src/template_generation/domain/generator.rs
@@ -222,6 +222,13 @@ impl fmt::Display for GeneratorError {
     }
 }
 
+impl GeneratorError {
+    /// Returns `true` if this error is transient and the operation may succeed on retry.
+    pub fn is_retriable(&self) -> bool {
+        matches!(self, GeneratorError::ApiError { .. })
+    }
+}
+
 // ---------------------------------------------------------------------------
 // ClaudeTemplateGenerator — Anthropic Messages API Implementation
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Add is_retriable() to RiskGatingError and GeneratorError — the 2 missing domain error types. 16/16 now have self-declared retriability.