### PR TITLE
[Issue #338] Contract freeze: orchestrator — all interfaces, DTOs, events, and API contracts defined

### DIFF
--- a/engine/src/error.rs
+++ b/engine/src/error.rs
@@ -32,6 +32,7 @@ use crate::enforcement::domain::EnforcementError;
 use crate::event_system::domain::EventSystemError;
 use crate::execution_engine::domain::ExecutionError;
 use crate::failure_classification::domain::FailureClassificationError;
+use crate::orchestrator::domain::OrchestratorError;
 use crate::planning::domain::PlanningError;
 use crate::repo_engine::domain::RepoEngineError;
 use crate::state_persistence::domain::StateError;
@@ -107,6 +108,10 @@ pub enum CoreOrchestratorError {
     #[error("Template error: {0}")]
     Template(#[from] TemplateError),
 
+    /// Orchestrator error — lifecycle failures, sub-service wiring.
+    #[error("Orchestrator error: {0}")]
+    Orchestrator(#[from] OrchestratorError),
+
     /// Failure classification error — classification failures,
     /// missing strategies.
     #[error("Failure classification error: {0}")]
@@ -176,6 +181,7 @@ impl CoreOrchestratorError {
             CoreOrchestratorError::Audit(e) => e.is_retriable(),
             CoreOrchestratorError::State(e) => e.is_retriable(),
             CoreOrchestratorError::Template(e) => e.is_retriable(),
+            CoreOrchestratorError::Orchestrator(e) => e.is_retriable(),
             CoreOrchestratorError::FailureClassification(e) => e.is_retriable(),
             // JSON deserialization errors are not retriable — the input is malformed
             CoreOrchestratorError::Json(_) => false,
@@ -200,6 +206,7 @@ impl CoreOrchestratorError {
             CoreOrchestratorError::Audit(_) => "AUDIT_ERROR",
             CoreOrchestratorError::State(_) => "STATE_ERROR",
             CoreOrchestratorError::Template(_) => "TEMPLATE_ERROR",
+            CoreOrchestratorError::Orchestrator(_) => "ORCHESTRATOR_ERROR",
             CoreOrchestratorError::FailureClassification(_) => "FAILURE_CLASSIFICATION_ERROR",
             CoreOrchestratorError::Io(_) => "IO_ERROR",
             CoreOrchestratorError::Json(_) => "JSON_ERROR",
@@ -224,6 +231,7 @@ impl CoreOrchestratorError {
             CoreOrchestratorError::Audit(_) => 500,
             CoreOrchestratorError::State(_) => 500,
             CoreOrchestratorError::Template(_) => 400,
+            CoreOrchestratorError::Orchestrator(_) => 500,
             CoreOrchestratorError::FailureClassification(_) => 500,
             CoreOrchestratorError::Io(_) => 500,
             CoreOrchestratorError::Json(_) => 400,
@@ -344,6 +352,10 @@ mod tests {
             CoreOrchestratorError::Template(TemplateError::NotFound {
                 id: "test".to_string(),
                 available: vec![],
+            }),
+            CoreOrchestratorError::Orchestrator(OrchestratorError::PlanningFailed {
+                detail: "test".to_string(),
+                intent: "test".to_string(),
             }),
             CoreOrchestratorError::FailureClassification(
                 FailureClassificationError::ClassificationFailed {

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -35,6 +35,7 @@ pub mod event_system;
 pub mod execution_engine;
 pub mod failure_classification;
 pub mod observability;
+pub mod orchestrator;
 pub mod planning;
 pub mod repo_engine;
 pub mod risk_gating;

--- a/engine/src/orchestrator/application/builder.rs
+++ b/engine/src/orchestrator/application/builder.rs
@@ -1,0 +1,75 @@
+//! OrchestratorBuilder — Constructs an OrchestratorService from Config.
+//!
+//! @canonical .pi/architecture/modules/orchestrator.md#builder
+//! Implements: Contract Freeze — OrchestratorBuilder trait
+//! Issue: #338
+//!
+//! Builder pattern for constructing an `OrchestratorService` from a `Config`,
+//! wiring all internal dependencies (PlanningPipeline, ParallelExecutionService,
+//! StateManagerService, CancellationService, EventBus, AuditService).
+//!
+//! Usage:
+//! ```rust,ignore
+//! let orchestrator = OrchestratorBuilder::new(config)
+//!     .with_repo_root(repo_root)
+//!     .with_enforcement_preset(enforcement_preset)
+//!     .build()
+//!     .await?;
+//!
+//! let result = orchestrator.run(RunInput { intent }).await?;
+//! ```
+//!
+//! # Contract (Frozen)
+//! - Builder methods return `Self` for chaining
+//! - `build()` is async and performs validation
+//! - No mutable state exposed after `build()`
+//! - Default behaviour when optional fields are omitted
+
+use async_trait::async_trait;
+
+use crate::orchestrator::domain::OrchestratorConfig;
+
+use super::service::OrchestratorService;
+
+/// Builder for constructing an `OrchestratorService`.
+///
+/// Wires all internal dependencies and configuration. The resulting service
+/// is fully initialised and ready for `run()` calls.
+#[async_trait]
+pub trait OrchestratorBuilder: Send + Sync {
+    /// Create a new builder with the given orchestrator configuration.
+    fn new(config: OrchestratorConfig) -> Self
+    where
+        Self: Sized;
+
+    /// Set the repository root path.
+    ///
+    /// Used to resolve relative paths in execution context metadata.
+    /// Required — omitted `build()` calls will return an error.
+    fn with_repo_root(self, repo_root: String) -> Self
+    where
+        Self: Sized;
+
+    /// Set the enforcement preset.
+    ///
+    /// Controls execution limits (max nodes, max LLM calls, etc.).
+    /// Optional — defaults to standard enforcement.
+    fn with_enforcement_preset(self, preset: String) -> Self
+    where
+        Self: Sized;
+
+    /// Set the LLM budget for this execution.
+    ///
+    /// Optional — defaults to unlimited.
+    fn with_llm_budget(self, max_calls: u32, max_tokens: u64) -> Self
+    where
+        Self: Sized;
+
+    /// Build the `OrchestratorService`.
+    ///
+    /// Validates configuration and wires all dependencies.
+    /// Returns an error if required fields are missing.
+    async fn build(self) -> Result<Box<dyn OrchestratorService>, crate::orchestrator::domain::OrchestratorError>
+    where
+        Self: Sized;
+}

--- a/engine/src/orchestrator/application/dto/mod.rs
+++ b/engine/src/orchestrator/application/dto/mod.rs
@@ -1,0 +1,135 @@
+//! Data Transfer Objects for the Orchestrator module.
+//!
+//! @canonical .pi/architecture/modules/orchestrator.md#dtos
+//! Implements: Contract Freeze — DTO schemas for run, plan_only, cancel, status
+//! Issue: #338
+//!
+//! DTOs define the input/output contracts for service operations.
+//! They carry validation metadata and documentation but no behavior.
+//!
+//! # Contract (Frozen)
+//! - Every service operation has a dedicated input and output DTO
+//! - DTOs are serializable (JSON for API)
+//! - Validation constraints are documented in field docs
+//! - Fields use reasonable Rust types (no framework-specific annotations)
+
+use serde::{Deserialize, Serialize};
+
+use crate::orchestrator::domain::record::{ExecutionRecord, ExecutionStatus};
+
+// ---------------------------------------------------------------------------
+// Run DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for a full orchestrator run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunInput {
+    /// The user's natural-language intent for execution.
+    pub intent: String,
+
+    /// Serialized configuration for the run.
+    pub config: serde_json::Value,
+
+    /// Repository root path.
+    pub repo_root: String,
+
+    /// Optional enforcement preset override.
+    pub enforcement_preset: Option<String>,
+}
+
+/// Output from a full orchestrator run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunOutput {
+    /// The execution ID assigned to this run.
+    pub execution_id: uuid::Uuid,
+
+    /// The complete execution record with all metadata.
+    pub record: ExecutionRecord,
+}
+
+// ---------------------------------------------------------------------------
+// Plan Only DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for a plan-only operation (no execution).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanOnlyInput {
+    /// The user's natural-language intent for planning.
+    pub intent: String,
+
+    /// Serialized configuration.
+    pub config: serde_json::Value,
+
+    /// Repository root path.
+    pub repo_root: String,
+}
+
+/// Output from a plan-only operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanOnlyOutput {
+    /// Plan result from the planning pipeline.
+    pub plan: serde_json::Value,
+
+    /// The proposed TaskGraph structure.
+    pub graph: serde_json::Value,
+}
+
+// ---------------------------------------------------------------------------
+// Cancel DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for cancelling a running execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CancelInput {
+    /// The execution ID to cancel.
+    pub execution_id: uuid::Uuid,
+
+    /// Optional reason for cancellation.
+    pub reason: Option<String>,
+}
+
+/// Output from a cancel operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CancelOutput {
+    /// The execution ID that was cancelled.
+    pub execution_id: uuid::Uuid,
+
+    /// Whether the execution was successfully aborted.
+    pub aborted: bool,
+
+    /// How many DAG nodes were cancelled mid-execution.
+    pub nodes_cancelled: u32,
+}
+
+// ---------------------------------------------------------------------------
+// Status DTOs
+// ---------------------------------------------------------------------------
+
+/// Output from a status query.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatusOutput {
+    /// The current execution ID.
+    pub execution_id: uuid::Uuid,
+
+    /// Current execution status.
+    pub status: ExecutionStatus,
+
+    /// Per-node state information.
+    pub nodes: Vec<NodeState>,
+}
+
+/// State of a single DAG node from a status query.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeState {
+    /// Unique identifier of the DAG node.
+    pub node_id: String,
+
+    /// Human-readable node name.
+    pub node_name: String,
+
+    /// Current status of this node.
+    pub status: String,
+
+    /// Human-readable status message.
+    pub message: Option<String>,
+}

--- a/engine/src/orchestrator/application/mod.rs
+++ b/engine/src/orchestrator/application/mod.rs
@@ -1,0 +1,24 @@
+//! Application layer interfaces for the Orchestrator bounded context.
+//!
+//! @canonical .pi/architecture/modules/orchestrator.md
+//! Implements: Contract Freeze — service traits, builder, DTOs
+//! Issue: #338
+//!
+//! This module defines:
+//! - Service traits (use cases / application services)
+//! - OrchestratorBuilder for constructing an OrchestratorService from Config
+//! - Input/Output DTOs with validation
+//!
+//! # Contract (Frozen)
+//! - All service methods are async (return `impl Future`)
+//! - All public methods return `Result<_, OrchestratorError>`
+//! - DTOs include validation documentation
+//! - No implementation logic — only trait definitions
+
+pub mod builder;
+pub mod dto;
+pub mod service;
+
+pub use builder::*;
+pub use dto::*;
+pub use service::*;

--- a/engine/src/orchestrator/application/service.rs
+++ b/engine/src/orchestrator/application/service.rs
@@ -1,0 +1,79 @@
+//! Service interfaces (use cases) for the Orchestrator bounded context.
+//!
+//! @canonical .pi/architecture/modules/orchestrator.md#orchestrator-service
+//! Implements: Contract Freeze — OrchestratorService trait
+//! Issue: #338
+//!
+//! These traits define the top-level operations for running a full Rigorix
+//! execution lifecycle. All methods are async and return domain error types.
+//!
+//! # Contract (Frozen)
+//! - Every use case has a corresponding trait method
+//! - Input/output types are DTOs defined in `dto/`
+//! - All methods are async (use `async-trait` for trait object safety)
+//! - No implementation — only contract signatures
+
+use async_trait::async_trait;
+
+use crate::orchestrator::domain::OrchestratorError;
+
+use super::dto::{
+    CancelInput, CancelOutput, PlanOnlyInput, PlanOnlyOutput, RunInput, RunOutput, StatusOutput,
+};
+
+/// Single entry point for executing a Rigorix run from intent to result.
+///
+/// Orchestrates the full lifecycle: planning → DAG execution → state persistence
+/// → event emission → audit envelope building.
+///
+/// Any consumer (CLI, CI/CD, IDE plugin) can run a complete execution with one
+/// call by using this trait. Implementations wire together the PlanningPipeline,
+/// ParallelExecutionService, StateManagerService, CancellationService, EventBus,
+/// and AuditService internally.
+#[async_trait]
+pub trait OrchestratorService: Send + Sync {
+    /// Full lifecycle: plan → execute → persist → emit → return record.
+    ///
+    /// # Lifecycle
+    /// 1. Generate execution_id (UUIDv7)
+    /// 2. Publish `PlanningStarted` event
+    /// 3. Run `PlanningPipeline::plan_with_graph(intent, budget)`
+    /// 4. Publish `PlanningCompleted` event
+    /// 5. Save initial `ExecutionState` (Pending)
+    /// 6. Execute DAG via `ParallelExecutionService` (cooperative cancellation)
+    /// 7. Save final `ExecutionState` (Completed/Failed)
+    /// 8. Drain `EventBus` → build `ExecutionRecord`
+    /// 9. Send audit envelope (best-effort)
+    /// 10. Return `ExecutionRecord`
+    ///
+    /// # Errors
+    /// Returns `OrchestratorError` for any phase failure. The record may be
+    /// partially complete depending on when the failure occurred.
+    async fn run(&self, input: RunInput) -> Result<RunOutput, OrchestratorError>;
+
+    /// Plan only (no execution). Returns the plan for preview.
+    ///
+    /// Useful for CLI `--plan` mode where the user wants to review the
+    /// generated plan before committing to execution.
+    async fn plan_only(&self, input: PlanOnlyInput) -> Result<PlanOnlyOutput, OrchestratorError>;
+
+    /// Cancel a running execution.
+    ///
+    /// Propagates the cancellation signal to all sub-services via the
+    /// `CancellationService`. Once cancelled, the execution enters the
+    /// `Cancelled` state and cannot be resumed.
+    async fn cancel(&self, input: CancelInput) -> Result<CancelOutput, OrchestratorError>;
+
+    /// Get current execution status.
+    ///
+    /// Returns the status of the current or most recent execution, including
+    /// which DAG nodes have been completed, are running, or are pending.
+    async fn status(&self) -> Result<StatusOutput, OrchestratorError>;
+
+    /// Access the EventBus for subscriber registration (TUI, logs).
+    ///
+    /// Allows external consumers to subscribe to lifecycle events before a
+    /// run starts. The returned reference must be valid for the lifetime of
+    /// the service.
+    fn event_bus(&self) -> &dyn crate::event_system::domain::EventBus;
+}

--- a/engine/src/orchestrator/domain/config.rs
+++ b/engine/src/orchestrator/domain/config.rs
@@ -1,0 +1,69 @@
+//! Orchestrator-specific configuration.
+//!
+//! @canonical .pi/architecture/modules/orchestrator.md#config
+//! Implements: Contract Freeze — OrchestratorConfig
+//! Issue: #338
+//!
+//! Configuration values specific to the orchestrator's execution lifecycle,
+//! independent of sub-service configuration (handled by their own configs).
+//!
+//! # Contract (Frozen)
+//! - All configuration values have sensible defaults
+//! - Configuration is validated at builder time, not during orchestration
+//! - Fields are public for the builder to construct
+
+use serde::{Deserialize, Serialize};
+
+/// Orchestrator-specific configuration.
+///
+/// Controls event buffer sizing, audit behaviour, cancellation timeouts,
+/// and other orchestrator-level settings.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrchestratorConfig {
+    /// Maximum number of events buffered in the EventBus before draining.
+    /// Larger values allow more events to accumulate before the record is built,
+    /// but consume more memory. Default: 10_000.
+    pub event_buffer_capacity: usize,
+
+    /// Whether to send audit envelopes after execution completes.
+    /// Disable for local/development runs where no audit backend is available.
+    /// Default: true.
+    pub audit_enabled: bool,
+
+    /// Timeout in seconds for the full `run()` lifecycle.
+    /// If the execution exceeds this duration, a `Cancelled` state is forced.
+    /// Default: 300 (5 minutes).
+    pub execution_timeout_secs: u64,
+
+    /// Timeout in seconds for the planning phase specifically.
+    /// Default: 60.
+    pub planning_timeout_secs: u64,
+
+    /// Timeout in seconds for state persistence operations.
+    /// Default: 10.
+    pub state_persistence_timeout_secs: u64,
+
+    /// Whether to save intermediate execution state after each DAG node.
+    /// Enables resumption after partial failures but adds I/O overhead.
+    /// Default: false.
+    pub save_intermediate_state: bool,
+
+    /// Whether to propagate cancellation signals to all sub-services
+    /// when a single phase fails.
+    /// Default: true.
+    pub propagate_cancellation: bool,
+}
+
+impl Default for OrchestratorConfig {
+    fn default() -> Self {
+        Self {
+            event_buffer_capacity: 10_000,
+            audit_enabled: true,
+            execution_timeout_secs: 300,
+            planning_timeout_secs: 60,
+            state_persistence_timeout_secs: 10,
+            save_intermediate_state: false,
+            propagate_cancellation: true,
+        }
+    }
+}

--- a/engine/src/orchestrator/domain/error.rs
+++ b/engine/src/orchestrator/domain/error.rs
@@ -1,0 +1,90 @@
+//! Orchestrator error types.
+//!
+//! @canonical .pi/architecture/modules/orchestrator.md#errors
+//! Implements: Contract Freeze — OrchestratorError enum
+//! Issue: #338
+//!
+//! Errors that can occur during the orchestration lifecycle. Each variant
+//! maps to a failure in a specific sub-service or phase.
+//!
+//! Note: `OrchestratorError` converts to `CoreOrchestratorError` via `#[from]`
+//! at the crate root, not the other way around — sub-errors carry their own
+//! types and are wrapped at the orchestrator boundary.
+//!
+//! # Contract (Frozen)
+//! - `OrchestratorError` is the single error type for this module
+//! - Each variant carries structured context for error reporting
+//! - Implements `std::error::Error` for library compatibility
+//! - Converted to `CoreOrchestratorError` via `#[from]` at the crate root
+
+use thiserror::Error;
+
+/// Errors that can occur during orchestrator operations.
+#[derive(Debug, Error)]
+pub enum OrchestratorError {
+    /// The planning phase failed (PlanningPipeline error).
+    #[error("Planning failed: {detail}")]
+    PlanningFailed {
+        /// Human-readable error description.
+        detail: String,
+        /// The intent that was being planned.
+        intent: String,
+    },
+
+    /// DAG execution failed (ParallelExecutionService error).
+    #[error("Execution failed: {detail}")]
+    ExecutionFailed {
+        /// Human-readable error description.
+        detail: String,
+        /// How many DAG nodes completed before the failure.
+        nodes_completed: u32,
+        /// How many nodes remain unexecuted.
+        nodes_remaining: u32,
+    },
+
+    /// State persistence failed (StateManagerService error).
+    #[error("State persistence failed: {detail}")]
+    StatePersistenceFailed {
+        /// Human-readable error description.
+        detail: String,
+        /// Which execution state was being saved.
+        state: String,
+    },
+
+    /// Cancellation signal could not be propagated.
+    #[error("Cancellation failed: {detail}")]
+    CancellationFailed {
+        /// Human-readable error description.
+        detail: String,
+    },
+
+    /// Audit envelope delivery failed (non-fatal).
+    #[error("Audit delivery failed: {detail}")]
+    AuditFailed {
+        /// Human-readable error description.
+        detail: String,
+        /// Whether the execution record was still returned successfully.
+        execution_completed: bool,
+    },
+
+    /// An internal orchestrator error occurred.
+    #[error("Internal orchestrator error: {detail}")]
+    Internal {
+        /// Error detail for diagnostics.
+        detail: String,
+        /// Source module or service that generated the error.
+        source: String,
+    },
+}
+
+impl OrchestratorError {
+    /// Returns `true` if the error is retriable at the orchestrator level.
+    pub fn is_retriable(&self) -> bool {
+        matches!(
+            self,
+            OrchestratorError::PlanningFailed { .. }
+                | OrchestratorError::ExecutionFailed { .. }
+                | OrchestratorError::StatePersistenceFailed { .. }
+        )
+    }
+}

--- a/engine/src/orchestrator/domain/event/mod.rs
+++ b/engine/src/orchestrator/domain/event/mod.rs
@@ -1,0 +1,112 @@
+//! Event payload schemas for the Orchestrator bounded context.
+//!
+//! @canonical .pi/architecture/modules/orchestrator.md#events
+//! Implements: Contract Freeze — OrchestratorEvent payload schemas
+//! Issue: #338
+//!
+//! These events are emitted on the `EventBus` during the orchestration lifecycle.
+//! Consumers (console, TUI, alerting) subscribe to these event types.
+//!
+//! # Contract (Frozen)
+//! - Each event carries the full context needed by consumers
+//! - No internal implementation details exposed
+//! - `execution_id` correlates to the originating execution
+
+use serde::{Deserialize, Serialize};
+
+/// Events emitted by the Orchestrator module.
+///
+/// Wrapped in `ExecutionEvent::Orchestrator(...)` at the orchestration layer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum OrchestratorEvent {
+    /// A new execution run has started.
+    RunStarted {
+        /// The execution ID for this run.
+        execution_id: uuid::Uuid,
+        /// Timestamp when the run started (ISO 8601 / UTC).
+        started_at: chrono::DateTime<chrono::Utc>,
+        /// The user intent being executed.
+        intent: String,
+    },
+
+    /// Execution run completed successfully.
+    RunCompleted {
+        /// The execution ID for this run.
+        execution_id: uuid::Uuid,
+        /// Duration of the run in milliseconds.
+        duration_ms: u64,
+        /// Number of DAG nodes executed.
+        nodes_executed: u32,
+        /// Number of DAG nodes that failed.
+        nodes_failed: u32,
+    },
+
+    /// Execution run failed.
+    RunFailed {
+        /// The execution ID for this run.
+        execution_id: uuid::Uuid,
+        /// Duration in milliseconds before failure.
+        duration_ms: u64,
+        /// The phase in which the failure occurred.
+        failed_phase: FailedPhase,
+        /// Error description.
+        reason: String,
+    },
+
+    /// Execution run was cancelled.
+    RunCancelled {
+        /// The execution ID for this run.
+        execution_id: uuid::Uuid,
+        /// Duration in milliseconds before cancellation.
+        duration_ms: u64,
+        /// Reason for cancellation (if provided).
+        reason: Option<String>,
+        /// Number of DAG nodes that were cancelled mid-execution.
+        nodes_cancelled: u32,
+    },
+
+    /// State was persisted at a checkpoint.
+    StatePersisted {
+        /// The execution ID for this run.
+        execution_id: uuid::Uuid,
+        /// Current execution state saved.
+        state: String,
+        /// Duration of the persist operation in milliseconds.
+        duration_ms: u64,
+    },
+
+    /// Cancellation signal was propagated to sub-services.
+    CancellationPropagated {
+        /// The execution ID for this run.
+        execution_id: uuid::Uuid,
+        /// Which services were notified.
+        services_notified: Vec<String>,
+        /// How many had already completed.
+        services_already_completed: u32,
+    },
+
+    /// Audit envelope was built (regardless of send success).
+    AuditEnvelopeBuilt {
+        /// The execution ID for this run.
+        execution_id: uuid::Uuid,
+        /// Number of events included in the envelope.
+        event_count: u32,
+        /// Whether the envelope was sent successfully.
+        sent_successfully: bool,
+    },
+}
+
+/// The phase in which a run failure occurred.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FailedPhase {
+    /// Failure during planning.
+    Planning,
+    /// Failure during DAG execution.
+    Execution,
+    /// Failure during state persistence.
+    StatePersistence,
+    /// Failure during cancellation.
+    Cancellation,
+    /// Failure during audit.
+    Audit,
+}

