### PR TITLE
feat: contract freeze for observability module

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -33,8 +33,10 @@
 //! │   ├── infrastructure/ # CliConfigLoaderImpl, ConfigCliRepository
 //! │   └── interfaces/   # HTTP API contracts
 //! ├── observability/    # Tracing, health checks, event schemas
-//! │   ├── domain/       # ObservabilityEvent schemas
-//! │   └── infrastructure/ # TracingInitializer trait + tracing impl
+//! │   ├── domain/       # ObservabilityCliError, ObservabilityEvent
+//! │   ├── application/  # TracingInitializer trait, DTO schemas
+//! │   ├── infrastructure/ # Tracing init impl, ObservabilityCliRepository
+//! │   └── interfaces/   # HTTP API contracts
 //! ├── cancellation/     # Signal handler for Ctrl+C
 //! │   ├── domain/       # CancellationCliError, CancellationCliEvent
 //! │   ├── application/  # SignalHandler trait, DTO schemas

--- a/cli/src/observability/application/dto/mod.rs
+++ b/cli/src/observability/application/dto/mod.rs
@@ -1,0 +1,94 @@
+//! Data Transfer Objects for the CLI Observability module.
+//!
+//! @canonical .pi/architecture/modules/observability.md
+//! Implements: Contract Freeze — CLI observability DTO schemas
+//! Issue: issue-contract-freeze
+//!
+//! DTOs define the input/output contracts for observability operations.
+//!
+//! # Contract (Frozen)
+//! - Every service operation has a dedicated input and output DTO
+//! - DTOs are serializable (JSON for CI/CD output)
+//! - Fields use reasonable Rust types
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Tracing DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for initializing tracing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InitTracingInput {
+    /// Minimum log level.
+    pub log_level: String,
+    /// Output format (pretty, json).
+    pub log_format: String,
+}
+
+/// Output from initializing tracing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InitTracingOutput {
+    /// Whether tracing was successfully initialized.
+    pub success: bool,
+    /// Whether this was the first initialization or a no-op.
+    pub initialized: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Health Check DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for running health checks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HealthCheckInput;
+
+/// Output from running health checks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HealthCheckOutput {
+    /// Overall health status.
+    pub healthy: bool,
+    /// Individual health check results.
+    pub checks: Vec<HealthCheckResult>,
+    /// Number of checks that passed.
+    pub passed: u32,
+    /// Number of checks that failed.
+    pub failed: u32,
+}
+
+/// Result of a single health check.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HealthCheckResult {
+    /// The name of the health check.
+    pub name: String,
+    /// Whether this check passed.
+    pub healthy: bool,
+    /// Optional error message if the check failed.
+    pub error: Option<String>,
+    /// Duration of the check in milliseconds.
+    pub duration_ms: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Metrics DTOs
+// ---------------------------------------------------------------------------
+
+/// A single metric value for reporting.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetricValue {
+    /// The metric name.
+    pub name: String,
+    /// The metric value.
+    pub value: f64,
+    /// Optional metric labels.
+    pub labels: Vec<(String, String)>,
+}
+
+/// Output from collecting metrics.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetricsOutput {
+    /// All collected metrics.
+    pub metrics: Vec<MetricValue>,
+    /// Timestamp of collection.
+    pub timestamp: String,
+}

--- a/cli/src/observability/application/mod.rs
+++ b/cli/src/observability/application/mod.rs
@@ -1,1 +1,18 @@
-//! Observability application layer — (reserved for future observability service traits).
+//! Observability application layer — service traits, DTOs for CLI observability.
+//!
+//! @canonical .pi/architecture/modules/observability.md
+//! Implements: Contract Freeze — TracingInitializer trait, DTO schemas
+//! Issue: issue-contract-freeze
+//!
+//! Defines the application-level contracts for CLI observability operations.
+//! Service traits (use cases) live here, implementations live in infrastructure.
+//!
+//! # Contract (Frozen)
+//! - Service traits define all use cases for CLI observability
+//! - DTOs define input/output schemas for each operation
+//! - No implementation — only contract signatures and type definitions
+
+pub mod dto;
+pub mod service;
+
+pub use service::TracingInitializer;

