### PR TITLE
feat: contract freeze for configuration module

### DIFF
--- a/cli/src/configuration/application/dto/mod.rs
+++ b/cli/src/configuration/application/dto/mod.rs
@@ -1,0 +1,87 @@
+//! Data Transfer Objects for the CLI Configuration module.
+//!
+//! @canonical .pi/architecture/modules/configuration.md
+//! Implements: Contract Freeze — CLI config DTO schemas
+//! Issue: issue-contract-freeze
+//!
+//! DTOs define the input/output contracts for CLI configuration operations.
+//! They are used by the `CliConfigLoader` trait and related services.
+//!
+//! # Contract (Frozen)
+//! - Every service operation has a dedicated input and output DTO
+//! - DTOs are serializable (JSON for CI/CD output)
+//! - Fields use reasonable Rust types (no framework-specific annotations)
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Config Load DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for loading configuration from an explicit path.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoadConfigInput {
+    /// Path to the config file to load.
+    pub path: String,
+}
+
+/// Output from a configuration load operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoadConfigOutput {
+    /// Path to the config file that was loaded (if any).
+    pub config_path: Option<String>,
+    /// The primary source of configuration values.
+    pub primary_source: ConfigSource,
+    /// List of all sources that contributed.
+    pub sources_used: Vec<ConfigSource>,
+    /// Whether an API key was found in any source.
+    pub api_key_configured: bool,
+}
+
+/// Describes the source of a configuration value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ConfigSource {
+    #[serde(rename = "default")]
+    Default,
+    #[serde(rename = "file")]
+    File,
+    #[serde(rename = "env")]
+    Environment,
+    #[serde(rename = "flags")]
+    CliFlags,
+}
+
+// ---------------------------------------------------------------------------
+// Config Validation DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for validating the current configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidateConfigInput {
+    /// Whether to check for the API key.
+    pub check_api_key: bool,
+    /// The command that will be executed (for context-specific validation).
+    pub command: Option<String>,
+}
+
+impl Default for ValidateConfigInput {
+    fn default() -> Self {
+        Self {
+            check_api_key: true,
+            command: None,
+        }
+    }
+}
+
+/// Output from configuration validation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidateConfigOutput {
+    /// Whether the configuration is valid.
+    pub valid: bool,
+    /// List of validation errors (empty if valid).
+    pub errors: Vec<String>,
+    /// List of warnings (non-blocking).
+    pub warnings: Vec<String>,
+    /// Whether an API key is configured.
+    pub api_key_configured: bool,
+}

--- a/cli/src/configuration/application/mod.rs
+++ b/cli/src/configuration/application/mod.rs
@@ -1,1 +1,18 @@
-//! Configuration application layer — (reserved for future CLI-side config service traits).
+//! Configuration application layer — service traits, DTOs for CLI config operations.
+//!
+//! @canonical .pi/architecture/modules/configuration.md
+//! Implements: Contract Freeze — CliConfigLoader trait, DTO schemas
+//! Issue: issue-contract-freeze
+//!
+//! Defines the application-level contracts for CLI configuration operations.
+//! Service traits (use cases) live here, implementations live in infrastructure.
+//!
+//! # Contract (Frozen)
+//! - Service traits define all use cases for CLI config operations
+//! - DTOs define input/output schemas for each operation
+//! - No implementation — only contract signatures and type definitions
+
+pub mod dto;
+pub mod service;
+
+pub use service::CliConfigLoader;

