### PR TITLE
feat: contract freeze for cancellation module

### DIFF
--- a/cli/src/cancellation/application/dto/mod.rs
+++ b/cli/src/cancellation/application/dto/mod.rs
@@ -1,0 +1,88 @@
+//! Data Transfer Objects for the CLI Cancellation module.
+//!
+//! @canonical .pi/architecture/modules/cancellation.md
+//! Implements: Contract Freeze — CLI cancellation DTO schemas
+//! Issue: issue-contract-freeze
+//!
+//! DTOs define the input/output contracts for CLI cancellation operations.
+//! They are used by the `SignalHandler` trait and cancellation service traits.
+//!
+//! # Contract (Frozen)
+//! - Every service operation has a dedicated input and output DTO
+//! - DTOs are serializable (JSON for CI/CD output)
+//! - Fields use reasonable Rust types (no framework-specific annotations)
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Shutdown DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for requesting a graceful shutdown.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GracefulShutdownInput {
+    /// Human-readable reason for the shutdown.
+    pub reason: Option<String>,
+
+    /// Timeout in seconds for in-flight tasks to complete.
+    pub timeout_secs: u64,
+}
+
+impl Default for GracefulShutdownInput {
+    fn default() -> Self {
+        Self {
+            reason: None,
+            timeout_secs: 30,
+        }
+    }
+}
+
+/// Input for requesting an immediate abort.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImmediateShutdownInput {
+    /// Human-readable reason for the abort.
+    pub reason: Option<String>,
+}
+
+/// Output from a shutdown operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShutdownOutput {
+    /// Whether the shutdown completed successfully.
+    pub success: bool,
+    /// Number of in-flight tasks that were cancelled.
+    pub tasks_cancelled: u32,
+    /// Duration of the shutdown process in milliseconds.
+    pub duration_ms: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Signal Handler Status DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for querying the signal handler status.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SignalStatusInput;
+
+/// Output from querying the signal handler status.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SignalStatusOutput {
+    /// Whether the signal handler is installed.
+    pub installed: bool,
+    /// The current shutdown level (none, graceful, immediate).
+    pub current_level: SignalLevel,
+    /// The double-press window in seconds.
+    pub double_press_window_secs: u64,
+    /// Timestamp of the last signal received (ISO 8601).
+    pub last_signal_at: Option<String>,
+}
+
+/// The current signal/shutdown level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SignalLevel {
+    /// No shutdown in progress.
+    None,
+    /// Graceful shutdown in progress.
+    Graceful,
+    /// Immediate abort in progress.
+    Immediate,
+}

--- a/cli/src/cancellation/application/mod.rs
+++ b/cli/src/cancellation/application/mod.rs
@@ -1,1 +1,19 @@
-//! Cancellation application layer — (reserved for future cancellation service traits).
+//! Cancellation application layer — service traits, DTOs for CLI cancellation.
+//!
+//! @canonical .pi/architecture/modules/cancellation.md
+//! Implements: Contract Freeze — SignalHandler trait, DTO schemas
+//! Issue: issue-contract-freeze
+//!
+//! Defines the application-level contracts for CLI cancellation operations.
+//! Service traits (use cases) live here, implementations live in infrastructure.
+//!
+//! # Contract (Frozen)
+//! - Service traits define all use cases for CLI cancellation
+//! - DTOs define input/output schemas for each operation
+//! - No implementation — only contract signatures and type definitions
+
+pub mod dto;
+pub mod service;
+
+pub use dto::*;
+pub use service::{ShutdownLevel, SignalHandler};