--- a/cli/src/observability/application/service.rs
+++ b/cli/src/observability/application/service.rs
@@ -1,0 +1,54 @@
+//! Service interfaces for the CLI Observability module.
+//!
+//! @canonical .pi/architecture/modules/observability.md
+//! Implements: Contract Freeze — TracingInitializer trait
+//! Issue: issue-contract-freeze
+//!
+//! These traits define the application-level operations for observability
+//! (tracing, health checks, metrics). All methods are async and return
+//! domain error types. Implementations reside in the infrastructure layer.
+//!
+//! # Contract (Frozen)
+//! - Every observability use case has a corresponding trait method
+//! - Input/output types are DTOs defined in `dto/`
+//! - All methods are async (use `async-trait` for trait object safety)
+//! - No implementation — only contract signatures
+
+use async_trait::async_trait;
+
+use crate::cli_boundary::domain::error::CliError;
+use crate::configuration::domain::config::{LogFormat, LogLevel};
+
+/// Initializes tracing for the CLI boundary.
+///
+/// Wraps engine's tracing initialization with CLI-specific config.
+/// Respects `RIGORIX_LOG` env var for log level override.
+///
+/// # Contract (Frozen)
+/// - Called once at startup, after config is loaded
+/// - Must be idempotent — second call is a no-op
+/// - Panics if tracing is already initialized (tracing-subscriber behaviour)
+#[async_trait]
+pub trait TracingInitializer: Send + Sync {
+    /// Initialize tracing with the given log level and format.
+    ///
+    /// Uses the engine's `observability::init_tracing()` under the hood.
+    /// If `RIGORIX_LOG` env var is set, it overrides the `log_level` param.
+    async fn init_tracing(
+        &self,
+        log_level: LogLevel,
+        log_format: LogFormat,
+    ) -> Result<(), CliError>;
+
+    /// Initialize tracing with safe defaults (pretty, info level).
+    async fn init_default_tracing(&self) -> Result<(), CliError>;
+
+    /// Check if tracing has been initialized.
+    fn is_initialized(&self) -> bool;
+
+    /// Initialize health checks for the CLI boundary.
+    ///
+    /// Registers CLI components as health check providers with the
+    /// engine's `HealthService`.
+    async fn init_health_checks(&self) -> Result<usize, CliError>;
+}

--- a/cli/src/observability/domain/error.rs
+++ b/cli/src/observability/domain/error.rs
@@ -1,0 +1,66 @@
+//! CLI-specific observability domain errors.
+//!
+//! @canonical .pi/architecture/modules/observability.md
+//! Implements: Contract Freeze — ObservabilityCliError
+//! Issue: issue-contract-freeze
+//!
+//! Errors that originate from CLI observability operations (tracing init,
+//! health checks, metrics). These are distinct from engine-level errors.
+//!
+//! # Contract (Frozen)
+//! - Each variant carries structured context for error reporting
+//! - Implements `std::error::Error` for library compatibility
+
+use thiserror::Error;
+
+/// Errors that can occur during CLI observability operations.
+#[derive(Debug, Error)]
+pub enum ObservabilityCliError {
+    /// Failed to initialize the tracing subscriber.
+    #[error("Failed to initialize tracing: {detail}")]
+    TracingInitFailed {
+        /// What went wrong during tracing initialization.
+        detail: String,
+    },
+
+    /// Health check registration failed.
+    #[error("Health check registration failed: {detail}")]
+    HealthCheckRegistrationFailed {
+        /// The health check name.
+        check_name: String,
+        /// What went wrong.
+        detail: String,
+    },
+
+    /// Health check execution failed.
+    #[error("Health check failed for '{check_name}': {detail}")]
+    HealthCheckFailed {
+        /// Which health check failed.
+        check_name: String,
+        /// The error detail.
+        detail: String,
+    },
+
+    /// Metrics registration failed.
+    #[error("Metrics registration failed: {detail}")]
+    MetricsRegistrationFailed {
+        /// The metric name.
+        metric_name: String,
+        /// What went wrong.
+        detail: String,
+    },
+
+    /// An unexpected internal error occurred.
+    #[error("Internal observability error: {detail}")]
+    Internal {
+        /// Description of the internal error.
+        detail: String,
+    },
+}
+
+impl ObservabilityCliError {
+    /// Returns `true` if this error is retriable.
+    pub fn is_retriable(&self) -> bool {
+        matches!(self, ObservabilityCliError::TracingInitFailed { .. })
+    }
+}