--- a/cli/src/configuration/application/service.rs
+++ b/cli/src/configuration/application/service.rs
@@ -1,0 +1,66 @@
+//! Service interfaces for the CLI Configuration module.
+//!
+//! @canonical .pi/architecture/modules/configuration.md
+//! Implements: Contract Freeze — CliConfigLoader trait
+//! Issue: issue-contract-freeze
+//!
+//! These traits define the application-level operations for CLI configuration
+//! loading, merging, and validation. All methods are async and return domain
+//! error types. Implementations reside in the infrastructure layer.
+//!
+//! # Contract (Frozen)
+//! - Every config use case has a corresponding trait method
+//! - Input/output types are DTOs defined in `dto/`
+//! - All methods are async (use `async-trait` for trait object safety)
+//! - No implementation — only contract signatures
+
+use async_trait::async_trait;
+
+use crate::cli_boundary::domain::error::CliError;
+use crate::configuration::domain::config::CliConfig;
+
+/// Loads and merges CLI configuration from multiple sources.
+///
+/// Merge order (later overrides earlier):
+/// 1. Engine defaults
+/// 2. `rigorix.toml` from cwd or `--config` path
+/// 3. Environment variables (`RIGORIX_*`)
+/// 4. CLI flags (passed via `cli_overrides`)
+///
+/// # Contract (Frozen)
+/// - `load()` returns the fully merged `CliConfig`
+/// - Merge order: CLI flags override env vars, which override file config,
+///   which override engine defaults
+/// - Missing non-critical values use sensible defaults
+/// - Missing critical values (e.g., API key) return `MissingConfig` error
+#[async_trait]
+pub trait CliConfigLoader: Send + Sync {
+    /// Load configuration from all sources and merge.
+    ///
+    /// Merge order (later overrides earlier):
+    /// 1. Engine defaults
+    /// 2. `rigorix.toml` from cwd or `--config` path
+    /// 3. Environment variables (`RIGORIX_*`)
+    /// 4. CLI flags (passed via `cli_overrides`)
+    ///
+    /// Returns `CliError::ConfigNotFound` if no config file is found
+    /// and no engine defaults apply.
+    /// Returns `CliError::MissingConfig` if a required value is missing.
+    async fn load(&self, cli_overrides: CliConfig) -> Result<CliConfig, CliError>;
+
+    /// Load configuration from an explicit file path.
+    ///
+    /// Skips automatic config discovery and uses the given path.
+    /// Still applies env var and CLI flag overrides on top.
+    async fn load_from_path(
+        &self,
+        path: &str,
+        cli_overrides: CliConfig,
+    ) -> Result<CliConfig, CliError>;
+
+    /// Check whether a configuration file exists at the default locations.
+    async fn has_default_config(&self) -> bool;
+
+    /// Get the list of config file paths that were searched.
+    async fn searched_paths(&self) -> Vec<String>;
+}

--- a/cli/src/configuration/domain/error.rs
+++ b/cli/src/configuration/domain/error.rs
@@ -1,0 +1,82 @@
+//! CLI-specific configuration domain errors.
+//!
+//! @canonical .pi/architecture/modules/configuration.md
+//! Implements: Contract Freeze — ConfigCliError
+//! Issue: issue-contract-freeze
+//!
+//! Errors that originate from CLI configuration operations (loading, merging,
+//! validation). These are distinct from the engine's `ConfigurationError` —
+//! they cover CLI-level concerns like file discovery, flag parsing, and
+//! source merging.
+//!
+//! # Contract (Frozen)
+//! - `ConfigCliError` is the single error type for this module
+//! - Each variant carries structured context for error reporting
+//! - Implements `std::error::Error` for library compatibility
+//! - Maps to `CliError` at the boundary layer
+
+use thiserror::Error;
+
+/// Errors that can occur during CLI configuration operations.
+#[derive(Debug, Error)]
+pub enum ConfigCliError {
+    /// Configuration file discovery failed (no file found at expected paths).
+    #[error("No configuration file found: {detail}")]
+    DiscoveryFailed {
+        /// Paths that were searched.
+        detail: String,
+    },
+
+    /// A configuration file was found but could not be parsed.
+    #[error("Failed to parse configuration file '{path}': {detail}")]
+    ParseFailed {
+        /// The path that failed parsing.
+        path: String,
+        /// What went wrong.
+        detail: String,
+    },
+
+    /// A required configuration value is missing.
+    #[error("Missing required configuration: {field}")]
+    MissingValue {
+        /// The name of the missing field.
+        field: String,
+        /// How to resolve the error.
+        hint: String,
+    },
+
+    /// An environment variable had an invalid value.
+    #[error("Invalid environment variable '{var}': {detail}")]
+    InvalidEnvVar {
+        /// The environment variable name.
+        var: String,
+        /// What was wrong with the value.
+        detail: String,
+    },
+
+    /// Source merging detected a conflict that couldn't be resolved.
+    #[error("Configuration merge conflict for '{field}'")]
+    MergeConflict {
+        /// The field with conflicting values.
+        field: String,
+        /// The conflicting values from different sources.
+        sources: Vec<String>,
+    },
+
+    /// An unexpected internal error occurred.
+    #[error("Internal configuration error: {detail}")]
+    Internal {
+        /// Description of the internal error.
+        detail: String,
+    },
+}
+
+impl ConfigCliError {
+    /// Returns `true` if this error is retriable.
+    pub fn is_retriable(&self) -> bool {
+        matches!(
+            self,
+            ConfigCliError::DiscoveryFailed { .. } | ConfigCliError::MissingValue { .. }
+        )
+    }
+}