--- a/engine/src/orchestrator/domain/mod.rs
+++ b/engine/src/orchestrator/domain/mod.rs
@@ -1,0 +1,25 @@
+//! Domain entities and interfaces for the Orchestrator bounded context.
+//!
+//! @canonical .pi/architecture/modules/orchestrator.md#domain
+//! Implements: Contract Freeze — domain entities ExecutionRecord, OrchestratorConfig,
+//!                                     OrchestratorError, OrchestratorEvent
+//! Issue: #338
+//!
+//! This module defines the core domain types — `ExecutionRecord`, `OrchestratorConfig`,
+//! `OrchestratorError`, and `OrchestratorEvent`. These are pure domain objects with no
+//! framework dependencies. They serve as the frozen contract that all implementation
+//! must satisfy.
+//!
+//! # Contract Freeze
+//! - No implementation logic beyond constructors and field accessors
+//! - All validation must happen in the application layer (service traits)
+//! - All persistence must happen behind repository interfaces
+
+pub mod config;
+pub mod error;
+pub mod event;
+pub mod record;
+
+pub use config::OrchestratorConfig;
+pub use error::OrchestratorError;
+pub use record::ExecutionRecord;

--- a/engine/src/orchestrator/domain/record.rs
+++ b/engine/src/orchestrator/domain/record.rs
@@ -1,0 +1,181 @@
+//! ExecutionRecord — Complete output of a Rigorix run.
+//!
+//! @canonical .pi/architecture/modules/orchestrator.md#record
+//! Implements: Contract Freeze — ExecutionRecord aggregate
+//! Issue: #338
+//!
+//! Complete output of a run, containing everything needed for audit, TUI,
+//! and persistence. Built by the orchestrator after the full lifecycle.
+//!
+//! # Contract (Frozen)
+//! - All fields are public for direct construction by the orchestrator
+//! - Field types are domain primitives (no framework-specific types)
+//! - The record is serializable for persistence and API responses
+//! - Optional fields use `Option` to handle partial completion
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Complete output of a Rigorix execution run.
+///
+/// Aggregates planning metadata, per-node task results, the drained event log,
+/// and execution timing information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutionRecord {
+    /// Globally unique execution identifier (UUIDv7).
+    pub execution_id: uuid::Uuid,
+
+    /// Metadata from the planning phase.
+    pub planning: PlanningMetadata,
+
+    /// Per-node task results from the DAG execution.
+    pub task_results: Vec<TaskResult>,
+
+    /// Drained event log from the EventBus.
+    pub events: Vec<ExecutionEventInfo>,
+
+    /// Execution context metadata.
+    pub context: ExecutionContext,
+
+    /// ISO 8601 timestamp when execution started.
+    pub started_at: chrono::DateTime<chrono::Utc>,
+
+    /// ISO 8601 timestamp when execution completed (None if failed before completion).
+    pub completed_at: Option<chrono::DateTime<chrono::Utc>>,
+
+    /// Total wall-clock duration in milliseconds.
+    pub duration_ms: u64,
+
+    /// Overall execution status.
+    pub status: ExecutionStatus,
+}
+
+/// Metadata captured during the planning phase.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanningMetadata {
+    /// Identifier of the template used for planning.
+    pub template_id: String,
+
+    /// Confidence score from the classifier (0.0–1.0).
+    pub confidence: f64,
+
+    /// Number of LLM calls made during planning.
+    pub llm_calls: u32,
+
+    /// Total tokens consumed across all LLM calls.
+    pub total_tokens: u32,
+
+    /// Hash of the planning prompt for replay reproducibility.
+    pub prompt_hash: String,
+}
+
+/// Result of executing a single DAG node.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskResult {
+    /// Unique identifier of the DAG node.
+    pub node_id: String,
+
+    /// Human-readable node name.
+    pub node_name: String,
+
+    /// Status of this task.
+    pub status: TaskStatus,
+
+    /// Duration in milliseconds.
+    pub duration_ms: u64,
+
+    /// Output produced by the task (if any).
+    pub output: Option<String>,
+
+    /// Error detail if the task failed.
+    pub error: Option<String>,
+
+    /// Number of retry attempts made.
+    pub retry_attempts: u32,
+
+    /// Tool used to execute the task (if applicable).
+    pub tool_used: Option<String>,
+}
+
+/// A single execution event from the drained event log.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutionEventInfo {
+    /// Machine-readable event type.
+    pub event_type: String,
+
+    /// Human-readable event summary.
+    pub summary: String,
+
+    /// ISO 8601 timestamp.
+    pub occurred_at: chrono::DateTime<chrono::Utc>,
+
+    /// Correlation ID linking this event across services.
+    pub correlation_id: Option<uuid::Uuid>,
+
+    /// Event payload as JSON (if available).
+    pub payload: Option<serde_json::Value>,
+
+    /// Status of the event.
+    pub status: EventInfoStatus,
+}
+
+/// Execution context metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutionContext {
+    /// Repository root path.
+    pub repo_root: String,
+
+    /// Hash of the symbol graph at execution time.
+    pub symbol_graph_hash: Option<String>,
+
+    /// Git commit hash (if available).
+    pub git_commit: Option<String>,
+
+    /// Git branch name (if available).
+    pub git_branch: Option<String>,
+
+    /// Execution environment (cli, ci, ide).
+    pub environment: String,
+
+    /// Arbitrary key-value metadata.
+    pub metadata: HashMap<String, String>,
+}
+
+/// Overall execution status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ExecutionStatus {
+    /// Execution completed successfully.
+    Completed,
+    /// Execution completed with some failures.
+    PartialFailure,
+    /// Execution failed entirely.
+    Failed,
+    /// Execution was cancelled.
+    Cancelled,
+}
+
+/// Status of a single DAG task.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TaskStatus {
+    /// Task completed successfully.
+    Success,
+    /// Task failed.
+    Failure,
+    /// Task was skipped (e.g. conditional).
+    Skipped,
+    /// Task was cancelled.
+    Cancelled,
+    /// Task is still pending.
+    Pending,
+}
+
+/// Status of an event in the drained log.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EventInfoStatus {
+    /// Event represents a successful occurrence.
+    Success,
+    /// Event represents a failure.
+    Failure,
+    /// Event was informational.
+    Info,
+}