--- a/cli/src/cancellation/application/service.rs
+++ b/cli/src/cancellation/application/service.rs
@@ -1,0 +1,54 @@
+//! Service interfaces for the CLI Cancellation module.
+//!
+//! @canonical .pi/architecture/modules/cancellation.md
+//! Implements: Contract Freeze — SignalHandler trait
+//! Issue: issue-contract-freeze
+//!
+//! These traits define the application-level operations for CLI cancellation
+//! and signal handling. All methods are async and return domain error types.
+//! Implementations reside in the infrastructure layer.
+//!
+//! # Contract (Frozen)
+//! - Every cancellation use case has a corresponding trait method
+//! - Input/output types are DTOs defined in `dto/`
+//! - All methods are async (use `async-trait` for trait object safety)
+//! - No implementation — only contract signatures
+
+use async_trait::async_trait;
+
+use crate::cli_boundary::domain::error::CliError;
+
+/// Represents a shutdown signal level from the user.
+///
+/// Two-level shutdown:
+/// - `Graceful` — single Ctrl+C: finish current work, no new tasks
+/// - `Immediate` — double Ctrl+C: abort all in-flight work
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShutdownLevel {
+    /// Graceful shutdown — finish current work, no new tasks.
+    Graceful,
+    /// Immediate abort — stop all in-flight work.
+    Immediate,
+}
+
+/// Captures OS signals and converts them to structured shutdown requests.
+///
+/// Implementations register with the OS signal handler (SIGINT, SIGTERM)
+/// and provide a channel receiver for the orchestrator to poll.
+///
+/// # Contract (Frozen)
+/// - `install()` registers the OS signal handler and returns a receiver
+/// - Double press detection uses a configurable window (default 2s)
+/// - Forwards signals to the engine's `CancellationService`
+/// - No signal handler state leaks between process invocations
+#[async_trait]
+pub trait SignalHandler: Send + Sync {
+    /// Install OS signal handlers and return a receiver for shutdown signals.
+    ///
+    /// Must be called early in `main()`, before any async tasks are spawned.
+    /// Returns a `tokio::sync::watch::Receiver` that yields `ShutdownLevel`.
+    async fn install(&self) -> Result<tokio::sync::watch::Receiver<ShutdownLevel>, CliError>;
+
+    /// Get the double-press window duration in seconds.
+    fn double_press_window_secs(&self) -> u64;
+}

--- a/cli/src/cancellation/domain/error.rs
+++ b/cli/src/cancellation/domain/error.rs
@@ -1,0 +1,60 @@
+//! CLI-specific cancellation domain errors.
+//!
+//! @canonical .pi/architecture/modules/cancellation.md
+//! Implements: Contract Freeze — CancellationCliError
+//! Issue: issue-contract-freeze
+//!
+//! Errors that originate from CLI cancellation operations (signal handling,
+//! shutdown coordination). These are distinct from the engine's `CancellationError`
+//! — they cover CLI-level concerns like signal handler installation failures.
+//!
+//! # Contract (Frozen)
+//! - `CancellationCliError` is the single error type for this module
+//! - Each variant carries structured context for error reporting
+//! - Implements `std::error::Error` for library compatibility
+//! - Maps to `CliError` at the boundary layer
+
+use thiserror::Error;
+
+/// Errors that can occur during CLI cancellation operations.
+#[derive(Debug, Error)]
+pub enum CancellationCliError {
+    /// Failed to install the OS signal handler.
+    #[error("Failed to install signal handler: {detail}")]
+    SignalInstallFailed {
+        /// What went wrong during signal handler setup.
+        detail: String,
+    },
+
+    /// The signal handler was already installed.
+    #[error("Signal handler already installed")]
+    AlreadyInstalled,
+
+    /// Failed to propagate the shutdown signal to components.
+    #[error("Failed to propagate shutdown signal: {detail}")]
+    SignalPropagationFailed {
+        /// What went wrong during signal propagation.
+        detail: String,
+    },
+
+    /// A requested operation is not valid in the current shutdown state.
+    #[error("Operation not allowed in current shutdown state: {state}")]
+    InvalidState {
+        /// The current shutdown state that prevented the operation.
+        state: String,
+    },
+
+    /// An unexpected internal error occurred.
+    #[error("Internal cancellation error: {detail}")]
+    Internal {
+        /// Description of the internal error.
+        detail: String,
+    },
+}
+
+impl CancellationCliError {
+    /// Returns `true` if this error is retriable.
+    pub fn is_retriable(&self) -> bool {
+        matches!(self, CancellationCliError::SignalInstallFailed { .. })
+    }
+}