--- a/cli/src/configuration/domain/event/mod.rs
+++ b/cli/src/configuration/domain/event/mod.rs
@@ -1,0 +1,74 @@
+//! Event payload schemas for the CLI Configuration module.
+//!
+//! @canonical .pi/architecture/modules/configuration.md
+//! Implements: Contract Freeze — ConfigCliEvent payload schemas
+//! Issue: issue-contract-freeze
+//!
+//! These events are emitted by the CLI configuration module whenever config
+//! is loaded, merged, or encounters errors. Consumers (output formatters,
+//! TUI, loggers) subscribe to these event types.
+//!
+//! # Contract (Frozen)
+//! - Each event carries the full context needed by consumers
+//! - No internal implementation details exposed
+//! - All events are serializable for logging and CI/CD output
+
+use serde::{Deserialize, Serialize};
+
+/// Events emitted by the CLI Configuration module.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ConfigCliEvent {
+    /// Configuration loading started.
+    ConfigLoadStarted {
+        /// Paths being searched for config files.
+        searched_paths: Vec<String>,
+    },
+
+    /// Configuration was successfully loaded and merged.
+    ConfigLoaded {
+        /// Source that provided the config (default, file, env, flags).
+        primary_source: String,
+        /// Path to the config file used (if any).
+        config_path: Option<String>,
+        /// Number of configuration sources that contributed.
+        source_count: u32,
+    },
+
+    /// Configuration was loaded from an explicit path.
+    ConfigLoadedFromPath {
+        /// The path that was loaded.
+        path: String,
+    },
+
+    /// Configuration loading failed.
+    ConfigLoadFailed {
+        /// Error message describing the failure.
+        error: String,
+        /// Paths that were searched.
+        searched_paths: Vec<String>,
+    },
+
+    /// An environment variable was applied as a config override.
+    EnvVarApplied {
+        /// The environment variable name.
+        var: String,
+        /// The config field it mapped to.
+        field: String,
+    },
+
+    /// A CLI flag was applied as a config override.
+    CliFlagApplied {
+        /// The flag name.
+        flag: String,
+        /// The config field it mapped to.
+        field: String,
+    },
+
+    /// API key validation completed.
+    ApiKeyValidated {
+        /// Whether the API key is configured.
+        configured: bool,
+        /// The command that required the key.
+        command: String,
+    },
+}

--- a/cli/src/configuration/domain/mod.rs
+++ b/cli/src/configuration/domain/mod.rs
@@ -1,3 +1,21 @@
-//! Configuration domain types — CliConfig value object.
+//! Configuration domain types — CliConfig value object, error types, event schemas.
+//!
+//! @canonical .pi/architecture/modules/configuration.md
+//! Implements: Contract Freeze — ConfigCliError, ConfigCliEvent
+//! Issue: issue-contract-freeze
+//!
+//! These types define the domain-level contracts for CLI configuration operations.
+//! They are pure domain objects with no framework dependencies.
+//!
+//! # Contract (Frozen)
+//! - Errors carry structured context for diagnostics
+//! - Events are serializable for logging and CI/CD output
+//! - No implementation logic — only type definitions
+
 pub mod config;
+pub mod error;
+pub mod event;
+
 pub use config::*;
