### PR TITLE
feat: hooks architecture readiness — runbook, DR plan, docs

### DIFF
--- a/engine/docs/dr-plan-hooks.md
+++ b/engine/docs/dr-plan-hooks.md
@@ -1,0 +1,164 @@
+# Disaster Recovery Plan: hooks Module
+
+<!--
+Canonical Reference: .pi/architecture/modules/hooks.md
+Last Updated: 2026-06-19
+-->
+
+## Scope
+
+This DR plan covers the `hooks` module — external script-based interception
+points that run as child processes around every tool execution. Hooks are
+stateless: configuration is loaded from `.rigorix/hooks.toml` at startup, and
+each hook execution is an independent child process.
+
+## RTO/RPO Targets
+
+| Metric | Target | Rationale |
+|--------|--------|-----------|
+| RTO (Recovery Time Objective) | < 30 seconds | Module is stateless — re-create `HookRunner` with config |
+| RPO (Recovery Point Objective) | N/A (stateless) | Hook configuration is stored in filesystem (`.rigorix/hooks.toml`) |
+
+## Backup Strategy
+
+### Configuration
+
+Hook configuration is stored in the workspace's `.rigorix/hooks.toml` file.
+This file should be version-controlled (committed to the project repository).
+
+| Data | Backup Strategy | Frequency | Retention |
+|------|----------------|-----------|-----------|
+| `hooks.toml` config | Version control (git) | On change | Full git history |
+
+### No State to Back Up
+
+The hooks module is **stateless**:
+- Hook commands are executed as child processes — no internal state is modified
+- Hook results (`HookRunResult`) are ephemeral — consumed immediately by the execution engine
+- No database, no queue, no persistent storage is managed by this module
+
+## Restore Procedure
+
+### Scenario: Hook Configuration Lost or Corrupted
+
+1. **Detect**: Engine logs `HookError::CommandNotFound` or configuration parse error
+2. **Isolate**: Verify `.rigorix/hooks.toml` exists and is valid TOML
+3. **Restore**: 
+   ```bash
+   # Restore from version control
+   git checkout HEAD -- .rigorix/hooks.toml
+   ```
+4. **Verify**:
+   ```bash
+   # Validate hook config
+   bash engine/.pi/scripts/ci/check_hooks_contracts.sh
+   ```
+5. **Recover**: Restart the engine or trigger config reload
+
+### Scenario: Hook Binary Missing
+
+1. **Detect**: `HookError::CommandNotFound` for hook command
+2. **Isolate**: Check if binary exists in PATH
+   ```bash
+   which rigorix-hook-validate-path
+   ```
+3. **Restore**: Install missing hook binary:
+   ```bash
+   cargo install rigorix-hooks
+   ```
+4. **Verify**: Test hook execution directly:
+   ```bash
+   echo '{"event":"pre_tool_use","tool_name":"ls","tool_input":{},"session_id":"test","workspace_root":"."}' \
+     | rigorix-hook-validate-path
+   ```
+5. **Recover**: Restart engine or trigger config reload
+
+### Scenario: All Hooks Failing
+
+1. **Stop**: Create `HookAbortSignal` to cancel running executions
+2. **Remove**: Temporarily clear hook config:
+   ```toml
+   [hooks]
+   pre_tool_use = []
+   post_tool_use = []
+   post_tool_use_failure = []
+   ```
+3. **Diagnose**: Test each hook in isolation
+4. **Restore**: Re-add verified hooks one at a time
+
+## Failover Plan
+
+### Single Instance (Default Deployment)
+
+The hooks module runs in-process within the engine. Failover follows the engine's
+failover plan:
+
+1. Engine process fails → OS restarts (systemd/supervisor)
+2. Engine re-initializes → `HookRunner` created fresh from config
+3. Hook binaries remain on filesystem — no data loss
+
+### High-Availability Deployment
+
+Not currently supported — hooks run in-process. If HA is required:
+
+1. Deploy engine behind a load balancer (multiple replicas)
+2. Each replica loads the same `.rigorix/hooks.toml` from shared config
+3. Hook binaries must be installed on every replica node
+4. File system hooks must use shared storage (NFS) or be containerized
+
+## Disaster Scenarios
+
+### Scenario 1: Malicious Hook Script
+
+| Aspect | Detail |
+|--------|--------|
+| **Impact** | Hook could modify files, exfiltrate data, or block legitimate operations |
+| **Detection** | Unexpected tool blocks, modified tool inputs, file system changes |
+| **Containment** | Kill engine process; remove malicious hook from config |
+| **Recovery** | Audit hook script; restore from git history; add security validation |
+| **Prevention** | Hooks run from `.rigorix/hooks/` directory only; validate hook paths |
+
+### Scenario 2: Hook Blocks All Tool Execution
+
+| Aspect | Detail |
+|--------|--------|
+| **Impact** | All tool executions denied — engine cannot function |
+| **Detection** | Every tool returns `PermissionOutcome::Deny` |
+| **Containment** | Clear `pre_tool_use` config and restart engine |
+| **Recovery** | Diagnose hook decision logic; fix deny condition; re-add hooks |
+| **Prevention** | Test hooks in CI; add integration tests for deny/allow decisions |
+
+### Scenario 3: Hook Corrupts Tool Input
+
+| Aspect | Detail |
+|--------|--------|
+| **Impact** | Tools execute with modified input — could cause data corruption |
+| **Detection** | Unexpected tool behavior; audit trail shows `updated_input` |
+| **Containment** | Disable hooks that use `Modify` decision; restart engine |
+| **Recovery** | Review hook `Modify` logic; validate input transformation |
+| **Prevention** | Immutable audit trail of original vs. modified input |
+
+## Testing DR Readiness
+
+| Test | Frequency | Procedure |
+|------|-----------|-----------|
+| Config load failure | Quarterly | Corrupt `.rigorix/hooks.toml` → verify engine degrades gracefully |
+| Hook binary missing | Quarterly | Remove hook binary → verify `CommandNotFound` handled |
+| Hook timeout | Quarterly | Set `timeout_secs: 1` with slow hook → verify timeout handling |
+| Hook abort signal | Quarterly | Set abort before execution → verify cancelled result |
+| All hooks denied | Quarterly | Configure deny-all hook → verify execution blocked gracefully |
+
+## DR Kit Contents
+
+| Item | Location | Purpose |
+|------|----------|---------|
+| Last known good `.rigorix/hooks.toml` | Version control | Emergency rollback of hook config |
+| Hook binary installation script | Repository | Re-install hook binaries |
+| DR test scripts | `.pi/scripts/dr/` | Automated DR readiness tests |
+| Architecture docs | `.pi/architecture/modules/hooks.md` | System understanding |
+
+## Related Documents
+
+- [Runbook: hooks](runbook-hooks.md)
+- [Architecture: hooks](../.pi/architecture/modules/hooks.md)
+- [Contract Freeze: hooks](../.pi/issues/issue-contract-freeze.md)