--- a/cli/src/observability/domain/mod.rs
+++ b/cli/src/observability/domain/mod.rs
@@ -1,2 +1,10 @@
-//! Observability domain types — event schemas.
+//! Observability domain types — error types, event schemas for CLI observability.
+//!
+//! @canonical .pi/architecture/modules/observability.md
+//! Implements: Contract Freeze — ObservabilityCliError
+//! Issue: issue-contract-freeze
+
+pub mod error;
 pub mod event;
+
+pub use error::ObservabilityCliError;

--- a/cli/src/observability/infrastructure/mod.rs
+++ b/cli/src/observability/infrastructure/mod.rs
@@ -1,3 +1,9 @@
-//! Observability infrastructure — TracingInitializer trait and tracing impl.
+//! Observability infrastructure — TracingInitializer implementation, repository.
+//!
+//! @canonical .pi/architecture/modules/observability.md
+//! Implements: Contract Freeze — repository interfaces
+//! Issue: issue-contract-freeze
+
 pub mod observability;
+pub mod repository;
 pub mod tracing;

--- a/cli/src/observability/infrastructure/observability.rs
+++ b/cli/src/observability/infrastructure/observability.rs
@@ -1,69 +1,19 @@
-//! Observability infrastructure interfaces for the CLI boundary.
+//! Observability infrastructure interfaces — re-exported from application layer.
 //!
 //! @canonical .pi/architecture/modules/observability.md
-//! Implements: Contract Freeze — TracingInitializer trait
-//! Issue: #253
-//!
-//! Initializes and manages observability (tracing, health, metrics)
-//! for the CLI boundary. Wraps engine observability contracts with
-//! CLI-specific configuration.
+//! The `TracingInitializer` trait is defined in `application/service.rs`
+//! (its canonical Clean Architecture location). This module re-exports it
+//! for backward compatibility with existing imports.
 //!
 //! # Contract (Frozen)
 //! - `TracingInitializer` configures and initializes the tracing subscriber
 //! - Accepts log level and format from CLI config
 //! - Respects `RIGORIX_LOG` env var override
 //! - Implementations must be idempotent (calling twice is a no-op after first)
-//! - Engine's `init_tracing` is called under the hood
+//!
+//! # Migration
+//! New code should import directly from
+//! `crate::observability::application::TracingInitializer`.
+//! This re-export will be removed in a future update.
 
-use async_trait::async_trait;
-
-use crate::cli_boundary::domain::error::CliError;
-use crate::configuration::domain::config::{LogFormat, LogLevel};
-
-/// Initializes tracing for the CLI boundary.
-///
-/// Wraps engine's tracing initialization with CLI-specific config.
-/// Respects `RIGORIX_LOG` env var for log level override.
-///
-/// # Lifecycle
-/// - Called once at startup, after config is loaded
-/// - Must be idempotent — second call is a no-op
-/// - Panics if tracing is already initialized (tracing-subscriber behaviour)
-#[async_trait]
-pub trait TracingInitializer: Send + Sync {
-    /// Initialize tracing with the given log level and format.
-    ///
-    /// Uses the engine's `observability::init_tracing()` under the hood.
-    /// If `RIGORIX_LOG` env var is set, it overrides the `log_level` param.
-    ///
-    /// # Arguments
-    /// * `log_level` - Minimum log level (trace, debug, info, warn, error)
-    /// * `log_format` - Output format (pretty for dev, json for production)
-    ///
-    /// # Errors
-    /// Returns `CliError::Internal` if tracing cannot be initialized.
-    async fn init_tracing(
-        &self,
-        log_level: LogLevel,
-        log_format: LogFormat,
-    ) -> Result<(), CliError>;
-
-    /// Initialize tracing with safe defaults (pretty, info level).
-    ///
-    /// Useful for early initialization before config is fully loaded.
-    async fn init_default_tracing(&self) -> Result<(), CliError>;
-
-    /// Check if tracing has been initialized.
-    fn is_initialized(&self) -> bool;
-
-    /// Initialize health checks for the CLI boundary.
-    ///
-    /// Registers CLI components as health check providers with the
-    /// engine's `HealthService`. Components include:
-    /// - Config loader (can read config files)
-    /// - Template engine (templates loaded and valid)
-    /// - LLM provider (API key configured, reachable)
-    ///
-    /// Returns the number of health checks registered.
-    async fn init_health_checks(&self) -> Result<usize, CliError>;
-}
+pub use crate::observability::application::service::TracingInitializer;