--- a/engine/src/orchestrator/infrastructure/mod.rs
+++ b/engine/src/orchestrator/infrastructure/mod.rs
@@ -1,0 +1,13 @@
+//! Infrastructure interfaces for the Orchestrator bounded context.
+//!
+//! @canonical .pi/architecture/modules/orchestrator.md
+//! Implements: Contract Freeze — repository interfaces
+//! Issue: #338
+//!
+//! Repositories abstract data access behind interfaces, allowing
+//! implementations to use local filesystem, database, or mock storage
+//! without coupling domain logic to infrastructure.
+
+pub mod repository;
+
+pub use repository::*;

--- a/engine/src/orchestrator/infrastructure/repository/mod.rs
+++ b/engine/src/orchestrator/infrastructure/repository/mod.rs
@@ -1,0 +1,74 @@
+//! Repository interfaces for the Orchestrator bounded context.
+//!
+//! @canonical .pi/architecture/modules/orchestrator.md
+//! Implements: Contract Freeze — ExecutionRecordRepository trait
+//! Issue: #338
+//!
+//! Repositories abstract data access behind interfaces, allowing
+//! implementations to use local filesystem, database, or mock storage
+//! without coupling domain logic to infrastructure.
+//!
+//! # Contract (Frozen)
+//! - All repository methods are async
+//! - All methods return domain error types
+//! - No framework-specific annotations on trait definitions
+//! - Implementations are hidden behind these interfaces
+
+use async_trait::async_trait;
+
+use crate::orchestrator::domain::{ExecutionRecord, OrchestratorError};
+
+/// Repository for persisting and retrieving execution records.
+///
+/// Implementations may use:
+/// - Local filesystem (JSON files per record)
+/// - SQLite/Postgres database
+/// - In-memory store (for testing)
+///
+/// # Security
+/// - Implementations MUST redact sensitive data in all log output
+/// - File paths must be validated against directory traversal
+#[async_trait]
+pub trait ExecutionRecordRepository: Send + Sync {
+    /// Persist an execution record.
+    ///
+    /// Saves the record for later retrieval or audit replay.
+    /// Returns `Internal` error on storage failure.
+    async fn save(&self, record: &ExecutionRecord) -> Result<(), OrchestratorError>;
+
+    /// Retrieve an execution record by execution ID.
+    ///
+    /// Returns `None` if no record exists for this execution ID.
+    async fn find_by_execution_id(
+        &self,
+        execution_id: &uuid::Uuid,
+    ) -> Result<Option<ExecutionRecord>, OrchestratorError>;
+
+    /// List all persisted records, optionally filtered by date range.
+    ///
+    /// Results ordered by started_at (newest first).
+    /// `limit` caps the number of results (default 100).
+    async fn list(
+        &self,
+        since: Option<chrono::DateTime<chrono::Utc>>,
+        until: Option<chrono::DateTime<chrono::Utc>>,
+        limit: Option<u32>,
+    ) -> Result<Vec<ExecutionRecord>, OrchestratorError>;
+
+    /// Delete a record by execution ID.
+    ///
+    /// No-op if the record doesn't exist.
+    async fn delete(&self, execution_id: &uuid::Uuid) -> Result<(), OrchestratorError>;
+
+    /// Count records matching optional filters.
+    async fn count(
+        &self,
+        since: Option<chrono::DateTime<chrono::Utc>>,
+        until: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<u64, OrchestratorError>;
+
+    /// Delete records older than the given timestamp.
+    ///
+    /// Returns the number of deleted records.
+    async fn prune(&self, older_than: chrono::DateTime<chrono::Utc>) -> Result<u64, OrchestratorError>;
+}

--- a/engine/src/orchestrator/interfaces/http/mod.rs
+++ b/engine/src/orchestrator/interfaces/http/mod.rs
@@ -1,0 +1,286 @@
+//! HTTP API contracts for Orchestrator endpoints.
+//!
+//! @canonical .pi/architecture/modules/orchestrator.md
+//! Implements: Contract Freeze — HTTP endpoint contracts and error formats
+//! Issue: #338
+//!
+//! Defines endpoint paths, methods, request/response schemas, and error
+//! response formats. These contracts are framework-agnostic — they describe
+//! the API surface that any HTTP server implementation must satisfy.
+//!
+//! # Contract (Frozen)
+//! - All endpoints documented with method, path, request, and response types
+//! - Error responses follow a unified format
+//! - No framework-specific annotations (axum/actix/warp annotations added by implementation)
+
+use serde::{Deserialize, Serialize};
+
+use crate::orchestrator::application::dto::{
+    CancelInput, CancelOutput, PlanOnlyInput, PlanOnlyOutput, RunInput, RunOutput, StatusOutput,
+};
+
+use crate::orchestrator::domain::record::{ExecutionRecord, ExecutionStatus};
+
+// ---------------------------------------------------------------------------
+// API Base Path
+// ---------------------------------------------------------------------------
+
+/// All orchestrator endpoints are served under this base path.
+pub const API_BASE_PATH: &str = "/api/v1/orchestrator";
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/orchestrator/run
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/orchestrator/run
+///
+/// Execute a full orchestrator lifecycle: plan → execute → persist → emit.
+///
+/// **Request:** `RunRequest`
+/// **Response:** `201 Created` with `RunResponse`
+pub const RUN_PATH: &str = "/api/v1/orchestrator/run";
+pub const RUN_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/orchestrator/run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunRequest {
+    /// The user's natural-language intent.
+    pub intent: String,
+
+    /// Serialized configuration.
+    pub config: serde_json::Value,
+
+    /// Repository root path.
+    pub repo_root: String,
+
+    /// Optional enforcement preset.
+    pub enforcement_preset: Option<String>,
+}
+
+impl From<RunRequest> for RunInput {
+    fn from(req: RunRequest) -> Self {
+        Self {
+            intent: req.intent,
+            config: req.config,
+            repo_root: req.repo_root,
+            enforcement_preset: req.enforcement_preset,
+        }
+    }
+}
+
+/// Response body for POST /api/v1/orchestrator/run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunResponse {
+    pub success: bool,
+    pub execution_id: uuid::Uuid,
+    pub record: ExecutionRecord,
+}
+
+impl From<RunOutput> for RunResponse {
+    fn from(output: RunOutput) -> Self {
+        Self {
+            success: true,
+            execution_id: output.execution_id,
+            record: output.record,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/orchestrator/plan
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/orchestrator/plan
+///
+/// Plan only (no execution). Returns the plan for preview.
+///
+/// **Request:** `PlanOnlyRequest`
+/// **Response:** `200 OK` with `PlanOnlyResponse`
+pub const PLAN_PATH: &str = "/api/v1/orchestrator/plan";
+pub const PLAN_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/orchestrator/plan.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanOnlyRequest {
+    /// The user's natural-language intent.
+    pub intent: String,
+
+    /// Serialized configuration.
+    pub config: serde_json::Value,
+
+    /// Repository root path.
+    pub repo_root: String,
+}
+
+impl From<PlanOnlyRequest> for PlanOnlyInput {
+    fn from(req: PlanOnlyRequest) -> Self {
+        Self {
+            intent: req.intent,
+            config: req.config,
+            repo_root: req.repo_root,
+        }
+    }
+}
+
+/// Response body for POST /api/v1/orchestrator/plan.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanOnlyResponse {
+    pub success: bool,
+    pub plan: serde_json::Value,
+    pub graph: serde_json::Value,
+}
+
+impl From<PlanOnlyOutput> for PlanOnlyResponse {
+    fn from(output: PlanOnlyOutput) -> Self {
+        Self {
+            success: true,
+            plan: output.plan,
+            graph: output.graph,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/orchestrator/cancel
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/orchestrator/cancel
+///
+/// Cancel a running execution.
+///
+/// **Request:** `CancelRequest`
+/// **Response:** `200 OK` with `CancelResponse`
+pub const CANCEL_PATH: &str = "/api/v1/orchestrator/cancel";
+pub const CANCEL_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/orchestrator/cancel.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CancelRequest {
+    /// The execution ID to cancel.
+    pub execution_id: uuid::Uuid,
+
+    /// Optional reason for cancellation.
+    pub reason: Option<String>,
+}
+
+impl From<CancelRequest> for CancelInput {
+    fn from(req: CancelRequest) -> Self {
+        Self {
+            execution_id: req.execution_id,
+            reason: req.reason,
+        }
+    }
+}
+
+/// Response body for POST /api/v1/orchestrator/cancel.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CancelResponse {
+    pub success: bool,
+    pub execution_id: uuid::Uuid,
+    pub aborted: bool,
+    pub nodes_cancelled: u32,
+}
+
+impl From<CancelOutput> for CancelResponse {
+    fn from(output: CancelOutput) -> Self {
+        Self {
+            success: true,
+            execution_id: output.execution_id,
+            aborted: output.aborted,
+            nodes_cancelled: output.nodes_cancelled,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: GET /api/v1/orchestrator/status
+// ---------------------------------------------------------------------------
+
+/// GET /api/v1/orchestrator/status
+///
+/// Get the current execution status.
+///
+/// **Response:** `200 OK` with `StatusResponse`
+pub const STATUS_PATH: &str = "/api/v1/orchestrator/status";
+pub const STATUS_METHOD: &str = "GET";
+
+/// Response body for GET /api/v1/orchestrator/status.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatusResponse {
+    pub success: bool,
+    pub execution_id: uuid::Uuid,
+    pub status: ExecutionStatus,
+    pub nodes: Vec<NodeStateDto>,
+}
+
+impl From<StatusOutput> for StatusResponse {
+    fn from(output: StatusOutput) -> Self {
+        Self {
+            success: true,
+            execution_id: output.execution_id,
+            status: output.status,
+            nodes: output.nodes.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+/// DTO for node state in API responses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeStateDto {
+    pub node_id: String,
+    pub node_name: String,
+    pub status: String,
+    pub message: Option<String>,
+}
+
+impl From<crate::orchestrator::application::dto::NodeState> for NodeStateDto {
+    fn from(state: crate::orchestrator::application::dto::NodeState) -> Self {
+        Self {
+            node_id: state.node_id,
+            node_name: state.node_name,
+            status: state.status,
+            message: state.message,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unified Error Response Format
+// ---------------------------------------------------------------------------
+
+/// Standard error response for all Orchestrator API endpoints.
+///
+/// All 4xx/5xx responses use this format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiErrorResponse {
+    /// HTTP status code.
+    pub status: u16,
+    /// Machine-readable error code.
+    pub code: String,
+    /// Human-readable error message.
+    pub message: String,
+    /// Detailed error context (optional, may include field-level errors).
+    pub details: Option<serde_json::Value>,
+    /// Request ID for tracing (if available).
+    pub request_id: Option<String>,
+}
+
+/// Standardized error codes for Orchestrator API.
+pub mod error_codes {
+    pub const PLANNING_FAILED: &str = "ORCH_PLANNING_FAILED";
+    pub const EXECUTION_FAILED: &str = "ORCH_EXECUTION_FAILED";
+    pub const STATE_PERSISTENCE_FAILED: &str = "ORCH_STATE_PERSISTENCE_FAILED";
+    pub const CANCELLATION_FAILED: &str = "ORCH_CANCELLATION_FAILED";
+    pub const AUDIT_FAILED: &str = "ORCH_AUDIT_FAILED";
+    pub const INTERNAL_ERROR: &str = "ORCH_INTERNAL_ERROR";
+}
+
+/// HTTP status code mappings for Orchestrator errors.
+pub mod status_codes {
+    pub const PLANNING_FAILED: u16 = 400;
+    pub const EXECUTION_FAILED: u16 = 500;
+    pub const STATE_PERSISTENCE_FAILED: u16 = 500;
+    pub const CANCELLATION_FAILED: u16 = 400;
+    pub const AUDIT_FAILED: u16 = 502;
+    pub const INTERNAL_ERROR: u16 = 500;
+}

--- a/engine/src/orchestrator/interfaces/mod.rs
+++ b/engine/src/orchestrator/interfaces/mod.rs
@@ -1,0 +1,9 @@
+//! API contracts for the Orchestrator bounded context.
+//!
+//! @canonical .pi/architecture/modules/orchestrator.md
+//! Implements: Contract Freeze — HTTP endpoint contracts
+//! Issue: #338
+//!
+//! Defines the external API surface for the orchestrator module.
+
+pub mod http;

--- a/engine/src/orchestrator/mod.rs
+++ b/engine/src/orchestrator/mod.rs
@@ -1,0 +1,45 @@
+//! Orchestrator bounded context.
+//!
+//! @canonical .pi/architecture/modules/orchestrator.md
+//! Implements: Contract Freeze — orchestrator module root
+//! Issue: #338
+//!
+//! Top-level entry point that wires the full Rigorix execution lifecycle into
+//! a single operation. Sequences: config loading → planning (via PlanningPipeline)
+//! → TaskGraph execution (via ExecutionEngine) → state persistence (via
+//! StateManagerService) → event emission (via EventBus) → audit envelope
+//! building (via AuditService).
+//!
+//! # Architecture
+//!
+//! ```text
+//! orchestrator/
+//! ├── domain/           # Domain entities (ExecutionRecord), config, errors, events
+//! │   ├── config.rs     # OrchestratorConfig
+//! │   ├── error.rs      # OrchestratorError enum
+//! │   ├── record.rs     # ExecutionRecord aggregate
+//! │   └── event/        # OrchestratorEvent payload schemas
+//! ├── application/      # Service traits, builder, DTOs
+//! │   ├── service.rs    # OrchestratorService trait
+//! │   ├── builder.rs    # OrchestratorBuilder trait
+//! │   └── dto/          # Input/Output DTOs with validation
+//! ├── infrastructure/   # Repository interfaces
+//! │   └── repository/   # ExecutionRecordRepository
+//! └── interfaces/       # API contracts
+//!     └── http/         # REST endpoint contracts
+//! ```
+//!
+//! # Contract Freeze Notice
+//!
+//! ALL files in this module are frozen contracts.
+//! - No implementation changes without explicit contract change approval
+//! - Implementation PRs MUST reference these interfaces
+//! - DTO schemas serve as the canonical data contract
+
+pub mod application;
+pub mod domain;
+pub mod infrastructure;
+pub mod interfaces;
+
+pub use application::*;
+pub use domain::*;


### PR DESCRIPTION
## Summary

Contract freeze for the orchestrator epic (#337). Defines all public interfaces, contracts, and schemas before any implementation begins.

### Components Frozen

- **OrchestratorService** — `application/service.rs`: `run()`, `plan_only()`, `cancel()`, `status()`, `event_bus()`
- **OrchestratorBuilder** — `application/builder.rs`: builder pattern for constructing OrchestratorService from Config
- **ExecutionRecord** — `domain/record.rs`: aggregate with planning metadata, task results, events, timing

### All Frozen Interfaces

| Layer | File | Contents |
|-------|------|----------|
| domain/ | `config.rs` | `OrchestratorConfig` with sensible defaults |
| domain/ | `error.rs` | `OrchestratorError` (6 variants) |
| domain/ | `record.rs` | `ExecutionRecord`, `PlanningMetadata`, `TaskResult`, `ExecutionContext` |
| domain/event/ | `mod.rs` | `OrchestratorEvent` (7 event types), `FailedPhase` |
| application/ | `service.rs` | `OrchestratorService` trait |
| application/ | `builder.rs` | `OrchestratorBuilder` trait |
| application/dto/ | `mod.rs` | RunInput/Output, PlanOnlyInput/Output, CancelInput/Output, StatusOutput |
| infrastructure/repository/ | `mod.rs` | `ExecutionRecordRepository` trait |
| interfaces/http/ | `mod.rs` | 4 endpoint contracts with request/response types, error format |

### Cross-Cutting

- `error.rs`: `Orchestrator` variant added to `CoreOrchestratorError` with `#[from]`, `is_retriable()`, `error_code()`, `http_status()`
- `lib.rs`: `pub mod orchestrator` registered

### Acceptance Criteria

- [x] All component interfaces defined in `domain/` and `application/`
- [x] DTO schemas documented with field-level docs
- [x] API contracts specified (4 endpoints)
- [x] Repository interfaces defined
- [x] Events schemas frozen
- [x] CoreOrchestratorError integration complete

Part of orchestrator epic (#337).