+pub use error::ConfigCliError;
+pub use event::ConfigCliEvent;

--- a/cli/src/configuration/infrastructure/config.rs
+++ b/cli/src/configuration/infrastructure/config.rs
@@ -1,11 +1,9 @@
-//! Config loading interface for the CLI boundary.
+//! Config loading interface — re-exported from the application layer.
 //!
-//! @canonical .pi/architecture/modules/cli-boundary.md
-//! Implements: Contract Freeze — CliConfigLoader trait
-//! Issue: issue-contract-freeze
-//!
-//! Loads and merges CLI-specific configuration from multiple sources:
-//! CLI flags → env vars (`RIGORIX_*`) → `rigorix.toml` → engine defaults.
+//! @canonical .pi/architecture/modules/configuration.md
+//! The `CliConfigLoader` trait is defined in `application/service.rs`
+//! (its canonical Clean Architecture location). This module re-exports it
+//! for backward compatibility with existing imports.
 //!
 //! # Contract (Frozen)
 //! - `load()` returns the fully merged `CliConfig`
@@ -13,41 +11,10 @@
 //!   which override engine defaults
 //! - Missing non-critical values use sensible defaults
 //! - Missing critical values (e.g., API key) return `MissingConfig` error
+//!
+//! # Migration
+//! New code should import directly from
+//! `crate::configuration::application::CliConfigLoader`.
+//! This re-export will be removed in a future update.
 
-use async_trait::async_trait;
-
-use crate::cli_boundary::domain::error::CliError;
-use crate::configuration::domain::config::CliConfig;
-
-/// Loads and merges CLI configuration from multiple sources.
-#[async_trait]
-pub trait CliConfigLoader: Send + Sync {
-    /// Load configuration from all sources and merge.
-    ///
-    /// Merge order (later overrides earlier):
-    /// 1. Engine defaults
-    /// 2. `rigorix.toml` from cwd or `--config` path
-    /// 3. Environment variables (`RIGORIX_*`)
-    /// 4. CLI flags (passed via `cli_overrides`)
-    ///
-    /// Returns `CliError::ConfigNotFound` if no config file is found
-    /// and no engine defaults apply.
-    /// Returns `CliError::MissingConfig` if a required value is missing.
-    async fn load(&self, cli_overrides: CliConfig) -> Result<CliConfig, CliError>;
-
-    /// Load configuration from an explicit file path.
-    ///
-    /// Skips automatic config discovery and uses the given path.
-    /// Still applies env var and CLI flag overrides on top.
-    async fn load_from_path(
-        &self,
-        path: &str,
-        cli_overrides: CliConfig,
-    ) -> Result<CliConfig, CliError>;
-
-    /// Check whether a configuration file exists at the default locations.
-    async fn has_default_config(&self) -> bool;
-
-    /// Get the list of config file paths that were searched.
-    async fn searched_paths(&self) -> Vec<String>;
-}
+pub use crate::configuration::application::service::CliConfigLoader;

--- a/cli/src/configuration/infrastructure/mod.rs
+++ b/cli/src/configuration/infrastructure/mod.rs
@@ -1,3 +1,14 @@
-//! Configuration infrastructure — config loading interfaces and implementation.
+//! Configuration infrastructure — config loading interfaces, implementation, repository.
+//!
+//! @canonical .pi/architecture/modules/configuration.md
+//! Implements: Contract Freeze — repository interfaces, CliConfigLoaderImpl
+//! Issue: issue-contract-freeze
+//!
+//! Infrastructure layer for CLI configuration operations:
+//! - `config.rs` re-exports `CliConfigLoader` trait from application/
+//! - `config_impl.rs` implements the trait via multi-source merging
+//! - `repository/` defines persistence interfaces for CLI-level config data
+
 pub mod config;
 pub mod config_impl;
+pub mod repository;