--- a/engine/docs/runbook-hooks.md
+++ b/engine/docs/runbook-hooks.md
@@ -1,0 +1,213 @@
+# Runbook: hooks Module
+
+<!--
+Canonical Reference: .pi/architecture/modules/hooks.md
+Last Updated: 2026-06-19
+-->
+
+## Overview
+
+The `hooks` module provides external script-based interception points around every
+tool execution. Hooks run as shell commands receiving JSON payloads on stdin and
+returning structured JSON decisions. They enable deployment-specific policies,
+CI/CD integration, audit enrichment, and custom pre/post-flight validation.
+
+## Startup Sequence
+
+### Dependencies
+
+| Dependency | Required | Description |
+|------------|----------|-------------|
+| std::process::Command | Yes | Child process spawning for hook commands |
+| serde / serde_json | Yes | JSON protocol serialization/deserialization |
+| std::sync::atomic | Yes | HookAbortSignal for cooperative cancellation |
+| HookConfig | Yes | Configuration loaded from `.rigorix/hooks.toml` |
+
+### Initialization
+
+1. Load `HookConfig` from configuration source (`.rigorix/hooks.toml`)
+2. Create a `HookRunner` (struct) with the config
+3. Pass the runner to the Execution Engine pipeline
+
+```rust
+use rigorix::hooks::domain::HookConfig;
+use rigorix::hooks::application::HookRunner;
+
+// From configuration
+let config: HookConfig = load_hook_config()?;
+let runner = HookRunner::new(config);
+```
+
+### Quick Start
+
+```rust
+use rigorix::hooks::domain::*;
+use rigorix::hooks::application::*;
+
+// Create a runner with PreToolUse hooks
+let config = HookConfig {
+    pre_tool_use: vec![
+        "rigorix-hook-validate-path".into(),
+        "rigorix-hook-ci-guard".into(),
+    ],
+    ..Default::default()
+};
+let runner = HookRunner::new(config);
+
+// Run hooks before a tool execution
+let result = runner.run_pre_tool_use(
+    "write_file",
+    &tool_input,
+    None,           // abort_signal
+    None,           // progress_reporter
+);
+
+if result.is_denied() {
+    // Tool blocked — report reason to LLM
+} else if let Some(modified) = result.modified_input() {
+    // Use modified input for tool execution
+}
+```
+
+## Graceful Shutdown
+
+### Hook Execution Interruption
+
+1. Create a `HookAbortSignal` and share it with running hooks
+2. Call `signal.abort()` to trigger cooperative cancellation
+3. Running hook processes should check the signal and terminate
+4. After timeout, any remaining processes are killed
+
+```rust
+let abort = HookAbortSignal::new();
+
+// Spawn hook runner with abort signal
+let signal = abort.clone();
+let handle = std::thread::spawn(move || {
+    runner.run_pre_tool_use("write_file", &input, Some(&signal), None);
+});
+
+// If cancellation needed:
+abort.abort();
+handle.join().unwrap();
+```
+
+### Timeout Handling
+
+- Default hook timeout: 30 seconds (configurable via `HookConfig.timeout_secs`)
+- On timeout: hook process is killed
+- PreToolUse timeout → tool is **blocked** (safety-first)
+- PostToolUse/PostToolUseFailure timeout → tool result returned without hook feedback
+
+## Common Failure Modes and Recovery
+
+| Failure Mode | Symptom | Cause | Recovery |
+|-------------|---------|-------|----------|
+| Hook command not found | `HookError::CommandNotFound` | Command not in PATH | Hook is skipped; execution continues with warning |
+| Hook execution timeout | `HookError::Timeout` | Hook script hangs or is slow | Increase `timeout_secs` in config; debug hook script |
+| Invalid JSON response | `HookError::InvalidJson` | Hook stdout malformed | Validate hook script output; check for stderr leakage |
+| Hook process error | `HookError::ProcessError` | Non-zero exit + no valid JSON | Check hook stderr; fix script |
+| Aborted execution | `HookError::Aborted` | AbortSignal triggered | User cancellation; check if intended |
+| All hooks denied | `HookRunResult.denied == true` | Hook policy prevents operation | Review hook decision logic; override if needed |
+| Permission override | `permission_override` set | Hook elevated/restricted risk | Verify hook is trusted; audit the override |
+
+## Configuration Reference
+
+### `.rigorix/hooks.toml`
+
+```toml
+[hooks]
+# Commands to run before every tool execution
+pre_tool_use = [
+    "rigorix-hook-validate-path",
+    "rigorix-hook-ci-guard --env $RIGORIX_ENV",
+]
+
+# Commands to run after every successful tool execution
+post_tool_use = [
+    "rigorix-hook-fmt-check --path $TOOL_PATH",
+]
+
+# Commands to run after every failed tool execution
+post_tool_use_failure = [
+    "rigorix-hook-notify --channel alerts",
+]
+
+# Hook execution timeout in seconds (default: 30)
+timeout_secs = 30
+
+# Whether PreToolUse hooks run sequentially (default: false = concurrent)
+sequential_pre_tool_use = true
+```
+
+### Environment Variables
+
+| Variable | Set By | Purpose |
+|----------|--------|---------|
+| `RIGORIX_TOOL_NAME` | Engine | Name of the tool being intercepted |
+| `RIGORIX_EVENT` | Engine | Lifecycle event (pre_tool_use, post_tool_use, post_tool_use_failure) |
+| `RIGORIX_SESSION_ID` | Engine | Session/execution identifier for correlation |
+| `RIGORIX_WORKSPACE` | Engine | Absolute path to workspace root |
+
+## Monitoring
+
+### Metrics
+
+Key metrics to monitor (see `Observability` section in architecture docs):
+
+- `hook_execution_duration_ms` — Per-hook execution latency
+- `hook_timeout_count` — Hook timeout counter
+- `hook_deny_count` — Number of tool executions blocked by hooks
+- `hook_failure_count` — Hook execution failure count
+- `hook_total_count` — Total hook executions
+
+### Logging
+
+- Hook lifecycle events emitted via `HookEventPayload` for event bus integration
+- Each hook execution produces: start, completed/failed/aborted events
+- Hook stdout responses are logged at debug level (redact sensitive input)
+- Non-recoverable errors are logged at error level
+
+## Health Check
+
+A healthy hooks module:
+1. Configuration loads successfully (syntax-valid TOML, commands exist)
+2. Hook commands can be spawned (PATH resolution works)
+3. JSON protocol round-trips correctly (valid stdin → valid stdout)
+4. AbortSignal operates correctly (set → detected → process killed)
+
+## Troubleshooting
+
+### Hook Not Executing
+
+1. Check `HookConfig.commands_for(event)` returns your commands
+2. Verify command exists in PATH (or is absolute path)
+3. Check logs for `HookError::CommandNotFound`
+
+### Hook Returns Unexpected Decision
+
+1. Test the hook script directly: `echo '{"event":"pre_tool_use",...}' | your-hook`
+2. Validate stdout is valid `HookStdoutResponse` JSON
+3. Check stderr — hook scripts should output only JSON on stdout
+
+### Hook Hangs
+
+1. Check `timeout_secs` configuration (default 30s)
+2. Verify hook doesn't wait for stdin beyond first read
+3. Check for infinite loops in hook script
+4. Ensure hook handles `HookAbortSignal` properly
+
+## Performance
+
+| Metric | Target | Notes |
+|--------|--------|-------|
+| PreToolUse hook latency | < 500ms per hook | Sequential execution by default for input modification |
+| PostToolUse hook latency | < 2s per hook | Concurrent execution (no input modification) |
+| Hook timeout | 30s (configurable) | Killed on timeout |
+| Process spawn overhead | < 10ms | Per hook command |
+
+## Related Documents
+
+- [Architecture: hooks](../.pi/architecture/modules/hooks.md)
+- [DR Plan: hooks](dr-plan-hooks.md)
+- [Tool System Architecture](../.pi/architecture/modules/tool-system.md)


### PR DESCRIPTION
## Summary

Production-readiness closeout for the hooks module.

## Files
- docs/runbook-hooks.md — startup, shutdown, failure modes, config reference, troubleshooting
- docs/dr-plan-hooks.md — RTO/RPO, backup/restore, failover, disaster scenarios

Closes #417