### PR TITLE
feat: Issue 1.2 — Configuration Loading

### DIFF
--- a/cli/.pi/.guardian-epic-state.json
+++ b/cli/.pi/.guardian-epic-state.json
@@ -1,6 +1,6 @@
 {
-  "name": "\"cli-boundary\"",
-  "trackingIssueId": "235",
+  "name": "\"configuration\"",
+  "trackingIssueId": "244",
   "epicId": null,
   "slices": [
     {
@@ -32,28 +32,28 @@
       "id": "issue-contract-freeze",
       "title": "Contract Freeze: Define interfaces and contracts",
       "status": "planned",
-      "remoteIssueId": "236"
+      "remoteIssueId": "245"
     },
     {
       "id": "issue--component-name-",
       "title": "[Component Name]: [What this component does]",
       "status": "planned",
-      "remoteIssueId": "237"
+      "remoteIssueId": "246"
     },
     {
       "id": "issue-proofing",
       "title": "Proofing: Validation scripts + CI integration",
       "status": "planned",
-      "remoteIssueId": "238"
+      "remoteIssueId": "247"
     },
     {
       "id": "issue-architecture-readiness",
       "title": "Architecture Readiness: Runbook, DR, docs, CI enforcement",
       "status": "planned",
-      "remoteIssueId": "239"
+      "remoteIssueId": "248"
     }
   ],
   "status": "planning",
   "currentIssueIndex": 0,
-  "createdAt": "2026-06-16T05:15:11.668Z"
+  "createdAt": "2026-06-16T16:53:11.151Z"
 }

--- a/cli/.pi/.guardian-pipeline-state.json
+++ b/cli/.pi/.guardian-pipeline-state.json
@@ -1,6 +1,6 @@
 {
-  "id": "PL-3081",
-  "name": "\"cli-boundary\"",
+  "id": "PL-4197",
+  "name": "\"configuration\"",
   "items": [
     "issue-contract-freeze",
     "issue--component-name-",
@@ -48,84 +48,17 @@
       }
     }
   ],
-  "currentItemIndex": 3,
-  "currentStepIndex": 0,
+  "currentItemIndex": 0,
+  "currentStepIndex": 1,
   "status": "running",
   "retryCount": 0,
   "results": [
     {
       "item": "issue-contract-freeze",
-      "status": "done",
-      "stepResults": [
-        {
-          "step": "merge",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "validate",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "create-mr",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "merge",
-          "status": "passed",
-          "reason": ""
-        }
-      ]
-    },
-    {
-      "item": "issue--component-name-",
-      "status": "done",
+      "status": "in-progress",
       "stepResults": [
         {
           "step": "implement",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "validate",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "create-mr",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "merge",
-          "status": "passed",
-          "reason": ""
-        }
-      ]
-    },
-    {
-      "item": "issue-proofing",
-      "status": "done",
-      "stepResults": [
-        {
-          "step": "implement",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "validate",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "create-mr",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "merge",
           "status": "passed",
           "reason": ""
         }
@@ -133,6 +66,6 @@
     }
   ],
   "mergeOnValid": true,
-  "createdAt": "2026-06-16T05:15:11.691Z",
-  "updatedAt": "2026-06-16T16:49:08.053Z"
+  "createdAt": "2026-06-16T16:53:11.184Z",
+  "updatedAt": "2026-06-16T16:58:11.784Z"
 }

--- a/cli/.pi/issues/issue-architecture-readiness.md
+++ b/cli/.pi/issues/issue-architecture-readiness.md
@@ -1,7 +1,7 @@
 ---
 guardian_issue:
   id: "ISSUE-READINESS"
-  epic: ""cli-boundary""
+  epic: ""configuration""
   component: "Architecture Readiness"
   module: "module-template"
   status: planned

--- a/cli/.pi/issues/issue-contract-freeze.md
+++ b/cli/.pi/issues/issue-contract-freeze.md
@@ -1,7 +1,7 @@
 ---
 guardian_issue:
   id: "ISSUE-CONTRACT-FREEZE"
-  epic: ""cli-boundary""
+  epic: ""configuration""
   component: "Contract Freeze"
   module: "module-template"
   status: planned

