### PR TITLE
feat(integration): wire final two connections — orchestrator builds CodeGraph, pipeline injects module_deps

### DIFF
--- a/engine/src/code_graph/application/builder.rs
+++ b/engine/src/code_graph/application/builder.rs
@@ -12,6 +12,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::code_graph::domain::{
@@ -40,7 +41,7 @@ use super::service::CodeGraphService;
 /// - Skips `node_modules/`, `target/`, `.git/`, and hidden directories
 pub struct CodeGraphBuilder {
     /// The graph service to populate with built graphs.
-    graph_service: Box<dyn CodeGraphService>,
+    graph_service: Arc<dyn CodeGraphService>,
 
     /// Root directories to scan.
     scan_roots: Vec<PathBuf>,
@@ -55,7 +56,7 @@ pub struct CodeGraphBuilder {
 impl CodeGraphBuilder {
     /// Create a new CodeGraphBuilder.
     pub fn new(
-        graph_service: Box<dyn CodeGraphService>,
+        graph_service: Arc<dyn CodeGraphService>,
         scan_roots: Vec<PathBuf>,
         extensions: Vec<String>,
         include_external: bool,
@@ -481,7 +482,7 @@ mod tests {
     use tempfile::tempdir;
 
     fn create_builder(roots: Vec<PathBuf>) -> CodeGraphBuilder {
-        let service: Box<dyn CodeGraphService> = Box::new(CodeGraphServiceImpl::new());
+        let service: Arc<dyn CodeGraphService> = Arc::new(CodeGraphServiceImpl::new());
         CodeGraphBuilder::new(
             service,
             roots,
@@ -492,7 +493,7 @@ mod tests {
 
     #[test]
     fn test_parse_rust_imports() {
-        let service: Box<dyn CodeGraphService> = Box::new(CodeGraphServiceImpl::new());
+        let service: Arc<dyn CodeGraphService> = Arc::new(CodeGraphServiceImpl::new());
         let builder = CodeGraphBuilder::new(service, vec![], vec![], false);
 
         let content = r#"
@@ -512,7 +513,7 @@ fn main() {}
 
     #[test]
     fn test_parse_ts_imports() {
-        let service: Box<dyn CodeGraphService> = Box::new(CodeGraphServiceImpl::new());
+        let service: Arc<dyn CodeGraphService> = Arc::new(CodeGraphServiceImpl::new());
         let builder = CodeGraphBuilder::new(service, vec![], vec![], false);
 
         let content = r#"
@@ -531,7 +532,7 @@ const fs = require('fs');
 
     #[test]
     fn test_parse_python_imports() {
-        let service: Box<dyn CodeGraphService> = Box::new(CodeGraphServiceImpl::new());
+        let service: Arc<dyn CodeGraphService> = Arc::new(CodeGraphServiceImpl::new());
         let builder = CodeGraphBuilder::new(service, vec![], vec![], false);
 
         let content = r#"
@@ -563,7 +564,7 @@ from ..core import engine
         std::fs::create_dir(dir.path().join("utils")).unwrap();
         std::fs::write(dir.path().join("utils/helper.rs"), "pub fn help() {}").unwrap();
 
-        let service: Box<dyn CodeGraphService> = Box::new(CodeGraphServiceImpl::new());
+        let service: Arc<dyn CodeGraphService> = Arc::new(CodeGraphServiceImpl::new());
         let builder = CodeGraphBuilder::new(
             service,
             vec![dir.path().to_path_buf()],
@@ -591,7 +592,7 @@ from ..core import engine
         std::fs::write(dir.path().join("node_modules/pkg.rs"), "").unwrap();
         std::fs::write(dir.path().join("visible.rs"), "").unwrap();
 
-        let service: Box<dyn CodeGraphService> = Box::new(CodeGraphServiceImpl::new());
+        let service: Arc<dyn CodeGraphService> = Arc::new(CodeGraphServiceImpl::new());
         let builder = CodeGraphBuilder::new(
             service,
             vec![dir.path().to_path_buf()],
@@ -619,7 +620,7 @@ from ..core import engine
         .unwrap();
         std::fs::write(dir.path().join("utils.rs"), "pub fn help() {}\n").unwrap();
 
-        let service: Box<dyn CodeGraphService> = Box::new(CodeGraphServiceImpl::new());
+        let service: Arc<dyn CodeGraphService> = Arc::new(CodeGraphServiceImpl::new());
         let builder = CodeGraphBuilder::new(
             service,
             vec![dir.path().to_path_buf()],

--- a/engine/src/orchestrator/application/orchestrator_impl.rs
+++ b/engine/src/orchestrator/application/orchestrator_impl.rs
@@ -34,6 +34,8 @@ use crate::cancellation::application as cancel_app;
 use crate::audit::application as audit_app;
 use crate::budget_tracking::application as budget_app;
 use crate::code_graph::application::CodeGraphService as CodeGraphServiceTrait;
+use crate::code_graph::application::service::CodeGraphFormatter as CodeGraphFormatterTrait;
+use crate::code_graph::application::service_impl::CodeGraphFormatterImpl;
 use crate::event_system::application as event_app;
 
 pub struct OrchestratorServiceImpl {
@@ -105,6 +107,51 @@ impl OrchestratorServiceImpl {
 
     fn gen_id(&self) -> Uuid {
         Uuid::new_v4()
+    }
+
+    /// Build a module dependency graph string from the repo root.
+    ///
+    /// Uses CodeGraphBuilder to scan the workspace and CodeGraphFormatter
+    /// to produce compact output. Returns None if CodeGraphService is not
+    /// configured or if any step fails (non-fatal — the pipeline continues
+    /// without module deps).
+    async fn build_module_deps(&self, repo_root: &str) -> Option<String> {
+        let code_graph_service = self.code_graph_service.as_ref()?.clone();
+        let root = std::path::PathBuf::from(repo_root);
+        if !root.exists() {
+            return None;
+        }
+
+        // 1. Use CodeGraphBuilder to scan the workspace
+        let extensions = vec![
+            "rs".to_string(),
+            "ts".to_string(),
+            "tsx".to_string(),
+            "js".to_string(),
+            "py".to_string(),
+        ];
+        let builder = crate::code_graph::application::builder::CodeGraphBuilder::new(
+            code_graph_service.clone(),
+            vec![root.clone()],
+            extensions,
+            false,
+        );
+        let build_out = builder.build().await.ok()?;
+
+        // 2. Format as compact citations (FastContext <final_answer> pattern)
+        let formatter = CodeGraphFormatterImpl::new();
+        let formatted = CodeGraphFormatterTrait::format(
+            &formatter,
+            crate::code_graph::application::dto::FormatGraphInput {
+                graph: build_out.graph,
+                format: crate::code_graph::application::dto::OutputFormat::Compact,
+                include_metadata: false,
+            },
+        )
+        .await
+        .ok()?;
+
+        Some(formatted.output)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -206,7 +253,10 @@ impl OrchestratorService for OrchestratorServiceImpl {
         // 1. Publish PlanningStarted
         let _ = self.event_bus.publish(Self::planning_started_event(execution_id, input.intent.clone())).await;
 
-        // 2. Run planning pipeline
+        // 2. Build module dependency graph if CodeGraphService is available
+        let module_deps = self.build_module_deps(&input.repo_root).await;
+
+        // 3. Run planning pipeline
         let plan_out = self.planning_pipeline
             .plan_with_graph(planning_dto::PlanWithGraphInput {
                 intent: crate::planning::domain::intent::UserIntent::new(input.intent.clone(), Some(execution_id)),
@@ -214,6 +264,7 @@ impl OrchestratorService for OrchestratorServiceImpl {
                 enable_generator_fallback: true,
                 skip_validation: false,
                 repo_root: input.repo_root.clone(),
+                module_deps,
             })
             .await
             .map_err(|e| OrchestratorError::PlanningFailed {
@@ -334,6 +385,7 @@ impl OrchestratorService for OrchestratorServiceImpl {
                 intent: crate::planning::domain::intent::UserIntent::new(input.intent, None),
                 execution_id: None, enable_generator_fallback: true, skip_validation: false,
                 repo_root: input.repo_root.clone(),
+                module_deps: None,
             })
             .await
             .map_err(|e| OrchestratorError::PlanningFailed { detail: e.to_string(), intent: String::new() })?;

--- a/engine/src/planning/application/dto/mod.rs
+++ b/engine/src/planning/application/dto/mod.rs
@@ -48,6 +48,13 @@ pub struct PlanInput {
     /// Repository root directory for building RepoContext.
     #[serde(default)]
     pub repo_root: String,
+
+    /// Pre-computed module dependency graph (CodeGraph formatted output).
+    /// Set by the orchestrator before passing to the pipeline.
+    /// When present, the pipeline injects this into RepoContext.module_deps
+    /// so the LLM sees module dependency relationships.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub module_deps: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -101,6 +108,11 @@ pub struct PlanWithGraphInput {
     /// Repository root directory for building RepoContext.
     #[serde(default)]
     pub repo_root: String,
+
+    /// Pre-computed module dependency graph (CodeGraph formatted output).
+    /// Set by the orchestrator before passing to the pipeline.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub module_deps: Option<String>,
 }
 
 /// Output from the `plan_with_graph()` flow.

--- a/engine/src/planning/application/pipeline_impl.rs
+++ b/engine/src/planning/application/pipeline_impl.rs
@@ -525,6 +525,11 @@ impl PlanningPipelineService for PlanningPipelineImpl {
                                         )
                                     });
 
+                            // Inject pre-computed module dependency graph if provided
+                            if let Some(ref deps) = input.module_deps {
+                                repo_context = repo_context.clone().with_module_deps(deps.clone());
+                            }
+
                             // Enrich with existing templates from the template engine
                             if let Ok(list_output) = self.template_service.list_templates().await {
                                 repo_context.existing_templates = list_output
@@ -601,6 +606,7 @@ impl PlanningPipelineService for PlanningPipelineImpl {
             enable_generator_fallback: input.enable_generator_fallback,
             skip_validation: input.skip_validation,
             repo_root: input.repo_root,
+            module_deps: input.module_deps,
         };
 
         let plan_output = self.plan(plan_input).await?;

--- a/engine/src/planning/tests.rs
+++ b/engine/src/planning/tests.rs
@@ -599,6 +599,7 @@ async fn test_plan_high_confidence_returns_planning_result() {
         enable_generator_fallback: false,
         skip_validation: true,
         repo_root: String::new(),
+        module_deps: None,
     };
 
     let result = pipeline.plan(input).await;
@@ -626,6 +627,7 @@ async fn test_plan_tracks_llm_usage() {
         enable_generator_fallback: false,
         skip_validation: true,
         repo_root: String::new(),
+        module_deps: None,
     };
 
     let result = pipeline.plan(input).await.unwrap();
@@ -644,6 +646,7 @@ async fn test_plan_low_confidence_no_generator_returns_error() {
         enable_generator_fallback: false,
         skip_validation: true,
         repo_root: String::new(),
+        module_deps: None,
     };
 
     let result = pipeline.plan(input).await;
@@ -671,6 +674,7 @@ async fn test_plan_with_generator_fallback_attempts_generation() {
         enable_generator_fallback: true,
         skip_validation: true,
         repo_root: String::new(),
+        module_deps: None,
     };
 
     let result = pipeline.plan(input).await;
@@ -698,6 +702,7 @@ async fn test_plan_with_graph_returns_output() {
         enable_generator_fallback: false,
         skip_validation: true,
         repo_root: String::new(),
+        module_deps: None,
     };
 
     let result = pipeline.plan_with_graph(input).await;


### PR DESCRIPTION
## Summary

Wires the two remaining connections that were missing after the code-graph epic integration audit.

### Connection 1: Orchestrator builds CodeGraph

```
Before: OrchestratorImpl stores code_graph_service but never calls it
After:  build_module_deps() helper scans workspace via CodeGraphBuilder,
        formats as Compact output, sets module_deps on PlanWithGraphInput
```

### Connection 2: Pipeline injects module_deps into RepoContext

```
Before: Pipeline receives module_deps in PlanWithGraphInput but ignores it
After:  After RepoContext::from_path(), chains .with_module_deps(deps) 
        when present
```

### Supporting change

CodeGraphBuilder now accepts `Arc<dyn CodeGraphService>` instead of `Box<dyn CodeGraphService>` for compatibility with the orchestrator's Arc-based DI pattern. All existing tests updated.

## End-to-end flow

```
OrchestratorBuilder
  .with_code_graph_service(Arc::new(CodeGraphServiceImpl))
  .build()
  → OrchestratorImpl::run() calls build_module_deps()
  → CodeGraphBuilder scans workspace
  → CodeGraphFormatter::Compact() formats as file → [deps]
  → module_deps lands in PlanWithGraphInput
  → PipelineImpl sets it on RepoContext via .with_module_deps()
  → build_system_prompt() includes MODULE DEPENDENCY GRAPH section
```

## Test Results
- 63 code_graph: ✅
- 120 planning: ✅
- 24 orchestrator: ✅