--- a/cli/src/cancellation/domain/event/mod.rs
+++ b/cli/src/cancellation/domain/event/mod.rs
@@ -1,0 +1,50 @@
+//! Event payload schemas for the CLI Cancellation module.
+//!
+//! @canonical .pi/architecture/modules/cancellation.md
+//! Implements: Contract Freeze — CancellationCliEvent payload schemas
+//! Issue: issue-contract-freeze
+//!
+//! These events are emitted by the CLI cancellation module whenever signals
+//! are received or shutdown state changes. Consumers (output formatters,
+//! TUI, loggers) subscribe to these event types.
+//!
+//! # Contract (Frozen)
+//! - Each event carries the full context needed by consumers
+//! - No internal implementation details exposed
+//! - All events are serializable for logging and CI/CD output
+
+use serde::{Deserialize, Serialize};
+
+/// Events emitted by the CLI Cancellation module.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum CancellationCliEvent {
+    /// A single Ctrl+C was received — graceful shutdown initiated.
+    GracefulShutdownRequested {
+        /// The double-press window in seconds.
+        grace_period_secs: u64,
+    },
+
+    /// A second Ctrl+C was received within the window — immediate abort.
+    ImmediateShutdownRequested {
+        /// Time elapsed between first and second signal in milliseconds.
+        elapsed_ms: u64,
+    },
+
+    /// The grace period expired without a second signal.
+    GracePeriodExpired,
+
+    /// The signal handler was successfully installed.
+    SignalHandlerInstalled,
+
+    /// The signal handler installation failed.
+    SignalHandlerInstallFailed {
+        /// Error message describing the failure.
+        error: String,
+    },
+
+    /// A shutdown signal was forwarded to the engine's cancellation service.
+    ShutdownSignalForwarded {
+        /// The shutdown level forwarded (graceful or immediate).
+        level: String,
+    },
+}

--- a/cli/src/cancellation/domain/mod.rs
+++ b/cli/src/cancellation/domain/mod.rs
@@ -1,1 +1,19 @@
-//! Cancellation domain types — (reserved for future domain types).
+//! Cancellation domain types — error types, event schemas for CLI cancellation.
+//!
+//! @canonical .pi/architecture/modules/cancellation.md
+//! Implements: Contract Freeze — CancellationCliError, CancellationCliEvent
+//! Issue: issue-contract-freeze
+//!
+//! These types define the domain-level contracts for CLI cancellation operations.
+//! They are pure domain objects with no framework dependencies.
+//!
+//! # Contract (Frozen)
+//! - Errors carry structured context for diagnostics
+//! - Events are serializable for logging and CI/CD output
+//! - No implementation logic — only type definitions
+
+pub mod error;
+pub mod event;
+
+pub use error::CancellationCliError;
+pub use event::CancellationCliEvent;

--- a/cli/src/cancellation/infrastructure/mod.rs
+++ b/cli/src/cancellation/infrastructure/mod.rs
@@ -1,3 +1,14 @@
-//! Cancellation infrastructure — signal handler interface and implementation.
+//! Cancellation infrastructure — signal handler implementation, repository interfaces.
+//!
+//! @canonical .pi/architecture/modules/cancellation.md
+//! Implements: Contract Freeze — repository interfaces, SignalHandlerImpl
+//! Issue: issue-contract-freeze
+//!
+//! Infrastructure layer for CLI cancellation operations:
+//! - `signal.rs` re-exports `SignalHandler` trait and `ShutdownLevel` from application/
+//! - `signal_impl.rs` implements the trait via tokio signal handling
+//! - `repository/` defines persistence interfaces for CLI-level signal state
+
+pub mod repository;
 pub mod signal;
 pub mod signal_impl;

