### PR TITLE
feat: contract freeze for template-generation module

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -60,6 +60,7 @@ pub mod cancellation;
 pub mod cli_boundary;
 pub mod configuration;
 pub mod observability;
+pub mod template_generation;
 pub mod templates;
 
 // Tests are defined in cli_boundary::tests which is #[cfg(test)] only.

--- a/cli/src/template_generation/application/dto/mod.rs
+++ b/cli/src/template_generation/application/dto/mod.rs
@@ -1,0 +1,46 @@
+//! Data Transfer Objects for the CLI Template Generation module.
+//!
+//! @canonical .pi/architecture/modules/template-generation.md
+//! Implements: Contract Freeze — CLI template generation DTO schemas
+//! Issue: issue-contract-freeze
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GenerateInput {
+    pub intent: String,
+    pub stdout: bool,
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GenerateOutput {
+    pub template_id: String,
+    pub saved_path: Option<String>,
+    pub persisted: bool,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DryRunInput {
+    pub intent: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DryRunOutput {
+    pub template_id: String,
+    pub content: String,
+    pub valid: bool,
+    pub errors: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CostEstimateInput {
+    pub intent: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CostEstimateOutput {
+    pub estimated_calls: u32,
+    pub estimated_tokens: u32,
+}

--- a/cli/src/template_generation/application/mod.rs
+++ b/cli/src/template_generation/application/mod.rs
@@ -1,0 +1,10 @@
+//! Template generation application layer — service traits and DTOs.
+//!
+//! @canonical .pi/architecture/modules/template-generation.md
+//! Implements: Contract Freeze — GenerateCommandService trait, DTOs
+//! Issue: issue-contract-freeze
+
+pub mod dto;
+pub mod service;
+
+pub use service::GenerateCommandService;

--- a/cli/src/template_generation/application/service.rs
+++ b/cli/src/template_generation/application/service.rs
@@ -1,0 +1,30 @@
+//! Service interfaces for the CLI Template Generation module.
+//!
+//! @canonical .pi/architecture/modules/template-generation.md
+//! Implements: Contract Freeze — GenerateCommandService trait
+//! Issue: issue-contract-freeze
+//!
+//! Wraps the engine's TemplateGenerator for CLI consumption.
+
+use async_trait::async_trait;
+
+use crate::cli_boundary::domain::error::CliError;
+use crate::configuration::domain::config::CliConfig;
+
+use super::dto::{
+    CostEstimateInput, CostEstimateOutput, DryRunInput, DryRunOutput, GenerateInput, GenerateOutput,
+};
+
+#[async_trait]
+pub trait GenerateCommandService: Send + Sync {
+    async fn new(config: CliConfig) -> Result<Self, CliError>
+    where
+        Self: Sized;
+
+    async fn generate(&self, input: GenerateInput) -> Result<GenerateOutput, CliError>;
+
+    async fn dry_run(&self, input: DryRunInput) -> Result<DryRunOutput, CliError>;
+
+    async fn estimate_cost(&self, input: CostEstimateInput)
+    -> Result<CostEstimateOutput, CliError>;
+}

--- a/cli/src/template_generation/domain/error.rs
+++ b/cli/src/template_generation/domain/error.rs
@@ -1,0 +1,37 @@
+//! CLI-specific template generation errors.
+//!
+//! @canonical .pi/architecture/modules/template-generation.md
+//! Implements: Contract Freeze — GenerationCliError
+//! Issue: issue-contract-freeze
+//!
+//! Errors that originate from CLI template generation operations.
+//! Distinct from the engine's `GeneratorError`.
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum GenerationCliError {
+    #[error("Generation failed: {detail}")]
+    GenerationFailed { detail: String },
+
+    #[error("Failed to persist generated template: {detail}")]
+    PersistFailed { path: String, detail: String },
+
+    #[error("Template validation after generation failed: {errors:?}")]
+    ValidationFailed { errors: Vec<String> },
+
+    #[error("LLM budget exceeded for generation: {detail}")]
+    BudgetExceeded { detail: String },
+
+    #[error("Repository context build failed: {detail}")]
+    RepoContextFailed { detail: String },
+
+    #[error("Internal error: {detail}")]
+    Internal { detail: String },
+}
+
+impl GenerationCliError {
+    pub fn is_retriable(&self) -> bool {
+        matches!(self, GenerationCliError::GenerationFailed { .. })
+    }
+}

--- a/cli/src/template_generation/domain/event/mod.rs
+++ b/cli/src/template_generation/domain/event/mod.rs
@@ -1,0 +1,30 @@
+//! Event payload schemas for the CLI Template Generation module.
+//!
+//! @canonical .pi/architecture/modules/template-generation.md
+//! Implements: Contract Freeze — TemplateGenerationCliEvent
+//! Issue: issue-contract-freeze
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TemplateGenerationCliEvent {
+    GenerationRequested {
+        intent: String,
+        dry_run: bool,
+    },
+    GenerationCompleted {
+        template_id: String,
+        persisted: bool,
+    },
+    GenerationFailed {
+        intent: String,
+        error: String,
+    },
+    TemplatePersisted {
+        template_id: String,
+        path: String,
+    },
+    DryRunCompleted {
+        content: String,
+    },
+}

--- a/cli/src/template_generation/domain/mod.rs
+++ b/cli/src/template_generation/domain/mod.rs
@@ -1,0 +1,11 @@
+//! Template generation domain types.
+//!
+//! @canonical .pi/architecture/modules/template-generation.md
+//! Implements: Contract Freeze — GenerationCliError, TemplateGenerationCliEvent
+//! Issue: issue-contract-freeze
+
+pub mod error;
+pub mod event;
+
+pub use error::GenerationCliError;
+pub use event::TemplateGenerationCliEvent;

--- a/cli/src/template_generation/infrastructure/mod.rs
+++ b/cli/src/template_generation/infrastructure/mod.rs
@@ -1,0 +1,7 @@
+//! Template generation infrastructure — repository interfaces.
+//!
+//! @canonical .pi/architecture/modules/template-generation.md
+//! Implements: Contract Freeze — repository interfaces
+//! Issue: issue-contract-freeze
+
+pub mod repository;

--- a/cli/src/template_generation/infrastructure/repository/mod.rs
+++ b/cli/src/template_generation/infrastructure/repository/mod.rs
@@ -1,0 +1,32 @@
+//! Repository interfaces for the CLI Template Generation module.
+//!
+//! @canonical .pi/architecture/modules/template-generation.md
+//! Implements: Contract Freeze — TemplateGenerationRepository trait
+//! Issue: issue-contract-freeze
+
+use async_trait::async_trait;
+
+use crate::template_generation::domain::GenerationCliError;
+
+#[async_trait]
+pub trait TemplateGenerationRepository: Send + Sync {
+    async fn store_generated_template(
+        &self,
+        template_id: &str,
+        content: &str,
+    ) -> Result<(), GenerationCliError>;
+
+    async fn get_generated_template(
+        &self,
+        template_id: &str,
+    ) -> Result<Option<String>, GenerationCliError>;
+
+    async fn list_generated_templates(&self) -> Result<Vec<String>, GenerationCliError>;
+
+    async fn delete_generated_template(
+        &self,
+        template_id: &str,
+    ) -> Result<bool, GenerationCliError>;
+
+    async fn clear(&self) -> Result<(), GenerationCliError>;
+}

--- a/cli/src/template_generation/interfaces/http/mod.rs
+++ b/cli/src/template_generation/interfaces/http/mod.rs
@@ -1,0 +1,108 @@
+//! HTTP API contracts for CLI Template Generation endpoints.
+//!
+//! @canonical .pi/architecture/modules/template-generation.md
+//! Implements: Contract Freeze — HTTP endpoint contracts
+//! Issue: issue-contract-freeze
+
+use serde::{Deserialize, Serialize};
+
+use crate::template_generation::application::dto::{
+    CostEstimateOutput, DryRunOutput, GenerateOutput,
+};
+
+pub const API_BASE_PATH: &str = "/api/v1/cli/template-generation";
+
+pub const GENERATE_PATH: &str = "/api/v1/cli/template-generation/generate";
+pub const GENERATE_METHOD: &str = "POST";
+
+pub const DRY_RUN_PATH: &str = "/api/v1/cli/template-generation/dry-run";
+pub const DRY_RUN_METHOD: &str = "POST";
+
+pub const ESTIMATE_COST_PATH: &str = "/api/v1/cli/template-generation/estimate-cost";
+pub const ESTIMATE_COST_METHOD: &str = "POST";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GenerateApiRequest {
+    pub intent: String,
+    #[serde(default)]
+    pub stdout: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GenerateApiResponse {
+    pub template_id: String,
+    pub saved_path: Option<String>,
+    pub persisted: bool,
+    pub content: String,
+}
+
+impl From<GenerateOutput> for GenerateApiResponse {
+    fn from(o: GenerateOutput) -> Self {
+        Self {
+            template_id: o.template_id,
+            saved_path: o.saved_path,
+            persisted: o.persisted,
+            content: o.content,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DryRunApiRequest {
+    pub intent: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DryRunApiResponse {
+    pub template_id: String,
+    pub content: String,
+    pub valid: bool,
+    pub errors: Vec<String>,
+}
+
+impl From<DryRunOutput> for DryRunApiResponse {
+    fn from(o: DryRunOutput) -> Self {
+        Self {
+            template_id: o.template_id,
+            content: o.content,
+            valid: o.valid,
+            errors: o.errors,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CostEstimateApiResponse {
+    pub estimated_calls: u32,
+    pub estimated_tokens: u32,
+}
+
+impl From<CostEstimateOutput> for CostEstimateApiResponse {
+    fn from(o: CostEstimateOutput) -> Self {
+        Self {
+            estimated_calls: o.estimated_calls,
+            estimated_tokens: o.estimated_tokens,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CliApiErrorResponse {
+    pub status: u16,
+    pub code: String,
+    pub message: String,
+    pub details: Option<serde_json::Value>,
+    pub request_id: Option<String>,
+}
+
+pub mod error_codes {
+    pub const GENERATION_FAILED: &str = "TEMPLATE_GENERATION_FAILED";
+    pub const BUDGET_EXCEEDED: &str = "TEMPLATE_GENERATION_BUDGET_EXCEEDED";
+    pub const INTERNAL_ERROR: &str = "TEMPLATE_GENERATION_INTERNAL_ERROR";
+}
+
+pub mod status_codes {
+    pub const GENERATION_FAILED: u16 = 422;
+    pub const BUDGET_EXCEEDED: u16 = 402;
+    pub const INTERNAL_ERROR: u16 = 500;
+}

--- a/cli/src/template_generation/interfaces/mod.rs
+++ b/cli/src/template_generation/interfaces/mod.rs
@@ -1,0 +1,7 @@
+//! Template generation interfaces — HTTP API contracts.
+//!
+//! @canonical .pi/architecture/modules/template-generation.md
+//! Implements: Contract Freeze — HTTP endpoint contracts
+//! Issue: issue-contract-freeze
+
+pub mod http;

--- a/cli/src/template_generation/mod.rs
+++ b/cli/src/template_generation/mod.rs
@@ -1,0 +1,36 @@
+//! Template Generation module — CLI wrapper for LLM-based template creation.
+//!
+//! @canonical .pi/architecture/modules/template-generation.md
+//! Implements: Contract Freeze — CLI Template Generation module (interfaces only)
+//! Issue: issue-contract-freeze
+//!
+//! Wraps the engine's TemplateGenerator for CLI consumption via `rigorix generate`.
+//!
+//! # Architecture
+//!
+//! ```text
+//! template_generation/
+//! ├── domain/           # GenerationCliError, TemplateGenerationCliEvent
+//! │   ├── mod.rs
+//! │   ├── error.rs      # GenerationCliError enum
+//! │   └── event/        # TemplateGenerationCliEvent payload schemas
+//! │       └── mod.rs
+//! ├── application/      # Service traits, DTO schemas
+//! │   ├── mod.rs
+//! │   ├── service.rs    # GenerateCommandService trait
+//! │   └── dto/          # GenerateInput/Output, DryRunInput/Output
+//! │       └── mod.rs
+//! ├── infrastructure/   # Repository interfaces
+//! │   ├── mod.rs
+//! │   └── repository/   # TemplateGenerationRepository trait
+//! │       └── mod.rs
+//! └── interfaces/       # HTTP API contracts
+//!     ├── mod.rs
+//!     └── http/         # Endpoint definitions, request/response schemas
+//!         └── mod.rs
+//! ```
+
+pub mod application;
+pub mod domain;
+pub mod infrastructure;
+pub mod interfaces;


### PR DESCRIPTION
Closes #303

Create full CLI template_generation module with Clean Architecture contract freeze.

**Domain:** GenerationCliError (6 variants), TemplateGenerationCliEvent (5 events)
**Application:** GenerateCommandService trait (generate, dry_run, estimate_cost)
**Infrastructure:** TemplateGenerationRepository trait (5 methods)
**Interfaces:** 3 API endpoints (generate, dry-run, estimate-cost)