--- a/cli/src/configuration/infrastructure/repository/mod.rs
+++ b/cli/src/configuration/infrastructure/repository/mod.rs
@@ -1,0 +1,54 @@
+//! Repository interfaces for the CLI Configuration module.
+//!
+//! @canonical .pi/architecture/modules/configuration.md
+//! Implements: Contract Freeze — ConfigCliRepository trait
+//! Issue: issue-contract-freeze
+//!
+//! Repositories abstract CLI-level configuration data storage behind interfaces,
+//! allowing implementations to use in-memory caching, filesystem persistence,
+//! or mock storage without coupling CLI logic to infrastructure.
+//!
+//! These repositories handle CLI-level concerns (cached config values, user
+//! preferences for output format). They are distinct from the engine's config
+//! repositories which handle full configuration persistence.
+//!
+//! # Contract (Frozen)
+//! - All repository methods are async
+//! - All methods return domain error types
+//! - No framework-specific annotations on trait definitions
+//! - Implementations are hidden behind these interfaces
+
+use async_trait::async_trait;
+
+use crate::configuration::domain::ConfigCliError;
+use crate::configuration::domain::config::CliConfig;
+
+/// Repository for CLI-level configuration data.
+///
+/// Handles caching and persistence of CLI configuration values.
+/// This is separate from the engine's configuration system and is
+/// used for persisting user preferences and CLI state across sessions.
+///
+/// # Contract (Frozen)
+/// - Read operations return cached data or delegate to the engine
+/// - All methods are safe to call concurrently
+#[async_trait]
+pub trait ConfigCliRepository: Send + Sync {
+    /// Store the current CLI configuration.
+    async fn store_config(&self, config: CliConfig) -> Result<(), ConfigCliError>;
+
+    /// Retrieve the stored CLI configuration.
+    async fn get_config(&self) -> Result<Option<CliConfig>, ConfigCliError>;
+
+    /// Store a single configuration override for the next session.
+    async fn store_override(&self, key: &str, value: &str) -> Result<(), ConfigCliError>;
+
+    /// Retrieve all stored overrides.
+    async fn get_overrides(&self) -> Result<Vec<(String, String)>, ConfigCliError>;
+
+    /// Clear all stored configuration and overrides.
+    async fn clear(&self) -> Result<(), ConfigCliError>;
+
+    /// Get the list of config file paths that have been used.
+    async fn get_searched_paths(&self) -> Result<Vec<String>, ConfigCliError>;
+}