--- a/cli/src/cancellation/infrastructure/repository/mod.rs
+++ b/cli/src/cancellation/infrastructure/repository/mod.rs
@@ -1,0 +1,58 @@
+//! Repository interfaces for the CLI Cancellation module.
+//!
+//! @canonical .pi/architecture/modules/cancellation.md
+//! Implements: Contract Freeze — CancellationCliRepository trait
+//! Issue: issue-contract-freeze
+//!
+//! Repositories abstract CLI-level cancellation data storage behind interfaces,
+//! allowing implementations to use in-memory state, filesystem persistence,
+//! or mock storage without coupling CLI logic to infrastructure.
+//!
+//! These repositories handle CLI-level concerns (signal state tracking,
+//! shutdown configuration). They are distinct from the engine's cancellation
+//! repositories which handle execution-level cancellation state.
+//!
+//! # Contract (Frozen)
+//! - All repository methods are async
+//! - All methods return domain error types
+//! - No framework-specific annotations on trait definitions
+//! - Implementations are hidden behind these interfaces
+
+use async_trait::async_trait;
+
+use crate::cancellation::application::dto::SignalLevel;
+use crate::cancellation::domain::CancellationCliError;
+
+/// Repository for CLI-level cancellation state.
+///
+/// Handles persistence and retrieval of signal handler state,
+/// shutdown configuration, and cancellation history at the CLI layer.
+///
+/// # Contract (Frozen)
+/// - Read operations return current state or cached configuration
+/// - State mutations are atomic
+/// - All methods are safe to call concurrently
+#[async_trait]
+pub trait CancellationCliRepository: Send + Sync {
+    /// Store the current signal level.
+    async fn set_signal_level(&self, level: SignalLevel) -> Result<(), CancellationCliError>;
+
+    /// Retrieve the current signal level.
+    async fn get_signal_level(&self) -> Result<SignalLevel, CancellationCliError>;
+
+    /// Record a signal event with timestamp.
+    async fn record_signal(
+        &self,
+        level: SignalLevel,
+        elapsed_ms: u64,
+    ) -> Result<(), CancellationCliError>;
+
+    /// Get the timestamp of the last signal received.
+    async fn last_signal_timestamp(&self) -> Result<Option<String>, CancellationCliError>;
+
+    /// Clear all recorded signal state.
+    async fn clear(&self) -> Result<(), CancellationCliError>;
+
+    /// Check if the signal handler is installed.
+    async fn is_installed(&self) -> Result<bool, CancellationCliError>;
+}

--- a/cli/src/cancellation/infrastructure/signal.rs
+++ b/cli/src/cancellation/infrastructure/signal.rs
@@ -1,46 +1,19 @@
-//! Signal handling interface for the CLI boundary.
+//! Signal handling interface — re-exported from the application layer.
 //!
-//! @canonical .pi/architecture/modules/cli-boundary.md
-//! Implements: Contract Freeze — SignalHandler trait
-//! Issue: issue-contract-freeze
-//!
-//! Captures Ctrl+C (SIGINT) and manages two-level shutdown:
-//! - Single press → graceful shutdown (finish current node)
-//! - Double press within 2s → immediate abort (abort all in-flight)
-//!
-//! Per ADR-007, the CLI is ephemeral — signal handling is per-process.
+//! @canonical .pi/architecture/modules/cancellation.md
+//! The `SignalHandler` trait and `ShutdownLevel` enum are defined in
+//! `application/service.rs` (their canonical Clean Architecture location).
+//! This module re-exports them for backward compatibility with existing imports.
 //!
 //! # Contract (Frozen)
 //! - `install()` registers the OS signal handler and returns a receiver
 //! - Double press detection uses a configurable window (default 2s)
 //! - Forwards signals to the engine's `CancellationService`
 //! - No signal handler state leaks between process invocations
+//!
+//! # Migration
+//! New code should import directly from
+//! `crate::cancellation::application::{SignalHandler, ShutdownLevel}`.
+//! This re-export will be removed in a future update.
 
-use async_trait::async_trait;
-
-use crate::cli_boundary::domain::error::CliError;
-
-/// Represents a shutdown signal level from the user.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ShutdownLevel {
-    /// Graceful shutdown — finish current work, no new tasks.
-    Graceful,
-    /// Immediate abort — stop all in-flight work.
-    Immediate,
-}
-
-/// Captures OS signals and converts them to structured shutdown requests.
-///
-/// Implementations register with the OS signal handler (SIGINT, SIGTERM)
-/// and provide a channel receiver for the orchestrator to poll.
-#[async_trait]
-pub trait SignalHandler: Send + Sync {
-    /// Install OS signal handlers and return a receiver for shutdown signals.
-    ///
-    /// Must be called early in `main()`, before any async tasks are spawned.
-    /// Returns a `tokio::sync::watch::Receiver` that yields `ShutdownLevel`.
-    async fn install(&self) -> Result<tokio::sync::watch::Receiver<ShutdownLevel>, CliError>;
-
-    /// Get the double-press window duration in seconds.
-    fn double_press_window_secs(&self) -> u64;
-}
+pub use crate::cancellation::application::service::{ShutdownLevel, SignalHandler};