--- a/cli/.pi/issues/issue-proofing.md
+++ b/cli/.pi/issues/issue-proofing.md
@@ -1,7 +1,7 @@
 ---
 guardian_issue:
   id: "ISSUE-PROOFING"
-  epic: ""cli-boundary""
+  epic: ""configuration""
   component: "Proofing & CI Enforcement"
   module: "module-template"
   status: planned

--- a/cli/src/domain/config.rs
+++ b/cli/src/domain/config.rs
@@ -102,6 +102,13 @@ pub struct CliConfig {
     /// CLI flag: `--force-tui`
     /// Default: `false`
     pub force_tui: bool,
+
+    /// Whether an API key was found in any source.
+    ///
+    /// Populated during config loading from `RIGORIX_API_KEY` env var
+    /// or the `cli.api_key` field in `rigorix.toml`.
+    /// Used to fail early with a clear error for commands requiring LLM access.
+    pub api_key_configured: bool,
 }
 
 impl Default for CliConfig {
@@ -114,6 +121,7 @@ impl Default for CliConfig {
             log_format: LogFormat::Pretty,
             config_path: None,
             force_tui: false,
+            api_key_configured: false,
         }
     }
 }

--- a/cli/src/infrastructure/config_impl.rs
+++ b/cli/src/infrastructure/config_impl.rs
@@ -11,6 +11,7 @@
 //! 3. rigorix.toml config file
 //! 4. Engine defaults
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use async_trait::async_trait;
@@ -69,6 +70,11 @@ impl CliConfigLoaderImpl {
 
     /// Apply environment variable overrides (RIGORIX_*) to a CliConfig.
     fn apply_env_overrides(config: &mut CliConfig) {
+        // Track API key presence
+        if std::env::var("RIGORIX_API_KEY").is_ok() {
+            config.api_key_configured = true;
+        }
+
         if let Ok(val) = std::env::var("RIGORIX_FORMAT") {
             config.output_format = match val.as_str() {
                 "json" => OutputFormat::Json,
@@ -262,6 +268,7 @@ fn apply_toml_to_config(config: &mut CliConfig, toml: &toml::Value) {
         // SAFETY: Setting env var for LLM API key during CLI startup.
         // This is safe because no other thread reads RIGORIX_API_KEY concurrently.
         unsafe { std::env::set_var("RIGORIX_API_KEY", api_key) };
+        config.api_key_configured = true;
     }
 
     // Parse [cli.logging] section (backward compat)
@@ -286,6 +293,54 @@ fn apply_toml_to_config(config: &mut CliConfig, toml: &toml::Value) {
             };
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Public validation helpers
+// ---------------------------------------------------------------------------
+
+/// Commands that require an LLM API key.
+pub fn command_requires_api_key(command: &str) -> bool {
+    matches!(command, "run" | "plan" | "generate")
+}
+
+/// Validate that the API key is configured for commands that need it.
+///
+/// Returns `None` if validation passes, or `Some(CliError::MissingConfig)`
+/// if the command requires an API key but none was found.
+pub fn validate_api_key_for_command(config: &CliConfig, command: &str) -> Option<CliError> {
+    if command_requires_api_key(command) && !config.api_key_configured {
+        return Some(CliError::MissingConfig {
+            field: "api_key".into(),
+            hint: "Set RIGORIX_API_KEY environment variable, add [cli.api_key] to rigorix.toml, or run `rigorix init` to configure interactively.".into(),
+        });
+    }
+    None
+}
+
+/// Build a `HashMap<String, String>` of CLI overrides for the engine's `ConfigService`.
+///
+/// Bridges the CLI-side `CliConfig` values to the engine's config schema
+/// using dot-notation keys (e.g., `logging.level`).
+pub fn build_engine_cli_overrides(config: &CliConfig) -> HashMap<String, String> {
+    let mut overrides = HashMap::new();
+
+    // Forward log settings to engine
+    overrides.insert(
+        "logging.level".to_string(),
+        config.log_level.as_tracing_filter().to_string(),
+    );
+    overrides.insert(
+        "logging.format".to_string(),
+        if config.log_format.is_json() {
+            "json"
+        } else {
+            "text"
+        }
+        .to_string(),
+    );
+
+    overrides
 }
 
 #[cfg(test)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -32,12 +32,15 @@ use tracing::info;
 use rigorix::domain::config::{CliConfig, ColorMode, LogFormat, LogLevel, OutputFormat};
 use rigorix::domain::error::CliError;
 use rigorix::infrastructure::config::CliConfigLoader;
-use rigorix::infrastructure::config_impl::CliConfigLoaderImpl;
+use rigorix::infrastructure::config_impl::{
+    CliConfigLoaderImpl, build_engine_cli_overrides, validate_api_key_for_command,
+};
 use rigorix::infrastructure::output::LogFormatter;
 use rigorix::infrastructure::output_impl::LogFormatterImpl;
 use rigorix::infrastructure::signal::SignalHandler;
 use rigorix::infrastructure::signal_impl::SignalHandlerImpl;
 use rigorix::interfaces::cli::{CliArgs, CliCommand, GlobalOptions};
+use rigorix_engine::configuration::application::ConfigService;
 
 #[tokio::main]
 async fn main() {
@@ -55,6 +58,27 @@ async fn main() {
             process::exit(e.exit_code());
         }
     };
+
+    // Validate config for the specific command before proceeding
+    let command_name = command_name(&args.command);
+    if let Some(err) = validate_api_key_for_command(&config, command_name) {
+        eprintln!("{}", err);
+        process::exit(err.exit_code());
+    }
+
+    // Bridge CLI config to engine's ConfigService
+    match init_engine_config(&config).await {
+        Ok(engine_config) => {
+            info!(
+                "Engine config loaded — sources: {:?}",
+                engine_config.sources_used
+            );
+        }
+        Err(e) => {
+            eprintln!("{}", e);
+            process::exit(e.exit_code());
+        }
+    }
 
     // Initialize tracing AFTER config is loaded (so we respect RIGORIX_LOG)
     rigorix::tracing::init_tracing(config.log_level, config.log_format);
@@ -115,6 +139,45 @@ fn parse_global_options(opts: &GlobalOptions) -> CliConfig {
         config_path: opts.config_path.clone(),
         ..CliConfig::default()
     }
+}
+
+/// Return a string name for the command (for validation purposes).
+fn command_name(command: &CliCommand) -> &'static str {
+    match command {
+        CliCommand::Run { .. } => "run",
+        CliCommand::Plan { .. } => "plan",
+        CliCommand::Init { .. } => "init",
+        CliCommand::Generate { .. } => "generate",
+        CliCommand::History(_) => "history",
+        CliCommand::Logs { .. } => "logs",
+        CliCommand::Audit(_) => "audit",
+        CliCommand::Template(_) => "template",
+    }
+}
+
+/// Initialize the engine's `ConfigService` with CLI-side values.
+///
+/// Bridges the CLI configuration to the engine's configuration pipeline so that
+/// CLI flags, env vars, and the config file are all available to engine services.
+async fn init_engine_config(
+    cli_config: &CliConfig,
+) -> Result<rigorix_engine::configuration::application::dto::LoadConfigOutput, CliError> {
+    let engine_service =
+        rigorix_engine::configuration::application::config_service_impl::ConfigServiceImpl::default(
+        );
+
+    let cli_overrides = build_engine_cli_overrides(cli_config);
+
+    let input = rigorix_engine::configuration::application::dto::LoadConfigInput {
+        config_path: cli_config.config_path.clone(),
+        cli_overrides: Some(cli_overrides),
+        ..Default::default()
+    };
+
+    engine_service
+        .load(input)
+        .await
+        .map_err(|e| CliError::Engine(rigorix_engine::error::CoreOrchestratorError::from(e)))
 }
 
 /// Load and merge CLI configuration.

--- a/cli/src/tests.rs
+++ b/cli/src/tests.rs
@@ -251,6 +251,7 @@ fn test_cli_config_serde_roundtrip() {
         log_format: crate::domain::config::LogFormat::Json,
         config_path: Some("/tmp/rigorix.toml".into()),
         force_tui: false,
+        api_key_configured: false,
     };
 
     let json = serde_json::to_string(&config).unwrap();


### PR DESCRIPTION
Implements Issue 1.2 from the roadmap.

### Changes
- Add `api_key_configured` field to `CliConfig`
- Fail fast with clear error when API key is missing for run/plan/generate
- Bridge CLI config to engine's `ConfigService` for unified config pipeline
- Wire validation + engine config into main.rs startup sequence

Closes #245