--- a/cli/src/configuration/interfaces/http/mod.rs
+++ b/cli/src/configuration/interfaces/http/mod.rs
@@ -1,0 +1,182 @@
+//! HTTP API contracts for CLI Configuration endpoints.
+//!
+//! @canonical .pi/architecture/modules/configuration.md
+//! Implements: Contract Freeze — HTTP endpoint contracts and error formats
+//! Issue: issue-contract-freeze
+//!
+//! Defines endpoint paths, methods, request/response schemas, and error
+//! response formats for CLI configuration operations. These contracts
+//! are framework-agnostic — they describe the API surface that any HTTP
+//! server implementation must satisfy.
+//!
+//! The CLI configuration module exposes operations for:
+//! - Loading configuration from files/env/flags
+//! - Querying current config values
+//! - Validating configuration completeness
+//!
+//! # Contract (Frozen)
+//! - All endpoints documented with method, path, request, and response types
+//! - Error responses follow a unified format
+//! - No framework-specific annotations (axum/actix/warp annotations added by implementation)
+
+use serde::{Deserialize, Serialize};
+
+use crate::configuration::application::dto::{
+    ConfigSource, LoadConfigOutput, ValidateConfigOutput,
+};
+
+// ---------------------------------------------------------------------------
+// API Base Path
+// ---------------------------------------------------------------------------
+
+/// All CLI configuration endpoints are served under this base path.
+pub const API_BASE_PATH: &str = "/api/v1/cli/config";
+
+// ---------------------------------------------------------------------------
+// Endpoint: GET /api/v1/cli/config
+// ---------------------------------------------------------------------------
+
+/// GET /api/v1/cli/config
+///
+/// Get the current CLI configuration.
+///
+/// **Response:** `200 OK` with `ConfigResponse`
+pub const GET_CONFIG_PATH: &str = "/api/v1/cli/config";
+pub const GET_CONFIG_METHOD: &str = "GET";
+
+/// Response for GET /api/v1/cli/config.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConfigResponse {
+    /// The output format.
+    pub output_format: String,
+    /// Whether TUI is enabled.
+    pub tui_enabled: bool,
+    /// The color mode.
+    pub color: String,
+    /// The log level.
+    pub log_level: String,
+    /// Whether an API key is configured.
+    pub api_key_configured: bool,
+    /// The primary source of configuration.
+    pub primary_source: String,
+}
+
+impl From<LoadConfigOutput> for ConfigResponse {
+    fn from(output: LoadConfigOutput) -> Self {
+        Self {
+            output_format: String::new(),
+            tui_enabled: false,
+            color: String::new(),
+            log_level: String::new(),
+            api_key_configured: output.api_key_configured,
+            primary_source: format!("{:?}", output.primary_source),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/cli/config/validate
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/cli/config/validate
+///
+/// Validate the current configuration.
+///
+/// **Request:** `ValidateConfigApiRequest`
+/// **Response:** `200 OK` with `ValidateConfigApiResponse`
+pub const VALIDATE_CONFIG_PATH: &str = "/api/v1/cli/config/validate";
+pub const VALIDATE_CONFIG_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/cli/config/validate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidateConfigApiRequest {
+    /// Whether to check for the API key.
+    #[serde(default = "default_true")]
+    pub check_api_key: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Response for POST /api/v1/cli/config/validate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidateConfigApiResponse {
+    pub valid: bool,
+    pub api_key_configured: bool,
+    pub errors: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+impl From<ValidateConfigOutput> for ValidateConfigApiResponse {
+    fn from(output: ValidateConfigOutput) -> Self {
+        Self {
+            valid: output.valid,
+            api_key_configured: output.api_key_configured,
+            errors: output.errors,
+            warnings: output.warnings,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/cli/config/reload
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/cli/config/reload
+///
+/// Reload configuration from the config file.
+///
+/// **Response:** `200 OK` with `ReloadConfigApiResponse`
+/// **Error:** `500 Internal Server Error` with `CliApiErrorResponse`
+pub const RELOAD_CONFIG_PATH: &str = "/api/v1/cli/config/reload";
+pub const RELOAD_CONFIG_METHOD: &str = "POST";
+
+/// Response for POST /api/v1/cli/config/reload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReloadConfigApiResponse {
+    pub success: bool,
+    pub config_path: Option<String>,
+    pub sources_used: Vec<ConfigSource>,
+}
+
+// ---------------------------------------------------------------------------
+// Unified Error Response Format
+// ---------------------------------------------------------------------------
+
+/// Standard error response for CLI Configuration API endpoints.
+///
+/// All 4xx/5xx responses use this format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CliApiErrorResponse {
+    /// HTTP status code.
+    pub status: u16,
+    /// Machine-readable error code.
+    pub code: String,
+    /// Human-readable error message.
+    pub message: String,
+    /// Detailed error context (optional).
+    pub details: Option<serde_json::Value>,
+    /// Request ID for tracing.
+    pub request_id: Option<String>,
+}
+
+/// Standardized error codes for CLI Configuration API.
+pub mod error_codes {
+    /// Configuration file not found.
+    pub const NOT_FOUND: &str = "CONFIG_NOT_FOUND";
+    /// Configuration parse error.
+    pub const PARSE_ERROR: &str = "CONFIG_PARSE_ERROR";
+    /// Missing required configuration value.
+    pub const MISSING_VALUE: &str = "CONFIG_MISSING_VALUE";
+    /// Internal server error.
+    pub const INTERNAL_ERROR: &str = "CONFIG_INTERNAL_ERROR";
+}
+
+/// HTTP status code mappings for CLI Configuration errors.
+pub mod status_codes {
+    pub const NOT_FOUND: u16 = 404;
+    pub const PARSE_ERROR: u16 = 400;
+    pub const MISSING_VALUE: u16 = 422;
+    pub const INTERNAL_ERROR: u16 = 500;
+}

--- a/cli/src/configuration/interfaces/mod.rs
+++ b/cli/src/configuration/interfaces/mod.rs
@@ -1,0 +1,10 @@
+//! Configuration interfaces — HTTP API contracts for CLI configuration.
+//!
+//! @canonical .pi/architecture/modules/configuration.md
+//! Implements: Contract Freeze — HTTP endpoint contracts
+//! Issue: issue-contract-freeze
+//!
+//! Defines the HTTP API surface for CLI configuration operations.
+//! These are framework-agnostic endpoint definitions.
+
+pub mod http;

--- a/cli/src/configuration/mod.rs
+++ b/cli/src/configuration/mod.rs
@@ -1,9 +1,48 @@
 //! Configuration module — CLI-side config loading and merging.
 //!
 //! @canonical .pi/architecture/modules/configuration.md
+//! Implements: Contract Freeze — CLI Configuration module (interfaces only)
+//! Issue: issue-contract-freeze
+//!
 //! Multi-source configuration loading with layered merging.
 //! CLI flags → env vars → rigorix.toml → engine defaults.
+//!
+//! # Architecture (Clean Architecture layers)
+//!
+//! ```text
+//! configuration/
+//! ├── domain/           # CliConfig, ConfigCliError, ConfigCliEvent
+//! │   ├── mod.rs
+//! │   ├── config.rs     # CliConfig value object
+//! │   ├── error.rs      # ConfigCliError enum
+//! │   └── event/        # ConfigCliEvent payload schemas
+//! │       └── mod.rs
+//! ├── application/      # Service traits, DTO schemas
+//! │   ├── mod.rs
+//! │   ├── service.rs    # CliConfigLoader trait
+//! │   └── dto/          # LoadConfigInput/Output, ValidateConfig types
+//! │       └── mod.rs
+//! ├── infrastructure/   # Trait implementations, repository interfaces
+//! │   ├── mod.rs
+//! │   ├── config.rs                   # Re-exports CliConfigLoader
+//! │   ├── config_impl.rs              # CliConfigLoaderImpl
+//! │   └── repository/                # ConfigCliRepository trait
+//! │       └── mod.rs
+//! └── interfaces/       # HTTP API contracts
+//!     ├── mod.rs
+//!     └── http/         # Endpoint definitions, request/response schemas
+//!         └── mod.rs
+//! ```
+//!
+//! # Contract Freeze Notice
+//!
+//! ALL interface files in this module are frozen contracts.
+//! - No implementation changes without explicit contract change approval
+//! - Implementation PRs MUST reference these interfaces
+//! - DTO schemas serve as the canonical data contract
+//! - The CliConfigLoader trait is the primary service contract
 
 pub mod application;
 pub mod domain;
 pub mod infrastructure;
+pub mod interfaces;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -28,8 +28,10 @@
 //! │   ├── interfaces/   # Clap CLI command definitions
 //! │   └── tui/          # Ratatui TUI renderer
 //! ├── configuration/    # Multi-source config loading
-//! │   ├── domain/       # CliConfig value object
-//! │   └── infrastructure/ # CliConfigLoader trait + impl
+//! │   ├── domain/       # CliConfig, ConfigCliError, ConfigCliEvent
+//! │   ├── application/  # CliConfigLoader trait, DTO schemas
+//! │   ├── infrastructure/ # CliConfigLoaderImpl, ConfigCliRepository
+//! │   └── interfaces/   # HTTP API contracts
 //! ├── observability/    # Tracing, health checks, event schemas
 //! │   ├── domain/       # ObservabilityEvent schemas
 //! │   └── infrastructure/ # TracingInitializer trait + tracing impl


### PR DESCRIPTION
Closes #282

## Summary
Define and freeze all public interfaces for the CLI Configuration module before implementation begins.

### Contract Freeze Coverage

**Domain layer:** ConfigCliError (6 variants), ConfigCliEvent (7 events)
**Application layer:** CliConfigLoader trait, LoadConfig/ValidateConfig DTOs
**Infrastructure layer:** ConfigCliRepository (6 methods), re-exports from application
**Interfaces layer:** 3 API endpoints (get config, validate, reload) + error format