### PR TITLE
fix: move classify.rs to application layer (M-05)

### DIFF
--- a/engine/src/failure_classification/application/classify.rs
+++ b/engine/src/failure_classification/application/classify.rs
@@ -12,7 +12,7 @@
 //! # Usage
 //!
 //! ```ignore
-//! use rigorix::failure_classification::classify::classify_failure;
+//! use rigorix::failure_classification::application::classify::classify_failure;
 //!
 //! let failure_type = classify_failure("connection timeout");
 //! assert_eq!(failure_type, FailureType::Transient);
@@ -42,7 +42,7 @@ use crate::failure_classification::domain::FailureType;
 /// # Examples
 ///
 /// ```
-/// use rigorix::failure_classification::classify::classify_failure;
+/// use rigorix::failure_classification::application::classify::classify_failure;
 /// use rigorix::failure_classification::domain::FailureType;
 ///
 /// assert_eq!(classify_failure("connection timed out"), FailureType::Transient);

--- a/engine/src/failure_classification/application/mod.rs
+++ b/engine/src/failure_classification/application/mod.rs
@@ -15,6 +15,7 @@
 //! - DTOs include validation annotations/documentation
 //! - No implementation logic — only trait definitions
 
+pub mod classify;
 pub mod dto;
 pub mod factory;
 pub mod failure_classifier_service_impl;

--- a/engine/src/failure_classification/mod.rs
+++ b/engine/src/failure_classification/mod.rs
@@ -36,7 +36,6 @@
 //! - DTO schemas serve as the canonical data contract
 
 pub mod application;
-pub mod classify;
 pub mod domain;
 pub mod infrastructure;
 pub mod interfaces;


### PR DESCRIPTION
Move classify_failure() free function from top-level classify.rs to failure_classification/application/classify.rs. Fixes the 4-layer pattern violation.