--- a/cli/src/cancellation/interfaces/http/mod.rs
+++ b/cli/src/cancellation/interfaces/http/mod.rs
@@ -1,0 +1,194 @@
+//! HTTP API contracts for CLI Cancellation endpoints.
+//!
+//! @canonical .pi/architecture/modules/cancellation.md
+//! Implements: Contract Freeze — HTTP endpoint contracts and error formats
+//! Issue: issue-contract-freeze
+//!
+//! Defines endpoint paths, methods, request/response schemas, and error
+//! response formats for CLI-to-engine cancellation operations. These contracts
+//! are framework-agnostic — they describe the API surface that any HTTP
+//! server implementation must satisfy.
+//!
+//! The CLI cancellation module exposes operations for:
+//! - Querying signal handler status
+//! - Requesting graceful shutdown
+//! - Requesting immediate abort
+//!
+//! # Contract (Frozen)
+//! - All endpoints documented with method, path, request, and response types
+//! - Error responses follow a unified format
+//! - No framework-specific annotations (axum/actix/warp annotations added by implementation)
+
+use serde::{Deserialize, Serialize};
+
+use crate::cancellation::application::dto::{
+    GracefulShutdownInput, ImmediateShutdownInput, ShutdownOutput, SignalStatusOutput,
+};
+
+// ---------------------------------------------------------------------------
+// API Base Path
+// ---------------------------------------------------------------------------
+
+/// All CLI cancellation endpoints are served under this base path.
+pub const API_BASE_PATH: &str = "/api/v1/cli/cancellation";
+
+// ---------------------------------------------------------------------------
+// Endpoint: GET /api/v1/cli/cancellation/status
+// ---------------------------------------------------------------------------
+
+/// GET /api/v1/cli/cancellation/status
+///
+/// Get the current signal handler status.
+///
+/// **Response:** `200 OK` with `CancellationStatusResponse`
+pub const CANCELLATION_STATUS_PATH: &str = "/api/v1/cli/cancellation/status";
+pub const CANCELLATION_STATUS_METHOD: &str = "GET";
+
+/// Response for GET /api/v1/cli/cancellation/status.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CancellationStatusResponse {
+    /// Whether the signal handler is installed.
+    pub installed: bool,
+    /// The current shutdown level.
+    pub current_level: String,
+    /// The double-press window in seconds.
+    pub double_press_window_secs: u64,
+    /// Timestamp of the last signal received.
+    pub last_signal_at: Option<String>,
+}
+
+impl From<SignalStatusOutput> for CancellationStatusResponse {
+    fn from(output: SignalStatusOutput) -> Self {
+        Self {
+            installed: output.installed,
+            current_level: format!("{:?}", output.current_level),
+            double_press_window_secs: output.double_press_window_secs,
+            last_signal_at: output.last_signal_at,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/cli/cancellation/shutdown/graceful
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/cli/cancellation/shutdown/graceful
+///
+/// Request a graceful shutdown.
+///
+/// **Request:** `GracefulShutdownApiRequest`
+/// **Response:** `200 OK` with `ShutdownApiResponse`
+pub const GRACEFUL_SHUTDOWN_PATH: &str = "/api/v1/cli/cancellation/shutdown/graceful";
+pub const GRACEFUL_SHUTDOWN_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/cli/cancellation/shutdown/graceful.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GracefulShutdownApiRequest {
+    /// Human-readable reason for the shutdown.
+    pub reason: Option<String>,
+    /// Timeout in seconds for in-flight tasks.
+    #[serde(default = "default_shutdown_timeout")]
+    pub timeout_secs: u64,
+}
+
+fn default_shutdown_timeout() -> u64 {
+    30
+}
+
+impl From<GracefulShutdownApiRequest> for GracefulShutdownInput {
+    fn from(req: GracefulShutdownApiRequest) -> Self {
+        Self {
+            reason: req.reason,
+            timeout_secs: req.timeout_secs,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/cli/cancellation/shutdown/immediate
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/cli/cancellation/shutdown/immediate
+///
+/// Request an immediate abort.
+///
+/// **Request:** `ImmediateShutdownApiRequest`
+/// **Response:** `200 OK` with `ShutdownApiResponse`
+pub const IMMEDIATE_SHUTDOWN_PATH: &str = "/api/v1/cli/cancellation/shutdown/immediate";
+pub const IMMEDIATE_SHUTDOWN_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/cli/cancellation/shutdown/immediate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImmediateShutdownApiRequest {
+    /// Human-readable reason for the abort.
+    pub reason: Option<String>,
+}
+
+impl From<ImmediateShutdownApiRequest> for ImmediateShutdownInput {
+    fn from(req: ImmediateShutdownApiRequest) -> Self {
+        Self { reason: req.reason }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Response DTOs
+// ---------------------------------------------------------------------------
+
+/// Response for shutdown API requests.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShutdownApiResponse {
+    pub success: bool,
+    pub tasks_cancelled: u32,
+    pub duration_ms: u64,
+}
+
+impl From<ShutdownOutput> for ShutdownApiResponse {
+    fn from(output: ShutdownOutput) -> Self {
+        Self {
+            success: output.success,
+            tasks_cancelled: output.tasks_cancelled,
+            duration_ms: output.duration_ms,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unified Error Response Format
+// ---------------------------------------------------------------------------
+
+/// Standard error response for CLI Cancellation API endpoints.
+///
+/// All 4xx/5xx responses use this format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CliApiErrorResponse {
+    /// HTTP status code.
+    pub status: u16,
+    /// Machine-readable error code.
+    pub code: String,
+    /// Human-readable error message.
+    pub message: String,
+    /// Detailed error context (optional).
+    pub details: Option<serde_json::Value>,
+    /// Request ID for tracing.
+    pub request_id: Option<String>,
+}
+
+/// Standardized error codes for CLI Cancellation API.
+pub mod error_codes {
+    /// Signal handler not installed.
+    pub const NOT_INSTALLED: &str = "CANCELLATION_NOT_INSTALLED";
+    /// Signal handler installation failed.
+    pub const INSTALL_FAILED: &str = "CANCELLATION_INSTALL_FAILED";
+    /// Shutdown already in progress.
+    pub const ALREADY_SHUTTING_DOWN: &str = "CANCELLATION_ALREADY_SHUTTING_DOWN";
+    /// Internal server error.
+    pub const INTERNAL_ERROR: &str = "CANCELLATION_INTERNAL_ERROR";
+}
+
+/// HTTP status code mappings for CLI Cancellation errors.
+pub mod status_codes {
+    pub const NOT_INSTALLED: u16 = 503;
+    pub const INSTALL_FAILED: u16 = 500;
+    pub const ALREADY_SHUTTING_DOWN: u16 = 409;
+    pub const INTERNAL_ERROR: u16 = 500;
+}

--- a/cli/src/cancellation/interfaces/mod.rs
+++ b/cli/src/cancellation/interfaces/mod.rs
@@ -1,0 +1,10 @@
+//! Cancellation interfaces — HTTP API contracts for CLI cancellation operations.
+//!
+//! @canonical .pi/architecture/modules/cancellation.md
+//! Implements: Contract Freeze — HTTP endpoint contracts
+//! Issue: issue-contract-freeze
+//!
+//! Defines the HTTP API surface for CLI cancellation operations.
+//! These are framework-agnostic endpoint definitions.
+
+pub mod http;

--- a/cli/src/cancellation/mod.rs
+++ b/cli/src/cancellation/mod.rs
@@ -1,9 +1,47 @@
 //! Cancellation module — signal handlers for graceful shutdown.
 //!
 //! @canonical .pi/architecture/modules/cancellation.md
+//! Implements: Contract Freeze — CLI Cancellation module (interfaces only)
+//! Issue: issue-contract-freeze
+//!
 //! Captures Ctrl+C (SIGINT) with double-press detection.
 //! Single press = graceful shutdown. Double press within 2s = immediate.
+//!
+//! # Architecture (Clean Architecture layers)
+//!
+//! ```text
+//! cancellation/
+//! ├── domain/           # CancellationCliError, CancellationCliEvent
+//! │   ├── mod.rs
+//! │   ├── error.rs      # CancellationCliError enum
+//! │   └── event/        # CancellationCliEvent payload schemas
+//! │       └── mod.rs
+//! ├── application/      # Service traits, DTO schemas
+//! │   ├── mod.rs
+//! │   ├── service.rs    # SignalHandler trait + ShutdownLevel enum
+//! │   └── dto/          # ShutdownInput/Output, SignalStatus types
+//! │       └── mod.rs
+//! ├── infrastructure/   # Trait implementations, repository interfaces
+//! │   ├── mod.rs
+//! │   ├── signal.rs                    # Re-exports SignalHandler + ShutdownLevel
+//! │   ├── signal_impl.rs               # SignalHandlerImpl implementation
+//! │   └── repository/                  # CancellationCliRepository trait
+//! │       └── mod.rs
+//! └── interfaces/       # HTTP API contracts
+//!     ├── mod.rs
+//!     └── http/         # Endpoint definitions, request/response schemas
+//!         └── mod.rs
+//! ```
+//!
+//! # Contract Freeze Notice
+//!
+//! ALL interface files in this module are frozen contracts.
+//! - No implementation changes without explicit contract change approval
+//! - Implementation PRs MUST reference these interfaces
+//! - DTO schemas serve as the canonical data contract
+//! - The SignalHandler trait is the primary service contract
 
 pub mod application;
 pub mod domain;
 pub mod infrastructure;
+pub mod interfaces;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -33,8 +33,16 @@
 //! ├── observability/    # Tracing, health checks, event schemas
 //! │   ├── domain/       # ObservabilityEvent schemas
 //! │   └── infrastructure/ # TracingInitializer trait + tracing impl
-//! └── cancellation/     # Signal handler for Ctrl+C
-//!     └── infrastructure/ # SignalHandler trait + impl
+//! ├── cancellation/     # Signal handler for Ctrl+C
+//! │   ├── domain/       # CancellationCliError, CancellationCliEvent
+//! │   ├── application/  # SignalHandler trait, DTO schemas
+//! │   ├── infrastructure/ # SignalHandlerImpl, CancellationCliRepository
+//! │   └── interfaces/   # HTTP API contracts
+//! └── templates/        # Template list/show commands
+//!     ├── domain/       # TemplateCliError, TemplateCliEvent
+//!     ├── application/  # TemplateCommandService trait, DTOs
+//!     ├── infrastructure/ # TemplateEngineHandler, TemplateCliRepository
+//!     └── interfaces/   # HTTP API contracts
 //! ```
 //!
 //! # Contract Freeze Notice


### PR DESCRIPTION
Closes #

## Summary
Define and freeze all public interfaces for the CLI Cancellation module before implementation begins. This prevents architecture drift — implementation must satisfy contracts, not the other way around.

### Contract Freeze Coverage

**Domain layer** (cancellation/domain/):
- CancellationCliError — typed error enum with 5 variants
- CancellationCliEvent — 6 event payload schemas

**Application layer** (cancellation/application/):
- SignalHandler trait — service contract for signal handling
- ShutdownLevel enum — Graceful/Immediate two-level shutdown
- GracefulShutdownInput/Output, ImmediateShutdownInput, SignalStatus DTOs

**Infrastructure layer** (cancellation/infrastructure/):
- CancellationCliRepository trait — persistence interface for signal state
- signal.rs re-exports SignalHandler + ShutdownLevel from application/

**Interfaces layer** (cancellation/interfaces/):
- HTTP API contracts: status, graceful shutdown, immediate shutdown endpoints
- Unified error response format with error codes