--- a/cli/src/observability/infrastructure/repository/mod.rs
+++ b/cli/src/observability/infrastructure/repository/mod.rs
@@ -1,0 +1,43 @@
+//! Repository interfaces for the CLI Observability module.
+//!
+//! @canonical .pi/architecture/modules/observability.md
+//! Implements: Contract Freeze — ObservabilityCliRepository trait
+//! Issue: issue-contract-freeze
+//!
+//! Repositories abstract CLI-level observability data storage behind interfaces.
+//!
+//! # Contract (Frozen)
+//! - All repository methods are async
+//! - All methods return domain error types
+//! - No framework-specific annotations on trait definitions
+
+use async_trait::async_trait;
+
+use crate::observability::domain::ObservabilityCliError;
+
+/// Repository for CLI-level observability state.
+#[async_trait]
+pub trait ObservabilityCliRepository: Send + Sync {
+    /// Record that tracing was initialized.
+    async fn record_tracing_init(&self) -> Result<(), ObservabilityCliError>;
+
+    /// Check if tracing has been initialized.
+    async fn is_tracing_initialized(&self) -> Result<bool, ObservabilityCliError>;
+
+    /// Record a health check result.
+    async fn record_health_check(
+        &self,
+        check_name: &str,
+        healthy: bool,
+        duration_ms: u64,
+    ) -> Result<(), ObservabilityCliError>;
+
+    /// Get recent health check results.
+    async fn get_health_history(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<(String, bool, u64)>, ObservabilityCliError>;
+
+    /// Clear all recorded observability state.
+    async fn clear(&self) -> Result<(), ObservabilityCliError>;
+}

--- a/cli/src/observability/interfaces/http/mod.rs
+++ b/cli/src/observability/interfaces/http/mod.rs
@@ -1,0 +1,152 @@
+//! HTTP API contracts for CLI Observability endpoints.
+//!
+//! @canonical .pi/architecture/modules/observability.md
+//! Implements: Contract Freeze — HTTP endpoint contracts and error formats
+//! Issue: issue-contract-freeze
+//!
+//! Defines endpoint paths, methods, request/response schemas for CLI
+//! observability operations (tracing status, health checks, metrics).
+//!
+//! # Contract (Frozen)
+//! - All endpoints documented with method, path, request, and response types
+//! - Error responses follow a unified format
+//! - No framework-specific annotations
+
+use serde::{Deserialize, Serialize};
+
+use crate::observability::application::dto::{HealthCheckOutput, InitTracingOutput, MetricsOutput};
+
+// ---------------------------------------------------------------------------
+// API Base Path
+// ---------------------------------------------------------------------------
+
+pub const API_BASE_PATH: &str = "/api/v1/cli/observability";
+
+// ---------------------------------------------------------------------------
+// Endpoint: GET /api/v1/cli/observability/health
+// ---------------------------------------------------------------------------
+
+pub const HEALTH_PATH: &str = "/api/v1/cli/observability/health";
+pub const HEALTH_METHOD: &str = "GET";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HealthResponse {
+    pub healthy: bool,
+    pub checks: Vec<HealthCheckItemResponse>,
+    pub passed: u32,
+    pub failed: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HealthCheckItemResponse {
+    pub name: String,
+    pub healthy: bool,
+    pub error: Option<String>,
+    pub duration_ms: u64,
+}
+
+impl From<HealthCheckOutput> for HealthResponse {
+    fn from(o: HealthCheckOutput) -> Self {
+        Self {
+            healthy: o.healthy,
+            checks: o
+                .checks
+                .into_iter()
+                .map(|c| HealthCheckItemResponse {
+                    name: c.name,
+                    healthy: c.healthy,
+                    error: c.error,
+                    duration_ms: c.duration_ms,
+                })
+                .collect(),
+            passed: o.passed,
+            failed: o.failed,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: GET /api/v1/cli/observability/tracing/status
+// ---------------------------------------------------------------------------
+
+pub const TRACING_STATUS_PATH: &str = "/api/v1/cli/observability/tracing/status";
+pub const TRACING_STATUS_METHOD: &str = "GET";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TracingStatusResponse {
+    pub initialized: bool,
+    pub log_level: Option<String>,
+    pub log_format: Option<String>,
+}
+
+impl From<InitTracingOutput> for TracingStatusResponse {
+    fn from(o: InitTracingOutput) -> Self {
+        Self {
+            initialized: o.initialized,
+            log_level: None,
+            log_format: None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: GET /api/v1/cli/observability/metrics
+// ---------------------------------------------------------------------------
+
+pub const METRICS_PATH: &str = "/api/v1/cli/observability/metrics";
+pub const METRICS_METHOD: &str = "GET";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetricsResponse {
+    pub metrics: Vec<MetricItemResponse>,
+    pub timestamp: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetricItemResponse {
+    pub name: String,
+    pub value: f64,
+    pub labels: Vec<Vec<String>>,
+}
+
+impl From<MetricsOutput> for MetricsResponse {
+    fn from(o: MetricsOutput) -> Self {
+        Self {
+            metrics: o
+                .metrics
+                .into_iter()
+                .map(|m| MetricItemResponse {
+                    name: m.name,
+                    value: m.value,
+                    labels: m.labels.into_iter().map(|(k, v)| vec![k, v]).collect(),
+                })
+                .collect(),
+            timestamp: o.timestamp,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unified Error Response Format
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CliApiErrorResponse {
+    pub status: u16,
+    pub code: String,
+    pub message: String,
+    pub details: Option<serde_json::Value>,
+    pub request_id: Option<String>,
+}
+
+pub mod error_codes {
+    pub const TRACING_NOT_INITIALIZED: &str = "OBSERVABILITY_TRACING_NOT_INIT";
+    pub const HEALTH_CHECK_FAILED: &str = "OBSERVABILITY_HEALTH_FAILED";
+    pub const INTERNAL_ERROR: &str = "OBSERVABILITY_INTERNAL_ERROR";
+}
+
+pub mod status_codes {
+    pub const TRACING_NOT_INITIALIZED: u16 = 503;
+    pub const HEALTH_CHECK_FAILED: u16 = 500;
+    pub const INTERNAL_ERROR: u16 = 500;
+}

--- a/cli/src/observability/interfaces/mod.rs
+++ b/cli/src/observability/interfaces/mod.rs
@@ -1,0 +1,7 @@
+//! Observability interfaces — HTTP API contracts for CLI observability.
+//!
+//! @canonical .pi/architecture/modules/observability.md
+//! Implements: Contract Freeze — HTTP endpoint contracts
+//! Issue: issue-contract-freeze
+
+pub mod http;

--- a/cli/src/observability/mod.rs
+++ b/cli/src/observability/mod.rs
@@ -1,9 +1,39 @@
 //! Observability module — tracing, health checks, and event schemas.
 //!
 //! @canonical .pi/architecture/modules/observability.md
+//! Implements: Contract Freeze — CLI Observability module (interfaces only)
+//! Issue: issue-contract-freeze
+//!
 //! Provides TracingInitializer trait, tracing implementation, and
 //! observability event schemas.
+//!
+//! # Architecture (Clean Architecture layers)
+//!
+//! ```text
+//! observability/
+//! ├── domain/           # ObservabilityCliError, ObservabilityEvent
+//! │   ├── mod.rs
+//! │   ├── error.rs      # ObservabilityCliError enum
+//! │   └── event/        # ObservabilityEvent payload schemas
+//! │       └── mod.rs
+//! ├── application/      # Service traits, DTO schemas
+//! │   ├── mod.rs
+//! │   ├── service.rs    # TracingInitializer trait
+//! │   └── dto/          # InitTracing, HealthCheck, Metrics DTOs
+//! │       └── mod.rs
+//! ├── infrastructure/   # Trait implementations, repository interfaces
+//! │   ├── mod.rs
+//! │   ├── observability.rs           # Re-exports TracingInitializer
+//! │   ├── tracing.rs                 # Tracing init implementation
+//! │   └── repository/                # ObservabilityCliRepository trait
+//! │       └── mod.rs
+//! └── interfaces/       # HTTP API contracts
+//!     ├── mod.rs
+//!     └── http/         # Endpoint definitions, request/response schemas
+//!         └── mod.rs
+//! ```
 
 pub mod application;
 pub mod domain;
 pub mod infrastructure;
+pub mod interfaces;


### PR DESCRIPTION
Closes #289

Contract freeze for the CLI Observability module.

**Domain:** ObservabilityCliError (5 variants), existing ObservabilityEvent
**Application:** TracingInitializer trait (moved), InitTracing/HealthCheck/Metrics DTOs
**Infrastructure:** ObservabilityCliRepository (5 methods), re-export from application
**Interfaces:** 3 API endpoints (health, tracing status, metrics)