### PR TITLE
feat: contract freeze for recovery-recipes module (#438)

### DIFF
--- a/engine/.pi/issues/issue-editfileinput.md
+++ b/engine/.pi/issues/issue-editfileinput.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-CODE-GENERATION-2"
+  epic: "TBD"
+  component: "EditFileInput"
+  module: "code-generation"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement EditFileInput for the code-generation module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for editfileinput
+    application:
+      - New service/handler for editfileinput
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/code-generation.md#editfileinput"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    The structured input the LLM provides to target an edit
+
+  file_changes:
+    - "create: src/code-generation/editfileinput/"
+    - "create: tests/unit/code-generation/editfileinput/"
+    - "create: tests/integration/code-generation/editfileinput/"
+---
+
+# ISSUE-CODE-GENERATION-2: EditFileInput
+
+## Intent
+
+The structured input the LLM provides to target an edit
+
+## Architecture Context
+
+- **Module:** code-generation
+- **Component:** EditFileInput
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement EditFileInput for the code-generation module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for editfileinput
+
+### Application
+- New service/handler for editfileinput
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/code-generation.md#editfileinput`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-editfileresult.md
+++ b/engine/.pi/issues/issue-editfileresult.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-CODE-GENERATION-3"
+  epic: "TBD"
+  component: "EditFileResult"
+  module: "code-generation"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement EditFileResult for the code-generation module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for editfileresult
+    application:
+      - New service/handler for editfileresult
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/code-generation.md#editfileresult"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Structured feedback returned to the LLM after every edit — enables self-verification
+
+  file_changes:
+    - "create: src/code-generation/editfileresult/"
+    - "create: tests/unit/code-generation/editfileresult/"
+    - "create: tests/integration/code-generation/editfileresult/"
+---
+
+# ISSUE-CODE-GENERATION-3: EditFileResult
+
+## Intent
+
+Structured feedback returned to the LLM after every edit — enables self-verification
+
+## Architecture Context
+
+- **Module:** code-generation
+- **Component:** EditFileResult
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement EditFileResult for the code-generation module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for editfileresult
+
+### Application
+- New service/handler for editfileresult
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/code-generation.md#editfileresult`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-editfiletool.md
+++ b/engine/.pi/issues/issue-editfiletool.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-CODE-GENERATION-1"
+  epic: "TBD"
+  component: "EditFileTool"
+  module: "code-generation"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement EditFileTool for the code-generation module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for editfiletool
+    application:
+      - New service/handler for editfiletool
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/code-generation.md#editfiletool"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    The primary code insertion mechanism. Replaces an exact text string in a file with new content. The `old_string` serves as both the position anchor and the correctness anchor.
+
+  file_changes:
+    - "create: src/code-generation/editfiletool/"
+    - "create: tests/unit/code-generation/editfiletool/"
+    - "create: tests/integration/code-generation/editfiletool/"
+---
+
+# ISSUE-CODE-GENERATION-1: EditFileTool
+
+## Intent
+
+The primary code insertion mechanism. Replaces an exact text string in a file with new content. The `old_string` serves as both the position anchor and the correctness anchor.
+
+## Architecture Context
+
+- **Module:** code-generation
+- **Component:** EditFileTool
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement EditFileTool for the code-generation module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for editfiletool
+
+### Application
+- New service/handler for editfiletool
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/code-generation.md#editfiletool`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-failurescenario.md
+++ b/engine/.pi/issues/issue-failurescenario.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-RECOVERY-RECIPES-1"
+  epic: "TBD"
+  component: "FailureScenario"
+  module: "recovery-recipes"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement FailureScenario for the recovery-recipes module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for failurescenario
+    application:
+      - New service/handler for failurescenario
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/recovery-recipes.md#failurescenario"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Typed enumeration of all known recoverable failure scenarios
+
+  file_changes:
+    - "create: src/recovery-recipes/failurescenario/"
+    - "create: tests/unit/recovery-recipes/failurescenario/"
+    - "create: tests/integration/recovery-recipes/failurescenario/"
+---
+
+# ISSUE-RECOVERY-RECIPES-1: FailureScenario
+
+## Intent
+
+Typed enumeration of all known recoverable failure scenarios
+
+## Architecture Context
+
+- **Module:** recovery-recipes
+- **Component:** FailureScenario
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement FailureScenario for the recovery-recipes module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for failurescenario
+
+### Application
+- New service/handler for failurescenario
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/recovery-recipes.md#failurescenario`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-hook-protocol.md
+++ b/engine/.pi/issues/issue-hook-protocol.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-HOOKS-2"
+  epic: "TBD"
+  component: "Hook Protocol"
+  module: "hooks"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement Hook Protocol for the hooks module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for hook-protocol
+    application:
+      - New service/handler for hook-protocol
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/hooks.md#hook-protocol"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    JSON contract between the engine and hook scripts
+
+  file_changes:
+    - "create: src/hooks/hook-protocol/"
+    - "create: tests/unit/hooks/hook-protocol/"
+    - "create: tests/integration/hooks/hook-protocol/"
+---
+
+# ISSUE-HOOKS-2: Hook Protocol
+
+## Intent
+
+JSON contract between the engine and hook scripts
+
+## Architecture Context
+
+- **Module:** hooks
+- **Component:** Hook Protocol
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement Hook Protocol for the hooks module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for hook-protocol
+
+### Application
+- New service/handler for hook-protocol
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/hooks.md#hook-protocol`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-hookconfig.md
+++ b/engine/.pi/issues/issue-hookconfig.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-HOOKS-5"
+  epic: "TBD"
+  component: "HookConfig"
+  module: "hooks"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement HookConfig for the hooks module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for hookconfig
+    application:
+      - New service/handler for hookconfig
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/hooks.md#hookconfig"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Declarative hook command registration per event, loaded from config
+
+  file_changes:
+    - "create: src/hooks/hookconfig/"
+    - "create: tests/unit/hooks/hookconfig/"
+    - "create: tests/integration/hooks/hookconfig/"
+---
+
+# ISSUE-HOOKS-5: HookConfig
+
+## Intent
+
+Declarative hook command registration per event, loaded from config
+
+## Architecture Context
+
+- **Module:** hooks
+- **Component:** HookConfig
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement HookConfig for the hooks module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for hookconfig
+
+### Application
+- New service/handler for hookconfig
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/hooks.md#hookconfig`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-hookevent.md
+++ b/engine/.pi/issues/issue-hookevent.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-HOOKS-1"
+  epic: "TBD"
+  component: "HookEvent"
+  module: "hooks"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement HookEvent for the hooks module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for hookevent
+    application:
+      - New service/handler for hookevent
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/hooks.md#hookevent"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Identifies which lifecycle point a hook runs at
+
+  file_changes:
+    - "create: src/hooks/hookevent/"
+    - "create: tests/unit/hooks/hookevent/"
+    - "create: tests/integration/hooks/hookevent/"
+---
+
+# ISSUE-HOOKS-1: HookEvent
+
+## Intent
+
+Identifies which lifecycle point a hook runs at
+
+## Architecture Context
+
+- **Module:** hooks
+- **Component:** HookEvent
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement HookEvent for the hooks module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for hookevent
+
+### Application
+- New service/handler for hookevent
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/hooks.md#hookevent`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-hookrunner.md
+++ b/engine/.pi/issues/issue-hookrunner.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-HOOKS-4"
+  epic: "TBD"
+  component: "HookRunner"
+  module: "hooks"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement HookRunner for the hooks module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for hookrunner
+    application:
+      - New service/handler for hookrunner
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/hooks.md#hookrunner"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Executes all registered hook commands for a given event and aggregates results
+
+  file_changes:
+    - "create: src/hooks/hookrunner/"
+    - "create: tests/unit/hooks/hookrunner/"
+    - "create: tests/integration/hooks/hookrunner/"
+---
+
+# ISSUE-HOOKS-4: HookRunner
+
+## Intent
+
+Executes all registered hook commands for a given event and aggregates results
+
+## Architecture Context
+
+- **Module:** hooks
+- **Component:** HookRunner
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement HookRunner for the hooks module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for hookrunner
+
+### Application
+- New service/handler for hookrunner
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/hooks.md#hookrunner`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-hookrunresult.md
+++ b/engine/.pi/issues/issue-hookrunresult.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-HOOKS-3"
+  epic: "TBD"
+  component: "HookRunResult"
+  module: "hooks"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement HookRunResult for the hooks module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for hookrunresult
+    application:
+      - New service/handler for hookrunresult
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/hooks.md#hookrunresult"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Aggregated result from running all hook commands for an event
+
+  file_changes:
+    - "create: src/hooks/hookrunresult/"
+    - "create: tests/unit/hooks/hookrunresult/"
+    - "create: tests/integration/hooks/hookrunresult/"
+---
+
+# ISSUE-HOOKS-3: HookRunResult
+
+## Intent
+
+Aggregated result from running all hook commands for an event
+
+## Architecture Context
+
+- **Module:** hooks
+- **Component:** HookRunResult
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement HookRunResult for the hooks module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for hookrunresult
+
+### Application
+- New service/handler for hookrunresult
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/hooks.md#hookrunresult`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-readfiletool.md
+++ b/engine/.pi/issues/issue-readfiletool.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-CODE-GENERATION-5"
+  epic: "TBD"
+  component: "ReadFileTool"
+  module: "code-generation"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement ReadFileTool for the code-generation module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for readfiletool
+    application:
+      - New service/handler for readfiletool
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/code-generation.md#readfiletool"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Read files with offset/limit paging and binary detection
+
+  file_changes:
+    - "create: src/code-generation/readfiletool/"
+    - "create: tests/unit/code-generation/readfiletool/"
+    - "create: tests/integration/code-generation/readfiletool/"
+---
+
+# ISSUE-CODE-GENERATION-5: ReadFileTool
+
+## Intent
+
+Read files with offset/limit paging and binary detection
+
+## Architecture Context
+
+- **Module:** code-generation
+- **Component:** ReadFileTool
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement ReadFileTool for the code-generation module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for readfiletool
+
+### Application
+- New service/handler for readfiletool
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/code-generation.md#readfiletool`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-recoverycontext.md
+++ b/engine/.pi/issues/issue-recoverycontext.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-RECOVERY-RECIPES-4"
+  epic: "TBD"
+  component: "RecoveryContext"
+  module: "recovery-recipes"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement RecoveryContext for the recovery-recipes module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for recoverycontext
+    application:
+      - New service/handler for recoverycontext
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/recovery-recipes.md#recoverycontext"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Tracks per-scenario attempt counts and recovery events within an execution session
+
+  file_changes:
+    - "create: src/recovery-recipes/recoverycontext/"
+    - "create: tests/unit/recovery-recipes/recoverycontext/"
+    - "create: tests/integration/recovery-recipes/recoverycontext/"
+---
+
+# ISSUE-RECOVERY-RECIPES-4: RecoveryContext
+
+## Intent
+
+Tracks per-scenario attempt counts and recovery events within an execution session
+
+## Architecture Context
+
+- **Module:** recovery-recipes
+- **Component:** RecoveryContext
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement RecoveryContext for the recovery-recipes module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for recoverycontext
+
+### Application
+- New service/handler for recoverycontext
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/recovery-recipes.md#recoverycontext`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-recoveryrecipe.md
+++ b/engine/.pi/issues/issue-recoveryrecipe.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-RECOVERY-RECIPES-3"
+  epic: "TBD"
+  component: "RecoveryRecipe"
+  module: "recovery-recipes"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement RecoveryRecipe for the recovery-recipes module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for recoveryrecipe
+    application:
+      - New service/handler for recoveryrecipe
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/recovery-recipes.md#recoveryrecipe"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Binds a scenario to its recovery steps and escalation policy
+
+  file_changes:
+    - "create: src/recovery-recipes/recoveryrecipe/"
+    - "create: tests/unit/recovery-recipes/recoveryrecipe/"
+    - "create: tests/integration/recovery-recipes/recoveryrecipe/"
+---
+
+# ISSUE-RECOVERY-RECIPES-3: RecoveryRecipe
+
+## Intent
+
+Binds a scenario to its recovery steps and escalation policy
+
+## Architecture Context
+
+- **Module:** recovery-recipes
+- **Component:** RecoveryRecipe
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement RecoveryRecipe for the recovery-recipes module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for recoveryrecipe
+
+### Application
+- New service/handler for recoveryrecipe
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/recovery-recipes.md#recoveryrecipe`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-recoveryresult.md
+++ b/engine/.pi/issues/issue-recoveryresult.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-RECOVERY-RECIPES-5"
+  epic: "TBD"
+  component: "RecoveryResult"
+  module: "recovery-recipes"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement RecoveryResult for the recovery-recipes module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for recoveryresult
+    application:
+      - New service/handler for recoveryresult
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/recovery-recipes.md#recoveryresult"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    pub enum RecoveryResult {
+
+  file_changes:
+    - "create: src/recovery-recipes/recoveryresult/"
+    - "create: tests/unit/recovery-recipes/recoveryresult/"
+    - "create: tests/integration/recovery-recipes/recoveryresult/"
+---
+
+# ISSUE-RECOVERY-RECIPES-5: RecoveryResult
+
+## Intent
+
+pub enum RecoveryResult {
+
+## Architecture Context
+
+- **Module:** recovery-recipes
+- **Component:** RecoveryResult
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement RecoveryResult for the recovery-recipes module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for recoveryresult
+
+### Application
+- New service/handler for recoveryresult
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/recovery-recipes.md#recoveryresult`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-recoverystep.md
+++ b/engine/.pi/issues/issue-recoverystep.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-RECOVERY-RECIPES-2"
+  epic: "TBD"
+  component: "RecoveryStep"
+  module: "recovery-recipes"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement RecoveryStep for the recovery-recipes module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for recoverystep
+    application:
+      - New service/handler for recoverystep
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/recovery-recipes.md#recoverystep"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Individual executable recovery actions
+
+  file_changes:
+    - "create: src/recovery-recipes/recoverystep/"
+    - "create: tests/unit/recovery-recipes/recoverystep/"
+    - "create: tests/integration/recovery-recipes/recoverystep/"
+---
+
+# ISSUE-RECOVERY-RECIPES-2: RecoveryStep
+
+## Intent
+
+Individual executable recovery actions
+
+## Architecture Context
+
+- **Module:** recovery-recipes
+- **Component:** RecoveryStep
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement RecoveryStep for the recovery-recipes module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for recoverystep
+
+### Application
+- New service/handler for recoverystep
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/recovery-recipes.md#recoverystep`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-structuredpatchhunk.md
+++ b/engine/.pi/issues/issue-structuredpatchhunk.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-CODE-GENERATION-4"
+  epic: "TBD"
+  component: "StructuredPatchHunk"
+  module: "code-generation"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement StructuredPatchHunk for the code-generation module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for structuredpatchhunk
+    application:
+      - New service/handler for structuredpatchhunk
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/code-generation.md#structuredpatchhunk"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Individual diff hunk for structured diff output
+
+  file_changes:
+    - "create: src/code-generation/structuredpatchhunk/"
+    - "create: tests/unit/code-generation/structuredpatchhunk/"
+    - "create: tests/integration/code-generation/structuredpatchhunk/"
+---
+
+# ISSUE-CODE-GENERATION-4: StructuredPatchHunk
+
+## Intent
+
+Individual diff hunk for structured diff output
+
+## Architecture Context
+
+- **Module:** code-generation
+- **Component:** StructuredPatchHunk
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement StructuredPatchHunk for the code-generation module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for structuredpatchhunk
+
+### Application
+- New service/handler for structuredpatchhunk
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/code-generation.md#structuredpatchhunk`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-syntaxgate.md
+++ b/engine/.pi/issues/issue-syntaxgate.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-CODE-GENERATION-6"
+  epic: "TBD"
+  component: "SyntaxGate"
+  module: "code-generation"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement SyntaxGate for the code-generation module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for syntaxgate
+    application:
+      - New service/handler for syntaxgate
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/code-generation.md#syntaxgate"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Post-edit tree-sitter syntax verification — uses Rigorix's existing `code_graph` module
+
+  file_changes:
+    - "create: src/code-generation/syntaxgate/"
+    - "create: tests/unit/code-generation/syntaxgate/"
+    - "create: tests/integration/code-generation/syntaxgate/"
+---
+
+# ISSUE-CODE-GENERATION-6: SyntaxGate
+
+## Intent
+
+Post-edit tree-sitter syntax verification — uses Rigorix's existing `code_graph` module
+
+## Architecture Context
+
+- **Module:** code-generation
+- **Component:** SyntaxGate
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement SyntaxGate for the code-generation module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for syntaxgate
+
+### Application
+- New service/handler for syntaxgate
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/code-generation.md#syntaxgate`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/scripts/ci/check_hooks_contracts.sh
+++ b/engine/.pi/scripts/ci/check_hooks_contracts.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# ============================================================================
+# check_hooks_contracts.sh
+#
+# Validates that every contract interface from the hooks module has a
+# concrete implementation. Uses grep/find to detect trait definitions and
+# their implementing structs.
+#
+# Usage: bash .pi/scripts/ci/check_hooks_contracts.sh [--help]
+#
+# Exit codes: 0 = all contracts implemented, 1 = violations found
+# ============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PI_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Determine source directory
+if [ -d "$(cd "$PI_DIR/.." && pwd)/engine/src" ]; then
+    SRC_DIR="$(cd "$PI_DIR/.." && pwd)/engine/src"
+elif [ -d "$(cd "$PI_DIR/.." && pwd)/src" ]; then
+    SRC_DIR="$(cd "$PI_DIR/.." && pwd)/src"
+else
+    echo "ERROR: Source directory not found"
+    exit 1
+fi
+
+HOOKS_DIR="$SRC_DIR/hooks"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+log_pass() { echo "  ✓ PASS: $1"; ((PASS++)); }
+log_fail() { echo "  ✗ FAIL: $1"; ERRORS+=("$1"); ((FAIL++)); }
+
+echo ""
+echo "═══ Hooks Contract Implementation Check ═══"
+echo "Source: $HOOKS_DIR"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Check 1: Service Contracts
+# ---------------------------------------------------------------------------
+echo "--- Service Contracts ---"
+
+if grep -q 'pub trait HookRunnerService' "$HOOKS_DIR/application/service.rs" 2>/dev/null; then
+    # Check for any implementation of HookRunnerService
+    ANY_IMPL=$(grep -rl 'impl.*HookRunnerService' "$HOOKS_DIR" 2>/dev/null || true)
+    if [ -n "$ANY_IMPL" ]; then
+        IMPL_FILE=$(basename "$(echo "$ANY_IMPL" | head -1)")
+        log_pass "HookRunnerService → $IMPL_FILE"
+    else
+        log_fail "HookRunnerService trait has no implementation"
+    fi
+else
+    log_fail "HookRunnerService trait not found"
+fi
+
+if grep -q 'pub trait HookCommandExecutor' "$HOOKS_DIR/application/service.rs" 2>/dev/null; then
+    ANY_IMPL=$(grep -rl 'impl.*HookCommandExecutor' "$HOOKS_DIR" 2>/dev/null || true)
+    if [ -n "$ANY_IMPL" ]; then
+        IMPL_FILE=$(basename "$(echo "$ANY_IMPL" | head -1)")
+        log_pass "HookCommandExecutor → $IMPL_FILE"
+    else
+        log_fail "HookCommandExecutor trait has no implementation"
+    fi
+else
+    log_fail "HookCommandExecutor trait not found"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 2: Factory Contracts
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Factory Contracts ---"
+
+if grep -q 'pub trait HookRunnerFactory' "$HOOKS_DIR/application/factory.rs" 2>/dev/null; then
+    ANY_IMPL=$(grep -rl 'impl.*HookRunnerFactory' "$HOOKS_DIR" 2>/dev/null || true)
+    if [ -n "$ANY_IMPL" ]; then
+        IMPL_FILE=$(basename "$(echo "$ANY_IMPL" | head -1)")
+        log_pass "HookRunnerFactory → $IMPL_FILE"
+    else
+        log_fail "HookRunnerFactory trait has no implementation"
+    fi
+else
+    log_fail "HookRunnerFactory trait not found"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 3: Repository Contracts
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Repository Contracts ---"
+
+if grep -q 'pub trait HookCommandRepository' "$HOOKS_DIR/infrastructure/repository/mod.rs" 2>/dev/null; then
+    ANY_IMPL=$(grep -rl 'impl.*HookCommandRepository' "$HOOKS_DIR" 2>/dev/null || true)
+    if [ -n "$ANY_IMPL" ]; then
+        IMPL_FILE=$(basename "$(echo "$ANY_IMPL" | head -1)")
+        log_pass "HookCommandRepository → $IMPL_FILE"
+    else
+        log_fail "HookCommandRepository trait has no implementation"
+    fi
+else
+    log_fail "HookCommandRepository trait not found"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 4: Domain entities exist
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Domain Entities ---"
+
+if grep -q 'pub enum HookEvent' "$HOOKS_DIR/domain/event.rs" 2>/dev/null; then
+    log_pass "HookEvent enum exists"
+    VARIANT_COUNT=$(grep -cE '    (PreToolUse|PostToolUse|PostToolUseFailure)($|[ ,])' "$HOOKS_DIR/domain/event.rs" 2>/dev/null || echo 0)
+    if [ "$VARIANT_COUNT" -ge 3 ]; then
+        log_pass "All 3 HookEvent variants present (found: $VARIANT_COUNT)"
+    else
+        log_fail "Only $VARIANT_COUNT HookEvent variants found (expected 3)"
+    fi
+else
+    log_fail "HookEvent enum not found"
+fi
+
+if grep -q 'pub struct HookRunResult' "$HOOKS_DIR/domain/result.rs" 2>/dev/null; then
+    log_pass "HookRunResult struct exists"
+else
+    log_fail "HookRunResult struct not found"
+fi
+
+if grep -q 'pub struct HookConfig' "$HOOKS_DIR/domain/config.rs" 2>/dev/null; then
+    log_pass "HookConfig struct exists"
+else
+    log_fail "HookConfig struct not found"
+fi
+
+if grep -q 'pub enum HookError' "$HOOKS_DIR/domain/error.rs" 2>/dev/null; then
+    log_pass "HookError enum exists"
+else
+    log_fail "HookError enum not found"
+fi
+
+if grep -q 'pub struct HookAbortSignal' "$HOOKS_DIR/domain/abort.rs" 2>/dev/null; then
+    log_pass "HookAbortSignal struct exists"
+else
+    log_fail "HookAbortSignal struct not found"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 5: Protocol types exist
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Protocol Types ---"
+
+for proto in HookStdinPayload HookStdoutResponse HookDecision HookPermissionOverride; do
+    if grep -q "pub \\(enum\\|struct\\) $proto" "$HOOKS_DIR/domain/protocol.rs" 2>/dev/null; then
+        log_pass "$proto exists"
+    else
+        log_fail "$proto not found"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Check 6: Event payload types exist
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Event Payload Types ---"
+
+for payload in HookExecutionStartedPayload HookExecutionCompletedPayload \
+               HookExecutionFailedPayload HookExecutionAbortedPayload HookEventPayload; do
+    if grep -q "pub \\(enum\\|struct\\) $payload" "$HOOKS_DIR/domain/event_payload.rs" 2>/dev/null; then
+        log_pass "$payload exists"
+    else
+        log_fail "$payload not found"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Check 7: DTOs exist
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- DTOs ---"
+
+for dto in RunPreToolUseInput RunPreToolUseOutput RunPostToolUseInput RunPostToolUseOutput \
+           RunPostToolUseFailureInput RunPostToolUseFailureOutput RunHooksInput RunHooksOutput \
+           HookRunnerConfigInput HookRunnerStatus; do
+    if grep -q "pub struct $dto" "$HOOKS_DIR/application/dto/mod.rs" 2>/dev/null; then
+        log_pass "$dto DTO exists"
+    else
+        log_fail "$dto DTO not found"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Check 8: HTTP Contracts exist
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- HTTP Contracts ---"
+
+for endpoint in RUN_HOOKS_PATH GET_HOOKS_CONFIG_PATH UPDATE_HOOKS_CONFIG_PATH TEST_HOOK_PATH; do
+    if grep -q "pub const $endpoint" "$HOOKS_DIR/interfaces/http/mod.rs" 2>/dev/null; then
+        log_pass "HTTP endpoint $endpoint exists"
+    else
+        log_fail "HTTP endpoint $endpoint not found"
+    fi
+done
+
+for req_resp in RunHooksRequest RunHooksResponse HookConfigResponse UpdateHookConfigRequest \
+                TestHookRequest TestHookResponse ApiErrorResponse; do
+    if grep -q "pub struct $req_resp" "$HOOKS_DIR/interfaces/http/mod.rs" 2>/dev/null; then
+        log_pass "$req_resp exists"
+    else
+        log_fail "$req_resp not found"
+    fi
+done
+
+if grep -q 'pub mod error_codes' "$HOOKS_DIR/interfaces/http/mod.rs" 2>/dev/null; then
+    log_pass "Error codes defined"
+else
+    log_fail "Error codes not defined"
+fi
+
+# ---------------------------------------------------------------------------
+# Helper methods check
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Helper Methods ---"
+
+for method in is_pre_tool_use is_post_tool_use is_post_tool_use_failure as_str; do
+    if grep -q "fn $method" "$HOOKS_DIR/domain/event.rs" 2>/dev/null; then
+        log_pass "HookEvent::$method() exists"
+    else
+        log_fail "HookEvent::$method() not found"
+    fi
+done
+
+for method in is_allowed is_denied allow deny; do
+    if grep -q "fn $method" "$HOOKS_DIR/domain/protocol.rs" 2>/dev/null; then
+        log_pass "HookStdoutResponse::$method() exists"
+    else
+        log_fail "HookStdoutResponse::$method() not found"
+    fi
+done
+
+for method in is_allowed is_denied is_failed is_cancelled merge modified_input; do
+    if grep -q "fn $method" "$HOOKS_DIR/domain/result.rs" 2>/dev/null; then
+        log_pass "HookRunResult::$method() exists"
+    else
+        log_fail "HookRunResult::$method() not found"
+    fi
+done
+
+for method in commands_for has_commands_for is_empty total_command_count; do
+    if grep -q "fn $method" "$HOOKS_DIR/domain/config.rs" 2>/dev/null; then
+        log_pass "HookConfig::$method() exists"
+    else
+        log_fail "HookConfig::$method() not found"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "═══ Summary ═══"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo ""
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo "FAILURES:"
+    for err in "${ERRORS[@]}"; do
+        echo "  - $err"
+    done
+    echo ""
+    echo "Some hooks contracts are missing implementations."
+    exit 1
+fi
+
+echo "All hooks contracts have implementations."
+exit 0

--- a/engine/.pi/scripts/ci/check_hooks_coverage.sh
+++ b/engine/.pi/scripts/ci/check_hooks_coverage.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# ============================================================================
+# check_hooks_coverage.sh
+#
+# Enforces minimum code coverage thresholds for the hooks module.
+# Uses cargo-tarpaulin or llvm-cov to measure line coverage.
+# Falls back to test count if no coverage tool is available.
+#
+# Usage: bash .pi/scripts/ci/check_hooks_coverage.sh [--help]
+#
+# Exit codes: 0 = coverage meets thresholds, 1 = below threshold
+# ============================================================================
+set -uo pipefail
+
+MIN_COVERAGE=80
+MIN_TEST_COUNT=60
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+log_pass() { echo "  ✓ PASS: $1"; ((PASS++)); }
+log_fail() { echo "  ✗ FAIL: $1"; ERRORS+=("$1"); ((FAIL++)); }
+
+echo ""
+echo "═══ Hooks Coverage Threshold Check ═══"
+echo ""
+
+# Determine if we're in a Rust project
+if [ ! -f "Cargo.toml" ] && [ ! -f "engine/Cargo.toml" ]; then
+    log_fail "No Cargo.toml found (not a Rust project)"
+    echo ""
+    echo "Coverage threshold check FAILED."
+    exit 1
+fi
+
+# Determine project root
+PROJECT_ROOT="."
+if [ -f "engine/Cargo.toml" ]; then
+    PROJECT_ROOT="engine"
+fi
+
+echo "Project: $PROJECT_ROOT"
+echo "Minimum coverage: ${MIN_COVERAGE}%"
+echo ""
+
+# Try tarpaulin first, then llvm-cov
+if command -v cargo-tarpaulin &>/dev/null; then
+    echo "Using cargo-tarpaulin for coverage..."
+    cd "$PROJECT_ROOT"
+
+    COVERAGE_OUTPUT=$(cargo tarpaulin --out Xml --output-dir ../coverage --exclude-files "src/hooks/interfaces/*" 2>&1 || true)
+    COVERAGE_PCT=$(echo "$COVERAGE_OUTPUT" | grep -oE '[0-9]+\.[0-9]+%' | tail -1 | tr -d '%')
+
+    if [ -z "$COVERAGE_PCT" ]; then
+        if [ -f "../coverage/cobertura.xml" ]; then
+            COVERAGE_PCT=$(grep -oE 'line-rate="[0-9.]+"' ../coverage/cobertura.xml | head -1 | grep -oE '[0-9.]+' | awk '{printf "%.0f", $1 * 100}')
+        fi
+    fi
+
+    if [ -z "$COVERAGE_PCT" ]; then
+        log_fail "Could not determine coverage percentage from tarpaulin output"
+    elif [ "$(printf '%.0f' "$COVERAGE_PCT")" -ge "$MIN_COVERAGE" ]; then
+        log_pass "Coverage: ${COVERAGE_PCT}% (threshold: ${MIN_COVERAGE}%)"
+    else
+        log_fail "Coverage: ${COVERAGE_PCT}% is below threshold of ${MIN_COVERAGE}%"
+    fi
+
+    cd ..
+
+elif command -v cargo-llvm-cov &>/dev/null; then
+    echo "Using cargo-llvm-cov for coverage..."
+
+    COVERAGE_OUTPUT=$(cargo llvm-cov --workspace --lcov --output-path coverage/lcov.info 2>&1 || true)
+    if [ -f "coverage/lcov.info" ]; then
+        TOTAL_LINES=$(grep -c '^DA:' coverage/lcov.info || true)
+        HIT_LINES=$(grep '^DA:.*,[1-9][0-9]*$' coverage/lcov.info | wc -l | tr -d ' ')
+        if [ "$TOTAL_LINES" -gt 0 ]; then
+            COVERAGE_PCT=$((HIT_LINES * 100 / TOTAL_LINES))
+            if [ "$COVERAGE_PCT" -ge "$MIN_COVERAGE" ]; then
+                log_pass "Coverage: ${COVERAGE_PCT}% (threshold: ${MIN_COVERAGE}%)"
+            else
+                log_fail "Coverage: ${COVERAGE_PCT}% is below threshold of ${MIN_COVERAGE}%"
+            fi
+        else
+            log_fail "No coverage data found"
+        fi
+    else
+        log_fail "No lcov.info generated"
+    fi
+else
+    echo "No coverage tool found (cargo-tarpaulin or cargo-llvm-cov)."
+    echo "Counting test functions as a fallback metric..."
+
+    # Count test functions in hooks module
+    TEST_COUNT=$(grep -r '^\s*#\[test\]' "$PROJECT_ROOT/src/hooks/" 2>/dev/null | wc -l | tr -d ' ')
+    if [ "$TEST_COUNT" -ge "$MIN_TEST_COUNT" ]; then
+        log_pass "Test count: $TEST_COUNT tests in hooks module (minimum $MIN_TEST_COUNT required)"
+    else
+        log_fail "Only $TEST_COUNT tests found in hooks module (minimum $MIN_TEST_COUNT required)"
+    fi
+fi
+
+echo ""
+echo "═══ Summary ═══"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo ""
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo "FAILURES:"
+    for err in "${ERRORS[@]}"; do
+        echo "  - $err"
+    done
+    echo ""
+    echo "Coverage thresholds not met."
+    exit 1
+fi
+
+echo "Coverage thresholds satisfied."
+exit 0

--- a/engine/.pi/scripts/ci/run_hardening_stages.sh
+++ b/engine/.pi/scripts/ci/run_hardening_stages.sh
@@ -299,6 +299,11 @@ run_stage "25" "execution-engine_proofing" \
 run_stage "26" "orchestrator_proofing" \
     "${SCRIPTS_DIR}/stage_orchestrator_proofing.sh" \
     "always"
+
+# Stage 27: Hooks Proofing
+run_stage "27" "hooks_proofing" \
+    "${SCRIPTS_DIR}/stage_hooks_proofing.sh" \
+    "always"
 # ── Summary ──
 
 echo ""

--- a/engine/.pi/scripts/ci/stage_hooks_proofing.sh
+++ b/engine/.pi/scripts/ci/stage_hooks_proofing.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# ============================================================================
+# stage_hooks_proofing.sh
+#
+# CI stage wrapper that runs all hooks proofing checks:
+#   1. Contract implementation check — all interfaces have implementations
+#   2. Coverage threshold check — meets minimum coverage
+#
+# Usage: bash .pi/scripts/ci/stage_hooks_proofing.sh [--help]
+#
+# Exit codes: 0 = all checks pass, 1 = any check fails
+# ============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+log_pass() { echo "  ✓ PASS: $1"; ((PASS++)); }
+log_fail() { echo "  ✗ FAIL: $1"; ERRORS+=("$1"); ((FAIL++)); }
+
+echo ""
+echo "╔══════════════════════════════════════════════╗"
+echo "║   Hooks Proofing Stage                        ║"
+echo "╚══════════════════════════════════════════════╝"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Check 1: Contract Implementation Check
+# ---------------------------------------------------------------------------
+echo "--- 1. Contract Implementation Check ---"
+echo ""
+
+if bash "${SCRIPT_DIR}/check_hooks_contracts.sh" 2>&1; then
+    log_pass "Contract implementation check passed"
+else
+    log_fail "Contract implementation check failed"
+fi
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# Check 2: Coverage Threshold Check
+# ---------------------------------------------------------------------------
+echo "--- 2. Coverage Threshold Check ---"
+echo ""
+
+if bash "${SCRIPT_DIR}/check_hooks_coverage.sh" 2>&1; then
+    log_pass "Coverage threshold check passed"
+else
+    log_fail "Coverage threshold check failed"
+fi
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "═══ Stage Summary ═══"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo ""
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo "FAILURES:"
+    for err in "${ERRORS[@]}"; then
+        echo "  - $err"
+    done
+    echo ""
+    echo "Hooks proofing stage FAILED."
+    exit 1
+fi
+
+echo "Hooks proofing stage PASSED."
+exit 0

--- a/engine/docs/dr-plan-hooks.md
+++ b/engine/docs/dr-plan-hooks.md
@@ -1,0 +1,164 @@
+# Disaster Recovery Plan: hooks Module
+
+<!--
+Canonical Reference: .pi/architecture/modules/hooks.md
+Last Updated: 2026-06-19
+-->
+
+## Scope
+
+This DR plan covers the `hooks` module — external script-based interception
+points that run as child processes around every tool execution. Hooks are
+stateless: configuration is loaded from `.rigorix/hooks.toml` at startup, and
+each hook execution is an independent child process.
+
+## RTO/RPO Targets
+
+| Metric | Target | Rationale |
+|--------|--------|-----------|
+| RTO (Recovery Time Objective) | < 30 seconds | Module is stateless — re-create `HookRunner` with config |
+| RPO (Recovery Point Objective) | N/A (stateless) | Hook configuration is stored in filesystem (`.rigorix/hooks.toml`) |
+
+## Backup Strategy
+
+### Configuration
+
+Hook configuration is stored in the workspace's `.rigorix/hooks.toml` file.
+This file should be version-controlled (committed to the project repository).
+
+| Data | Backup Strategy | Frequency | Retention |
+|------|----------------|-----------|-----------|
+| `hooks.toml` config | Version control (git) | On change | Full git history |
+
+### No State to Back Up
+
+The hooks module is **stateless**:
+- Hook commands are executed as child processes — no internal state is modified
+- Hook results (`HookRunResult`) are ephemeral — consumed immediately by the execution engine
+- No database, no queue, no persistent storage is managed by this module
+
+## Restore Procedure
+
+### Scenario: Hook Configuration Lost or Corrupted
+
+1. **Detect**: Engine logs `HookError::CommandNotFound` or configuration parse error
+2. **Isolate**: Verify `.rigorix/hooks.toml` exists and is valid TOML
+3. **Restore**: 
+   ```bash
+   # Restore from version control
+   git checkout HEAD -- .rigorix/hooks.toml
+   ```
+4. **Verify**:
+   ```bash
+   # Validate hook config
+   bash engine/.pi/scripts/ci/check_hooks_contracts.sh
+   ```
+5. **Recover**: Restart the engine or trigger config reload
+
+### Scenario: Hook Binary Missing
+
+1. **Detect**: `HookError::CommandNotFound` for hook command
+2. **Isolate**: Check if binary exists in PATH
+   ```bash
+   which rigorix-hook-validate-path
+   ```
+3. **Restore**: Install missing hook binary:
+   ```bash
+   cargo install rigorix-hooks
+   ```
+4. **Verify**: Test hook execution directly:
+   ```bash
+   echo '{"event":"pre_tool_use","tool_name":"ls","tool_input":{},"session_id":"test","workspace_root":"."}' \
+     | rigorix-hook-validate-path
+   ```
+5. **Recover**: Restart engine or trigger config reload
+
+### Scenario: All Hooks Failing
+
+1. **Stop**: Create `HookAbortSignal` to cancel running executions
+2. **Remove**: Temporarily clear hook config:
+   ```toml
+   [hooks]
+   pre_tool_use = []
+   post_tool_use = []
+   post_tool_use_failure = []
+   ```
+3. **Diagnose**: Test each hook in isolation
+4. **Restore**: Re-add verified hooks one at a time
+
+## Failover Plan
+
+### Single Instance (Default Deployment)
+
+The hooks module runs in-process within the engine. Failover follows the engine's
+failover plan:
+
+1. Engine process fails → OS restarts (systemd/supervisor)
+2. Engine re-initializes → `HookRunner` created fresh from config
+3. Hook binaries remain on filesystem — no data loss
+
+### High-Availability Deployment
+
+Not currently supported — hooks run in-process. If HA is required:
+
+1. Deploy engine behind a load balancer (multiple replicas)
+2. Each replica loads the same `.rigorix/hooks.toml` from shared config
+3. Hook binaries must be installed on every replica node
+4. File system hooks must use shared storage (NFS) or be containerized
+
+## Disaster Scenarios
+
+### Scenario 1: Malicious Hook Script
+
+| Aspect | Detail |
+|--------|--------|
+| **Impact** | Hook could modify files, exfiltrate data, or block legitimate operations |
+| **Detection** | Unexpected tool blocks, modified tool inputs, file system changes |
+| **Containment** | Kill engine process; remove malicious hook from config |
+| **Recovery** | Audit hook script; restore from git history; add security validation |
+| **Prevention** | Hooks run from `.rigorix/hooks/` directory only; validate hook paths |
+
+### Scenario 2: Hook Blocks All Tool Execution
+
+| Aspect | Detail |
+|--------|--------|
+| **Impact** | All tool executions denied — engine cannot function |
+| **Detection** | Every tool returns `PermissionOutcome::Deny` |
+| **Containment** | Clear `pre_tool_use` config and restart engine |
+| **Recovery** | Diagnose hook decision logic; fix deny condition; re-add hooks |
+| **Prevention** | Test hooks in CI; add integration tests for deny/allow decisions |
+
+### Scenario 3: Hook Corrupts Tool Input
+
+| Aspect | Detail |
+|--------|--------|
+| **Impact** | Tools execute with modified input — could cause data corruption |
+| **Detection** | Unexpected tool behavior; audit trail shows `updated_input` |
+| **Containment** | Disable hooks that use `Modify` decision; restart engine |
+| **Recovery** | Review hook `Modify` logic; validate input transformation |
+| **Prevention** | Immutable audit trail of original vs. modified input |
+
+## Testing DR Readiness
+
+| Test | Frequency | Procedure |
+|------|-----------|-----------|
+| Config load failure | Quarterly | Corrupt `.rigorix/hooks.toml` → verify engine degrades gracefully |
+| Hook binary missing | Quarterly | Remove hook binary → verify `CommandNotFound` handled |
+| Hook timeout | Quarterly | Set `timeout_secs: 1` with slow hook → verify timeout handling |
+| Hook abort signal | Quarterly | Set abort before execution → verify cancelled result |
+| All hooks denied | Quarterly | Configure deny-all hook → verify execution blocked gracefully |
+
+## DR Kit Contents
+
+| Item | Location | Purpose |
+|------|----------|---------|
+| Last known good `.rigorix/hooks.toml` | Version control | Emergency rollback of hook config |
+| Hook binary installation script | Repository | Re-install hook binaries |
+| DR test scripts | `.pi/scripts/dr/` | Automated DR readiness tests |
+| Architecture docs | `.pi/architecture/modules/hooks.md` | System understanding |
+
+## Related Documents
+
+- [Runbook: hooks](runbook-hooks.md)
+- [Architecture: hooks](../.pi/architecture/modules/hooks.md)
+- [Contract Freeze: hooks](../.pi/issues/issue-contract-freeze.md)

--- a/engine/docs/runbook-hooks.md
+++ b/engine/docs/runbook-hooks.md
@@ -1,0 +1,213 @@
+# Runbook: hooks Module
+
+<!--
+Canonical Reference: .pi/architecture/modules/hooks.md
+Last Updated: 2026-06-19
+-->
+
+## Overview
+
+The `hooks` module provides external script-based interception points around every
+tool execution. Hooks run as shell commands receiving JSON payloads on stdin and
+returning structured JSON decisions. They enable deployment-specific policies,
+CI/CD integration, audit enrichment, and custom pre/post-flight validation.
+
+## Startup Sequence
+
+### Dependencies
+
+| Dependency | Required | Description |
+|------------|----------|-------------|
+| std::process::Command | Yes | Child process spawning for hook commands |
+| serde / serde_json | Yes | JSON protocol serialization/deserialization |
+| std::sync::atomic | Yes | HookAbortSignal for cooperative cancellation |
+| HookConfig | Yes | Configuration loaded from `.rigorix/hooks.toml` |
+
+### Initialization
+
+1. Load `HookConfig` from configuration source (`.rigorix/hooks.toml`)
+2. Create a `HookRunner` (struct) with the config
+3. Pass the runner to the Execution Engine pipeline
+
+```rust
+use rigorix::hooks::domain::HookConfig;
+use rigorix::hooks::application::HookRunner;
+
+// From configuration
+let config: HookConfig = load_hook_config()?;
+let runner = HookRunner::new(config);
+```
+
+### Quick Start
+
+```rust
+use rigorix::hooks::domain::*;
+use rigorix::hooks::application::*;
+
+// Create a runner with PreToolUse hooks
+let config = HookConfig {
+    pre_tool_use: vec![
+        "rigorix-hook-validate-path".into(),
+        "rigorix-hook-ci-guard".into(),
+    ],
+    ..Default::default()
+};
+let runner = HookRunner::new(config);
+
+// Run hooks before a tool execution
+let result = runner.run_pre_tool_use(
+    "write_file",
+    &tool_input,
+    None,           // abort_signal
+    None,           // progress_reporter
+);
+
+if result.is_denied() {
+    // Tool blocked — report reason to LLM
+} else if let Some(modified) = result.modified_input() {
+    // Use modified input for tool execution
+}
+```
+
+## Graceful Shutdown
+
+### Hook Execution Interruption
+
+1. Create a `HookAbortSignal` and share it with running hooks
+2. Call `signal.abort()` to trigger cooperative cancellation
+3. Running hook processes should check the signal and terminate
+4. After timeout, any remaining processes are killed
+
+```rust
+let abort = HookAbortSignal::new();
+
+// Spawn hook runner with abort signal
+let signal = abort.clone();
+let handle = std::thread::spawn(move || {
+    runner.run_pre_tool_use("write_file", &input, Some(&signal), None);
+});
+
+// If cancellation needed:
+abort.abort();
+handle.join().unwrap();
+```
+
+### Timeout Handling
+
+- Default hook timeout: 30 seconds (configurable via `HookConfig.timeout_secs`)
+- On timeout: hook process is killed
+- PreToolUse timeout → tool is **blocked** (safety-first)
+- PostToolUse/PostToolUseFailure timeout → tool result returned without hook feedback
+
+## Common Failure Modes and Recovery
+
+| Failure Mode | Symptom | Cause | Recovery |
+|-------------|---------|-------|----------|
+| Hook command not found | `HookError::CommandNotFound` | Command not in PATH | Hook is skipped; execution continues with warning |
+| Hook execution timeout | `HookError::Timeout` | Hook script hangs or is slow | Increase `timeout_secs` in config; debug hook script |
+| Invalid JSON response | `HookError::InvalidJson` | Hook stdout malformed | Validate hook script output; check for stderr leakage |
+| Hook process error | `HookError::ProcessError` | Non-zero exit + no valid JSON | Check hook stderr; fix script |
+| Aborted execution | `HookError::Aborted` | AbortSignal triggered | User cancellation; check if intended |
+| All hooks denied | `HookRunResult.denied == true` | Hook policy prevents operation | Review hook decision logic; override if needed |
+| Permission override | `permission_override` set | Hook elevated/restricted risk | Verify hook is trusted; audit the override |
+
+## Configuration Reference
+
+### `.rigorix/hooks.toml`
+
+```toml
+[hooks]
+# Commands to run before every tool execution
+pre_tool_use = [
+    "rigorix-hook-validate-path",
+    "rigorix-hook-ci-guard --env $RIGORIX_ENV",
+]
+
+# Commands to run after every successful tool execution
+post_tool_use = [
+    "rigorix-hook-fmt-check --path $TOOL_PATH",
+]
+
+# Commands to run after every failed tool execution
+post_tool_use_failure = [
+    "rigorix-hook-notify --channel alerts",
+]
+
+# Hook execution timeout in seconds (default: 30)
+timeout_secs = 30
+
+# Whether PreToolUse hooks run sequentially (default: false = concurrent)
+sequential_pre_tool_use = true
+```
+
+### Environment Variables
+
+| Variable | Set By | Purpose |
+|----------|--------|---------|
+| `RIGORIX_TOOL_NAME` | Engine | Name of the tool being intercepted |
+| `RIGORIX_EVENT` | Engine | Lifecycle event (pre_tool_use, post_tool_use, post_tool_use_failure) |
+| `RIGORIX_SESSION_ID` | Engine | Session/execution identifier for correlation |
+| `RIGORIX_WORKSPACE` | Engine | Absolute path to workspace root |
+
+## Monitoring
+
+### Metrics
+
+Key metrics to monitor (see `Observability` section in architecture docs):
+
+- `hook_execution_duration_ms` — Per-hook execution latency
+- `hook_timeout_count` — Hook timeout counter
+- `hook_deny_count` — Number of tool executions blocked by hooks
+- `hook_failure_count` — Hook execution failure count
+- `hook_total_count` — Total hook executions
+
+### Logging
+
+- Hook lifecycle events emitted via `HookEventPayload` for event bus integration
+- Each hook execution produces: start, completed/failed/aborted events
+- Hook stdout responses are logged at debug level (redact sensitive input)
+- Non-recoverable errors are logged at error level
+
+## Health Check
+
+A healthy hooks module:
+1. Configuration loads successfully (syntax-valid TOML, commands exist)
+2. Hook commands can be spawned (PATH resolution works)
+3. JSON protocol round-trips correctly (valid stdin → valid stdout)
+4. AbortSignal operates correctly (set → detected → process killed)
+
+## Troubleshooting
+
+### Hook Not Executing
+
+1. Check `HookConfig.commands_for(event)` returns your commands
+2. Verify command exists in PATH (or is absolute path)
+3. Check logs for `HookError::CommandNotFound`
+
+### Hook Returns Unexpected Decision
+
+1. Test the hook script directly: `echo '{"event":"pre_tool_use",...}' | your-hook`
+2. Validate stdout is valid `HookStdoutResponse` JSON
+3. Check stderr — hook scripts should output only JSON on stdout
+
+### Hook Hangs
+
+1. Check `timeout_secs` configuration (default 30s)
+2. Verify hook doesn't wait for stdin beyond first read
+3. Check for infinite loops in hook script
+4. Ensure hook handles `HookAbortSignal` properly
+
+## Performance
+
+| Metric | Target | Notes |
+|--------|--------|-------|
+| PreToolUse hook latency | < 500ms per hook | Sequential execution by default for input modification |
+| PostToolUse hook latency | < 2s per hook | Concurrent execution (no input modification) |
+| Hook timeout | 30s (configurable) | Killed on timeout |
+| Process spawn overhead | < 10ms | Per hook command |
+
+## Related Documents
+
+- [Architecture: hooks](../.pi/architecture/modules/hooks.md)
+- [DR Plan: hooks](dr-plan-hooks.md)
+- [Tool System Architecture](../.pi/architecture/modules/tool-system.md)

--- a/engine/src/code_gen/application/dto/mod.rs
+++ b/engine/src/code_gen/application/dto/mod.rs
@@ -1,0 +1,335 @@
+//! Data Transfer Objects for the Code Generation Pipeline module.
+//!
+//! @canonical .pi/architecture/modules/code-generation.md
+//! Implements: Contract Freeze — DTO schemas for edit_file, read_file, syntax gate
+//! Issue: #424
+//!
+//! DTOs define the input/output contracts for service operations.
+//! They carry validation metadata and documentation but no behavior.
+//!
+//! # Contract (Frozen)
+//! - Every service operation has a dedicated input and output DTO
+//! - DTOs are serializable (JSON for API)
+//! - Validation constraints are documented in field docs
+//! - Fields use reasonable Rust types (no framework-specific annotations)
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// EditFile DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for the edit_file operation.
+///
+/// The LLM provides the exact text to find and replace. The `old_string`
+/// serves as both the position anchor and the correctness check.
+///
+/// # Example
+///
+/// ```json
+/// {
+///     "path": "src/main.rs",
+///     "old_string": "let x = 5;",
+///     "new_string": "let x = 10;",
+///     "replace_all": false
+/// }
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EditFileInput {
+    /// Absolute or workspace-relative file path.
+    pub path: String,
+
+    /// Exact text to find in the file. This is the position anchor and
+    /// correctness check — the edit is rejected if this text does not
+    /// exist in the file.
+    pub old_string: String,
+
+    /// Replacement text. Can be larger, smaller, or the same length
+    /// as old_string. Must differ from old_string (identity check).
+    pub new_string: String,
+
+    /// Replace all occurrences of old_string in the file.
+    /// Default: only the first occurrence is replaced.
+    #[serde(default)]
+    pub replace_all: Option<bool>,
+}
+
+/// Output from the edit_file operation.
+///
+/// Returns complete before/after content plus a unified diff so the
+/// LLM can self-verify its edit.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EditFileOutput {
+    /// Path of the file that was edited.
+    pub file_path: String,
+
+    /// The old_string that was matched (echoed back for verification).
+    pub old_string: String,
+
+    /// The new_string that was inserted (echoed back for verification).
+    pub new_string: String,
+
+    /// Complete original file content before the edit.
+    pub original_file: String,
+
+    /// Complete updated file content after the edit.
+    pub updated_content: String,
+
+    /// Unified diff between original and updated (human and LLM readable).
+    pub unified_diff: String,
+
+    /// Whether all occurrences were replaced.
+    pub replace_all: bool,
+
+    /// Number of occurrences that were replaced.
+    pub occurrences_replaced: usize,
+
+    /// Syntax gate result (if configured).
+    #[serde(default)]
+    pub syntax_gate_result: Option<crate::code_gen::domain::result::SyntaxGateResult>,
+
+    /// Structured patch hunks for programmatic processing.
+    #[serde(default)]
+    pub patch_hunks: Vec<StructuredPatchHunk>,
+}
+
+// ---------------------------------------------------------------------------
+// StructuredPatchHunk
+// ---------------------------------------------------------------------------
+
+/// A single diff hunk with old/new line ranges.
+///
+/// Provides structured diff output for programmatic processing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StructuredPatchHunk {
+    /// Starting line of the hunk in the original file (1-indexed).
+    pub old_start: usize,
+
+    /// Number of lines in the original file covered by this hunk.
+    pub old_lines: usize,
+
+    /// Starting line of the hunk in the new file (1-indexed).
+    pub new_start: usize,
+
+    /// Number of lines in the new file covered by this hunk.
+    pub new_lines: usize,
+
+    /// The diff lines, prefixed with '-' (removed), '+' (added), or ' ' (context).
+    pub lines: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// ReadFile DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for the read_file operation (extended beyond basic file read).
+///
+/// Supports offset/limit paging for large files and binary detection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReadFileInput {
+    /// Absolute or workspace-relative file path.
+    pub path: String,
+
+    /// Starting line offset (1-indexed). If omitted, read from line 1.
+    #[serde(default)]
+    pub offset: Option<usize>,
+
+    /// Maximum number of lines to return. If omitted, return all lines.
+    #[serde(default)]
+    pub limit: Option<usize>,
+
+    /// Maximum file size in bytes (default: 10MB).
+    /// Files larger than this are rejected with FileTooLarge.
+    #[serde(default = "default_max_file_size")]
+    pub max_file_size: Option<u64>,
+}
+
+fn default_max_file_size() -> Option<u64> {
+    Some(10_485_760) // 10 MB
+}
+
+/// Output from the read_file operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReadFileOutput {
+    /// Path of the file that was read.
+    pub file_path: String,
+
+    /// The file contents (or the requested line window).
+    pub content: String,
+
+    /// Starting line number of the returned content (1-indexed).
+    pub start_line: usize,
+
+    /// Total number of lines in the file.
+    pub total_lines: usize,
+
+    /// Total file size in bytes.
+    pub total_bytes: u64,
+
+    /// Whether the file was detected as binary.
+    pub is_binary: bool,
+
+    /// The requested offset (if any).
+    pub requested_offset: Option<usize>,
+
+    /// The requested limit (if any).
+    pub requested_limit: Option<usize>,
+}
+
+// ---------------------------------------------------------------------------
+// SyntaxGate DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for running the syntax gate on a file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyntaxGateInput {
+    /// Path of the file to verify (used for language detection).
+    pub file_path: String,
+
+    /// The file content to verify.
+    pub content: String,
+}
+
+/// Output from running the syntax gate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyntaxGateOutput {
+    /// The syntax gate result.
+    pub result: crate::code_gen::domain::result::SyntaxGateResult,
+
+    /// The language that was detected for verification.
+    pub detected_language: Option<String>,
+
+    /// Duration of the syntax check in milliseconds.
+    pub duration_ms: u64,
+}
+
+// ---------------------------------------------------------------------------
+// SyntaxGate Configuration DTO
+// ---------------------------------------------------------------------------
+
+/// Configuration for the SyntaxGate service.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyntaxGateConfig {
+    /// Whether the syntax gate is enabled.
+    /// When disabled, edits are applied without syntax verification.
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+
+    /// Whether to block edits that produce syntax errors.
+    /// When false, edits are applied and syntax errors are reported as warnings.
+    #[serde(default)]
+    pub block_on_error: bool,
+
+    /// Whether to skip syntax verification for files without a parser.
+    /// When true, files in unsupported languages pass without verification.
+    #[serde(default = "default_skip_unsupported")]
+    pub skip_unsupported: bool,
+
+    /// Maximum file size in bytes for syntax verification.
+    /// Files larger than this are skipped.
+    #[serde(default = "default_max_verify_size")]
+    pub max_verify_size: u64,
+
+    /// List of supported language identifiers (e.g., "rust", "typescript", "python").
+    #[serde(default)]
+    pub supported_languages: Vec<String>,
+}
+
+fn default_enabled() -> bool { true }
+fn default_skip_unsupported() -> bool { true }
+fn default_max_verify_size() -> u64 { 1_048_576 } // 1 MB
+
+impl Default for SyntaxGateConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            block_on_error: false,
+            skip_unsupported: true,
+            max_verify_size: 1_048_576,
+            supported_languages: vec![
+                "rust".into(),
+                "typescript".into(),
+                "python".into(),
+            ],
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EditFileConfig
+// ---------------------------------------------------------------------------
+
+/// Configuration for the edit_file operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EditFileConfig {
+    /// Maximum file size in bytes for editing (default: 10MB).
+    #[serde(default = "default_max_edit_size")]
+    pub max_file_size: u64,
+
+    /// Whether to enable the identity check (old_string == new_string rejection).
+    #[serde(default = "default_identity_check")]
+    pub enable_identity_check: bool,
+
+    /// Whether to require syntax gate verification after each edit.
+    #[serde(default)]
+    pub require_syntax_gate: bool,
+
+    /// Maximum number of occurrences to replace when replace_all is true.
+    /// Prevents excessive replacements.
+    #[serde(default = "default_max_replacements")]
+    pub max_replacements: usize,
+}
+
+fn default_max_edit_size() -> u64 { 10_485_760 }
+fn default_identity_check() -> bool { true }
+fn default_max_replacements() -> usize { 1000 }
+
+impl Default for EditFileConfig {
+    fn default() -> Self {
+        Self {
+            max_file_size: 10_485_760,
+            enable_identity_check: true,
+            require_syntax_gate: false,
+            max_replacements: 1000,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CodeGen Service DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for configuring the code generation pipeline.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodeGenConfig {
+    /// Configuration for the edit_file operation.
+    #[serde(default)]
+    pub edit_file: EditFileConfig,
+
+    /// Configuration for the syntax gate.
+    #[serde(default)]
+    pub syntax_gate: SyntaxGateConfig,
+
+    /// Workspace root for path validation.
+    pub workspace_root: Option<String>,
+}
+
+impl Default for CodeGenConfig {
+    fn default() -> Self {
+        Self {
+            edit_file: EditFileConfig::default(),
+            syntax_gate: SyntaxGateConfig::default(),
+            workspace_root: None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: Diff computation constants
+// ---------------------------------------------------------------------------
+
+/// Maximum number of context lines in a unified diff.
+pub const DIFF_CONTEXT_LINES: usize = 3;
+
+/// Maximum diff size in bytes before truncation.
+pub const MAX_DIFF_SIZE: u64 = 100_000;

--- a/engine/src/code_gen/application/factory.rs
+++ b/engine/src/code_gen/application/factory.rs
@@ -1,0 +1,45 @@
+//! Factory interfaces for constructing Code Generation service instances.
+//!
+//! @canonical .pi/architecture/modules/code-generation.md
+//! Implements: Contract Freeze — SyntaxGateFactory trait, EditFileFactory trait
+//! Issue: #424
+//!
+//! Factories encapsulate the construction of service instances, allowing
+//! implementations to inject dependencies (tree-sitter parsers, configuration)
+//! and apply default configurations.
+
+use crate::code_gen::domain::error::CodeGenError;
+
+use super::dto::CodeGenConfig;
+use super::service::{EditFileService, ReadFileService, SyntaxGateService};
+
+/// Factory for constructing `SyntaxGateService` instances.
+pub trait SyntaxGateFactory: Send + Sync {
+    /// Create a SyntaxGateService with default configuration.
+    fn create_default(&self) -> Result<Box<dyn SyntaxGateService>, CodeGenError>;
+
+    /// Create a SyntaxGateService with explicit configuration.
+    fn create(&self, config: super::dto::SyntaxGateConfig) -> Result<Box<dyn SyntaxGateService>, CodeGenError>;
+
+    /// Create a SyntaxGateService with the given tree-sitter parsers.
+    fn create_with_parsers(
+        &self,
+        config: super::dto::SyntaxGateConfig,
+        parsers: std::collections::HashMap<String, tree_sitter::Parser>,
+    ) -> Result<Box<dyn SyntaxGateService>, CodeGenError>;
+}
+
+/// Factory for constructing `EditFileService` instances.
+pub trait EditFileFactory: Send + Sync {
+    /// Create an EditFileService with default configuration.
+    fn create_default(&self) -> Result<Box<dyn EditFileService>, CodeGenError>;
+
+    /// Create an EditFileService with explicit configuration.
+    fn create(&self, config: CodeGenConfig) -> Result<Box<dyn EditFileService>, CodeGenError>;
+}
+
+/// Factory for constructing `ReadFileService` instances.
+pub trait ReadFileFactory: Send + Sync {
+    /// Create a ReadFileService with the given workspace root.
+    fn create(&self, workspace_root: String) -> Result<Box<dyn ReadFileService>, CodeGenError>;
+}

--- a/engine/src/code_gen/application/mod.rs
+++ b/engine/src/code_gen/application/mod.rs
@@ -1,0 +1,24 @@
+//! Application layer interfaces for the Code Generation Pipeline.
+//!
+//! @canonical .pi/architecture/modules/code-generation.md
+//! Implements: Contract Freeze — service traits, DTOs, factory interfaces
+//! Issue: #424
+//!
+//! This module defines:
+//! - Service traits (use cases / application services)
+//! - Input/Output DTOs with validation
+//! - Factory interfaces for constructing code generation services
+//!
+//! # Contract (Frozen)
+//! - All service methods return `Result<_, CodeGenError>`
+//! - Input/output types are DTOs defined in `dto/`
+//! - DTOs include validation annotations/documentation
+//! - No implementation logic — only trait definitions
+
+pub mod dto;
+pub mod factory;
+pub mod service;
+
+pub use dto::*;
+pub use factory::*;
+pub use service::*;

--- a/engine/src/code_gen/application/service.rs
+++ b/engine/src/code_gen/application/service.rs
@@ -1,0 +1,95 @@
+//! Service interfaces (use cases) for the Code Generation Pipeline.
+//!
+//! @canonical .pi/architecture/modules/code-generation.md#syntax-service
+//! Implements: Contract Freeze — SyntaxGateService trait, EditFileService trait
+//! Issue: #424
+//!
+//! These traits define the application-level operations for code generation:
+//! syntax verification, file editing orchestration, and code generation
+//! configuration.
+//!
+//! # Contract (Frozen)
+//! - Every use case has a corresponding trait method
+//! - Input/output types are DTOs defined in `dto/`
+//! - No implementation — only contract signatures
+
+use crate::code_gen::domain::error::CodeGenError;
+
+use super::dto::{
+    CodeGenConfig, EditFileInput, EditFileOutput, ReadFileInput, ReadFileOutput,
+    SyntaxGateInput, SyntaxGateOutput,
+};
+
+/// Service for post-edit syntax verification using tree-sitter.
+///
+/// Validates that a file's content parses without syntax errors after
+/// an edit. Uses Rigorix's existing tree-sitter integration for AST
+/// parsing. Language is auto-detected from file extension.
+///
+/// # Behaviour
+/// - If the language has no parser, returns `Skipped`
+/// - If the file is syntactically valid, returns `Passed`
+/// - If syntax errors are found, returns `Failed` with error locations
+/// - Maximum file size is configurable (files larger than limit are Skipped)
+pub trait SyntaxGateService: Send + Sync {
+    /// Verify that `content` produces a valid AST for the file at `path`.
+    ///
+    /// Language is auto-detected from file extension. If no parser is
+    /// available, the check is skipped (not an error).
+    fn verify(&self, input: SyntaxGateInput) -> Result<SyntaxGateOutput, CodeGenError>;
+
+    /// Verify multiple files in batch.
+    ///
+    /// Useful when multiple files were edited in a single turn.
+    fn verify_batch(&self, inputs: Vec<SyntaxGateInput>) -> Result<Vec<SyntaxGateOutput>, CodeGenError>;
+
+    /// Get the current configuration of the syntax gate.
+    fn get_config(&self) -> super::dto::SyntaxGateConfig;
+
+    /// Update the syntax gate configuration at runtime.
+    fn reconfigure(&self, config: super::dto::SyntaxGateConfig) -> Result<(), CodeGenError>;
+
+    /// Get the list of languages supported by this syntax gate instance.
+    fn supported_languages(&self) -> Vec<String>;
+}
+
+/// Service for orchestrating the edit_file operation.
+///
+/// Handles the full edit pipeline:
+/// 1. Path validation (workspace boundary, symlink detection, binary detection)
+/// 2. File reading
+/// 3. Identity check (old_string != new_string)
+/// 4. Existence check (old_string exists in file)
+/// 5. String replacement (first or all occurrences)
+/// 6. Atomic write
+/// 7. Unified diff computation
+/// 8. Optional syntax gate verification
+pub trait EditFileService: Send + Sync {
+    /// Execute an edit_file operation.
+    ///
+    /// Performs all validation gates, the replacement, and returns
+    /// structured before/after/diff output.
+    fn edit(&self, input: EditFileInput) -> Result<EditFileOutput, CodeGenError>;
+
+    /// Preview an edit without applying it.
+    ///
+    /// Returns the diff and updated content but does NOT write to disk.
+    /// Useful for the LLM to verify an edit before committing.
+    fn preview_edit(&self, input: EditFileInput) -> Result<EditFileOutput, CodeGenError>;
+}
+
+/// Service for reading files with extended options.
+///
+/// Extends the basic file read with:
+/// - Offset/limit paging (line-based)
+/// - Binary file detection (NUL byte scan)
+/// - File size limits
+/// - Total line count reporting
+pub trait ReadFileService: Send + Sync {
+    /// Read a file with optional offset/limit.
+    fn read(&self, input: ReadFileInput) -> Result<ReadFileOutput, CodeGenError>;
+
+    /// Read only the first N bytes of a file for binary detection.
+    /// Returns Ok if text, Err if binary.
+    fn detect_binary(&self, path: &str) -> Result<bool, CodeGenError>;
+}

--- a/engine/src/code_gen/domain/error.rs
+++ b/engine/src/code_gen/domain/error.rs
@@ -1,0 +1,209 @@
+//! CodeGenError — typed error enum for code generation failures.
+//!
+//! @canonical .pi/architecture/modules/code-generation.md#error-handling
+//! Implements: Contract Freeze — CodeGenError enum
+//! Issue: #424
+//!
+//! All errors use `thiserror` derive macros. No `anyhow` in library code.
+//!
+//! # Contract (Frozen)
+//! - `CodeGenError` is the single error type for this module
+//! - Each variant carries structured context for error reporting
+//! - Implements `std::error::Error` for library compatibility
+
+use thiserror::Error;
+
+/// Errors that can occur during code generation operations.
+///
+/// # Error Recovery
+///
+/// | Variant | Severity | Recovery |
+/// |---------|----------|----------|
+/// | `OldStringNotFound` | Error | LLM must issue corrected edit_file |
+/// | `IdentityEdit` | Warning | LLM must provide differing old/new strings |
+/// | `BinaryFile` | Error | Edit_file rejected for binary files |
+/// | `FileTooLarge` | Error | Rerun with smaller scope |
+/// | `WorkspaceEscape` | Critical | Path traversal blocked |
+/// | `SyntaxError` | Warning | Edit applied but syntax errors detected |
+/// | `PathValidationFailed` | Error | Path invalid or symlink detected |
+#[derive(Debug, Error)]
+pub enum CodeGenError {
+    /// The old_string was not found in the file.
+    ///
+    /// This is the correctness anchor for edit_file. The LLM must verify
+    /// the exact text it wants to replace and issue a corrected edit.
+    #[error("old_string not found in {path}")]
+    OldStringNotFound {
+        /// The file path that was searched.
+        path: String,
+    },
+
+    /// old_string and new_string are identical.
+    ///
+    /// The edit would be a no-op. The LLM must provide different values.
+    #[error("old_string and new_string must differ")]
+    IdentityEdit,
+
+    /// The file appears to be binary (contains NUL bytes).
+    ///
+    /// Binary files cannot be edited with old_string matching.
+    #[error("File appears to be binary: {path}")]
+    BinaryFile {
+        /// The file path that was detected as binary.
+        path: String,
+    },
+
+    /// The file exceeds the maximum allowed size.
+    #[error("File too large: {size} bytes (max {max})")]
+    FileTooLarge {
+        /// Actual file size in bytes.
+        size: u64,
+        /// Maximum allowed size in bytes.
+        max: u64,
+    },
+
+    /// The specified path escapes the workspace boundary.
+    #[error("Path escapes workspace: {path}")]
+    WorkspaceEscape {
+        /// The offending path.
+        path: String,
+    },
+
+    /// Syntax error detected during post-edit verification.
+    ///
+    /// The edit was applied but tree-sitter detected syntax errors.
+    #[error("Syntax error at {path}:{line}:{col}: {message}")]
+    SyntaxError {
+        /// The file with the syntax error.
+        path: String,
+        /// Line number (1-indexed).
+        line: usize,
+        /// Column number (1-indexed).
+        col: usize,
+        /// Error description.
+        message: String,
+    },
+
+    /// Path validation failed (symlink detected, invalid path, etc.).
+    #[error("Path validation failed: {path}: {reason}")]
+    PathValidationFailed {
+        /// The path that failed validation.
+        path: String,
+        /// Reason for failure.
+        reason: String,
+    },
+
+    /// Internal error occurred.
+    #[error("Internal code generation error: {detail}")]
+    Internal {
+        /// Error detail for diagnostics.
+        detail: String,
+    },
+}
+
+impl CodeGenError {
+    /// Returns true if this error is recoverable (edit was applied but has issues).
+    pub fn is_recoverable(&self) -> bool {
+        matches!(self, CodeGenError::SyntaxError { .. })
+    }
+
+    /// Returns true if this error is retriable (LLM can reissue the edit).
+    pub fn is_retriable(&self) -> bool {
+        matches!(self, CodeGenError::OldStringNotFound { .. } | CodeGenError::IdentityEdit)
+    }
+
+    /// Returns the file path associated with this error, if available.
+    pub fn path(&self) -> Option<&str> {
+        match self {
+            CodeGenError::OldStringNotFound { path }
+            | CodeGenError::BinaryFile { path }
+            | CodeGenError::WorkspaceEscape { path }
+            | CodeGenError::SyntaxError { path, .. }
+            | CodeGenError::PathValidationFailed { path, .. } => Some(path),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_old_string_not_found() {
+        let err = CodeGenError::OldStringNotFound {
+            path: "src/main.rs".into(),
+        };
+        assert!(err.is_retriable());
+        assert!(!err.is_recoverable());
+        assert_eq!(err.path(), Some("src/main.rs"));
+        assert_eq!(err.to_string(), "old_string not found in src/main.rs");
+    }
+
+    #[test]
+    fn test_identity_edit() {
+        let err = CodeGenError::IdentityEdit;
+        assert!(err.is_retriable());
+        assert!(!err.is_recoverable());
+        assert!(err.path().is_none());
+        assert_eq!(err.to_string(), "old_string and new_string must differ");
+    }
+
+    #[test]
+    fn test_binary_file() {
+        let err = CodeGenError::BinaryFile {
+            path: "image.png".into(),
+        };
+        assert!(!err.is_retriable());
+        assert_eq!(err.to_string(), "File appears to be binary: image.png");
+    }
+
+    #[test]
+    fn test_file_too_large() {
+        let err = CodeGenError::FileTooLarge {
+            size: 20_000_000,
+            max: 10_000_000,
+        };
+        assert!(err.path().is_none());
+        assert!(err.to_string().contains("20,000,000") || err.to_string().contains("20000000"));
+    }
+
+    #[test]
+    fn test_workspace_escape() {
+        let err = CodeGenError::WorkspaceEscape {
+            path: "../../etc/passwd".into(),
+        };
+        assert!(err.to_string().contains("../../etc/passwd"));
+    }
+
+    #[test]
+    fn test_syntax_error() {
+        let err = CodeGenError::SyntaxError {
+            path: "lib.rs".into(),
+            line: 42,
+            col: 5,
+            message: "expected `;`".into(),
+        };
+        assert!(err.is_recoverable());
+        assert!(err.to_string().contains("lib.rs:42:5"));
+    }
+
+    #[test]
+    fn test_path_validation_failed() {
+        let err = CodeGenError::PathValidationFailed {
+            path: "/etc/passwd".into(),
+            reason: "path traverses symlink outside workspace".into(),
+        };
+        assert!(!err.is_retriable());
+        assert!(!err.is_recoverable());
+    }
+
+    #[test]
+    fn test_internal() {
+        let err = CodeGenError::Internal {
+            detail: "parse error".into(),
+        };
+        assert!(err.path().is_none());
+        assert!(!err.is_retriable());
+    }
+}

--- a/engine/src/code_gen/domain/event/mod.rs
+++ b/engine/src/code_gen/domain/event/mod.rs
@@ -1,0 +1,251 @@
+//! Event payload schemas for the Code Generation Pipeline.
+//!
+//! @canonical .pi/architecture/modules/code-generation.md#events
+//! Implements: Contract Freeze — CodeGenEvent payload schemas
+//! Issue: #424
+//!
+//! These events are emitted when code editing operations are performed.
+//! Consumers (audit trail, console printer, TUI) subscribe to these events.
+//!
+//! # Contract (Frozen)
+//! - Each event carries the full context needed by consumers
+//! - No internal implementation details exposed
+//! - All types are serializable for event bus integration
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Events emitted by the Code Generation Pipeline.
+///
+/// Wrapped in `ExecutionEvent::CodeGen(...)` at the orchestration layer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CodeGenEvent {
+    /// An edit_file operation was started.
+    EditFileStarted {
+        /// The session/execution ID for correlation.
+        session_id: String,
+        /// Path of the file being edited.
+        file_path: String,
+        /// Length of old_string (for logging/diagnostics).
+        old_string_length: usize,
+        /// Length of new_string (for logging/diagnostics).
+        new_string_length: usize,
+        /// ISO 8601 timestamp.
+        timestamp: DateTime<Utc>,
+    },
+
+    /// An edit_file operation completed successfully.
+    EditFileCompleted {
+        /// The session/execution ID for correlation.
+        session_id: String,
+        /// Path of the edited file.
+        file_path: String,
+        /// Whether replace_all was used.
+        replace_all: bool,
+        /// Length of the unified diff produced.
+        diff_length: usize,
+        /// Whether the syntax gate was applied.
+        syntax_gate_applied: bool,
+        /// Whether the syntax gate passed.
+        syntax_gate_passed: bool,
+        /// Duration of the operation in milliseconds.
+        duration_ms: u64,
+        /// ISO 8601 timestamp.
+        timestamp: DateTime<Utc>,
+    },
+
+    /// An edit_file operation failed.
+    EditFileFailed {
+        /// The session/execution ID for correlation.
+        session_id: String,
+        /// Path of the file that was targeted.
+        file_path: String,
+        /// Error message describing the failure.
+        error: String,
+        /// Error code for machine-readable handling.
+        error_code: String,
+        /// Duration of the operation in milliseconds.
+        duration_ms: u64,
+        /// ISO 8601 timestamp.
+        timestamp: DateTime<Utc>,
+    },
+
+    /// A read_file operation was performed.
+    ReadFileCompleted {
+        /// The session/execution ID for correlation.
+        session_id: String,
+        /// Path of the file that was read.
+        file_path: String,
+        /// Total lines in the file.
+        total_lines: usize,
+        /// Number of bytes read.
+        bytes_read: u64,
+        /// Whether the file was detected as binary.
+        is_binary: bool,
+        /// Duration of the operation in milliseconds.
+        duration_ms: u64,
+        /// ISO 8601 timestamp.
+        timestamp: DateTime<Utc>,
+    },
+
+    /// The syntax gate was applied to an edited file.
+    SyntaxGateApplied {
+        /// The session/execution ID for correlation.
+        session_id: String,
+        /// Path of the file verified.
+        file_path: String,
+        /// The syntax gate outcome (passed, failed, skipped).
+        outcome: String,
+        /// Number of syntax errors found (0 if passed/skipped).
+        error_count: usize,
+        /// Duration of the syntax check in milliseconds.
+        duration_ms: u64,
+        /// ISO 8601 timestamp.
+        timestamp: DateTime<Utc>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_session() -> String {
+        "session-1".into()
+    }
+
+    #[test]
+    fn test_edit_file_started() {
+        let event = CodeGenEvent::EditFileStarted {
+            session_id: sample_session(),
+            file_path: "src/main.rs".into(),
+            old_string_length: 10,
+            new_string_length: 20,
+            timestamp: Utc::now(),
+        };
+        match &event {
+            CodeGenEvent::EditFileStarted { file_path, .. } => {
+                assert_eq!(file_path, "src/main.rs");
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn test_edit_file_completed() {
+        let event = CodeGenEvent::EditFileCompleted {
+            session_id: sample_session(),
+            file_path: "src/lib.rs".into(),
+            replace_all: false,
+            diff_length: 200,
+            syntax_gate_applied: true,
+            syntax_gate_passed: true,
+            duration_ms: 50,
+            timestamp: Utc::now(),
+        };
+        match &event {
+            CodeGenEvent::EditFileCompleted { file_path, syntax_gate_passed, .. } => {
+                assert_eq!(file_path, "src/lib.rs");
+                assert!(*syntax_gate_passed);
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn test_edit_file_failed() {
+        let event = CodeGenEvent::EditFileFailed {
+            session_id: sample_session(),
+            file_path: "src/main.rs".into(),
+            error: "old_string not found".into(),
+            error_code: "OLD_STRING_NOT_FOUND".into(),
+            duration_ms: 10,
+            timestamp: Utc::now(),
+        };
+        match &event {
+            CodeGenEvent::EditFileFailed { error_code, .. } => {
+                assert_eq!(error_code, "OLD_STRING_NOT_FOUND");
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn test_read_file_completed() {
+        let event = CodeGenEvent::ReadFileCompleted {
+            session_id: sample_session(),
+            file_path: "Cargo.toml".into(),
+            total_lines: 50,
+            bytes_read: 2048,
+            is_binary: false,
+            duration_ms: 5,
+            timestamp: Utc::now(),
+        };
+        match &event {
+            CodeGenEvent::ReadFileCompleted { file_path, total_lines, .. } => {
+                assert_eq!(file_path, "Cargo.toml");
+                assert_eq!(*total_lines, 50);
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn test_syntax_gate_applied() {
+        let event = CodeGenEvent::SyntaxGateApplied {
+            session_id: sample_session(),
+            file_path: "src/main.rs".into(),
+            outcome: "passed".into(),
+            error_count: 0,
+            duration_ms: 100,
+            timestamp: Utc::now(),
+        };
+        match &event {
+            CodeGenEvent::SyntaxGateApplied { outcome, error_count, .. } => {
+                assert_eq!(outcome, "passed");
+                assert_eq!(*error_count, 0);
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let event = CodeGenEvent::EditFileCompleted {
+            session_id: "s1".into(),
+            file_path: "f.rs".into(),
+            replace_all: false,
+            diff_length: 100,
+            syntax_gate_applied: true,
+            syntax_gate_passed: true,
+            duration_ms: 30,
+            timestamp: Utc::now(),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let deserialized: CodeGenEvent = serde_json::from_str(&json).unwrap();
+        match deserialized {
+            CodeGenEvent::EditFileCompleted { file_path, .. } => {
+                assert_eq!(file_path, "f.rs");
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn test_serde_tagged_union() {
+        let event = CodeGenEvent::ReadFileCompleted {
+            session_id: "s1".into(),
+            file_path: "f.rs".into(),
+            total_lines: 100,
+            bytes_read: 5000,
+            is_binary: false,
+            duration_ms: 10,
+            timestamp: Utc::now(),
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(
+            json.get("type").and_then(|v| v.as_str()),
+            Some("read_file_completed")
+        );
+    }
+}

--- a/engine/src/code_gen/domain/mod.rs
+++ b/engine/src/code_gen/domain/mod.rs
@@ -1,0 +1,27 @@
+//! Domain entities for the Code Generation Pipeline bounded context.
+//!
+//! @canonical .pi/architecture/modules/code-generation.md#domain
+//! Implements: Contract Freeze — SyntaxGateResult, SyntaxError, CodeGenError
+//! Issue: #424
+//!
+//! This module defines the core domain types:
+//! - `CodeGenError` — Typed error enum for code generation failures
+//! - `CodeGenEvent` — Event payload schemas for code generation lifecycle
+//! - `SyntaxGateResult` — Outcome of post-edit tree-sitter syntax verification
+//! - `SyntaxError` — Individual syntax error with location context
+//!
+//! These are pure domain objects with no framework dependencies.
+//! They serve as the frozen contract that all implementation must satisfy.
+//!
+//! # Contract (Frozen)
+//! - No implementation logic beyond constructors and field accessors
+//! - All validation must happen in the application layer (service traits)
+//! - All persistence must happen behind repository interfaces
+
+pub mod error;
+pub mod event;
+pub mod result;
+
+pub use error::CodeGenError;
+pub use event::CodeGenEvent;
+pub use result::{SyntaxError, SyntaxGateResult};

--- a/engine/src/code_gen/domain/result.rs
+++ b/engine/src/code_gen/domain/result.rs
@@ -1,0 +1,197 @@
+//! SyntaxGateResult — outcome of post-edit tree-sitter syntax verification.
+//!
+//! @canonical .pi/architecture/modules/code-generation.md#syntax-result
+//! Implements: Contract Freeze — SyntaxGateResult, SyntaxError
+//! Issue: #424
+//!
+//! Defines the outcome of running tree-sitter AST validation on a file
+//! after an edit. The syntax gate is optional — it can be configured to
+//! block edits on syntax errors or merely warn.
+//!
+//! # Contract (Frozen)
+//! - Three variants: Passed, Failed (with errors), Skipped (no parser)
+//! - SyntaxError carries structured location context for the LLM
+//! - All types are serializable for API responses
+
+use serde::{Deserialize, Serialize};
+
+/// Outcome of post-edit tree-sitter syntax verification.
+///
+/// # Variants
+///
+/// | Variant | Meaning | Action |
+/// |---------|---------|--------|
+/// | `Passed` | File parses without errors | Edit confirmed |
+/// | `Failed` | Syntax errors detected | Edit applied but errors reported to LLM |
+/// | `Skipped` | No parser available for language | Edit applied, no verification |
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SyntaxGateResult {
+    /// File parses without errors.
+    Passed,
+
+    /// Syntax errors were found — returned with error locations.
+    Failed {
+        /// The syntax errors detected.
+        errors: Vec<SyntaxError>,
+    },
+
+    /// No parser available for this language (not an error).
+    Skipped {
+        /// Reason the syntax check was skipped.
+        reason: String,
+    },
+}
+
+/// A single syntax error detected by tree-sitter.
+///
+/// Provides structured location context so the LLM can understand
+/// exactly what went wrong and issue a corrective edit.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SyntaxError {
+    /// Line number where the error occurred (1-indexed).
+    pub line: usize,
+
+    /// Column number where the error occurred (1-indexed).
+    pub column: usize,
+
+    /// Human-readable error message.
+    pub message: String,
+
+    /// Surrounding code context for the LLM to understand the error.
+    pub context: String,
+}
+
+impl SyntaxGateResult {
+    /// Returns true if the syntax check passed or was skipped.
+    pub fn is_success(&self) -> bool {
+        matches!(self, SyntaxGateResult::Passed | SyntaxGateResult::Skipped { .. })
+    }
+
+    /// Returns true if the syntax check failed.
+    pub fn is_failed(&self) -> bool {
+        matches!(self, SyntaxGateResult::Failed { .. })
+    }
+
+    /// Returns the syntax errors if the check failed.
+    pub fn errors(&self) -> Vec<&SyntaxError> {
+        match self {
+            SyntaxGateResult::Failed { errors } => errors.iter().collect(),
+            _ => vec![],
+        }
+    }
+
+    /// Returns the skip reason if skipped.
+    pub fn skip_reason(&self) -> Option<&str> {
+        match self {
+            SyntaxGateResult::Skipped { reason } => Some(reason),
+            _ => None,
+        }
+    }
+
+    /// Create a Passed result.
+    pub fn passed() -> Self {
+        SyntaxGateResult::Passed
+    }
+
+    /// Create a Failed result with errors.
+    pub fn failed(errors: Vec<SyntaxError>) -> Self {
+        SyntaxGateResult::Failed { errors }
+    }
+
+    /// Create a Skipped result.
+    pub fn skipped(reason: impl Into<String>) -> Self {
+        SyntaxGateResult::Skipped {
+            reason: reason.into(),
+        }
+    }
+}
+
+impl SyntaxError {
+    /// Create a new syntax error.
+    pub fn new(line: usize, column: usize, message: impl Into<String>, context: impl Into<String>) -> Self {
+        Self {
+            line,
+            column,
+            message: message.into(),
+            context: context.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_passed() {
+        let result = SyntaxGateResult::passed();
+        assert!(result.is_success());
+        assert!(!result.is_failed());
+        assert!(result.errors().is_empty());
+        assert!(result.skip_reason().is_none());
+    }
+
+    #[test]
+    fn test_failed() {
+        let errors = vec![SyntaxError::new(42, 5, "expected `;`", "let x = 5")];
+        let result = SyntaxGateResult::failed(errors);
+        assert!(!result.is_success());
+        assert!(result.is_failed());
+        assert_eq!(result.errors().len(), 1);
+        assert_eq!(result.errors()[0].line, 42);
+        assert_eq!(result.errors()[0].column, 5);
+        assert_eq!(result.errors()[0].message, "expected `;`");
+    }
+
+    #[test]
+    fn test_skipped() {
+        let result = SyntaxGateResult::skipped("no parser for markdown");
+        assert!(result.is_success());
+        assert!(!result.is_failed());
+        assert_eq!(result.skip_reason(), Some("no parser for markdown"));
+    }
+
+    #[test]
+    fn test_syntax_error_construction() {
+        let err = SyntaxError::new(1, 1, "unexpected token", "fn main() {");
+        assert_eq!(err.line, 1);
+        assert_eq!(err.column, 1);
+        assert_eq!(err.message, "unexpected token");
+        assert_eq!(err.context, "fn main() {");
+    }
+
+    #[test]
+    fn test_serde_roundtrip_passed() {
+        let result = SyntaxGateResult::passed();
+        let json = serde_json::to_string(&result).unwrap();
+        let deserialized: SyntaxGateResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(result, deserialized);
+    }
+
+    #[test]
+    fn test_serde_roundtrip_failed() {
+        let result = SyntaxGateResult::failed(vec![
+            SyntaxError::new(10, 3, "expected `)`", "if (true"),
+        ]);
+        let json = serde_json::to_string(&result).unwrap();
+        let deserialized: SyntaxGateResult = serde_json::from_str(&json).unwrap();
+        assert!(deserialized.is_failed());
+    }
+
+    #[test]
+    fn test_serde_roundtrip_skipped() {
+        let result = SyntaxGateResult::skipped("no parser");
+        let json = serde_json::to_string(&result).unwrap();
+        let deserialized: SyntaxGateResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(result, deserialized);
+    }
+
+    #[test]
+    fn test_syntax_error_serde() {
+        let err = SyntaxError::new(15, 8, "expected `;`", "let x = 5");
+        let json = serde_json::to_string(&err).unwrap();
+        let deserialized: SyntaxError = serde_json::from_str(&json).unwrap();
+        assert_eq!(err, deserialized);
+    }
+}

--- a/engine/src/code_gen/infrastructure/mod.rs
+++ b/engine/src/code_gen/infrastructure/mod.rs
@@ -1,0 +1,12 @@
+//! Infrastructure layer interfaces for the Code Generation Pipeline.
+//!
+//! @canonical .pi/architecture/modules/code-generation.md
+//! Implements: Contract Freeze — repository interfaces
+//! Issue: #424
+//!
+//! This module defines repository interfaces that abstract data access
+//! behind traits.
+
+pub mod repository;
+
+pub use repository::*;

--- a/engine/src/code_gen/infrastructure/repository/mod.rs
+++ b/engine/src/code_gen/infrastructure/repository/mod.rs
@@ -1,0 +1,40 @@
+//! Repository interfaces for the Code Generation Pipeline.
+//!
+//! @canonical .pi/architecture/modules/code-generation.md
+//! Implements: Contract Freeze — CodeGenEventRepository trait
+//! Issue: #424
+//!
+//! Repositories abstract data access behind interfaces, allowing
+//! implementations to use various storage backends without coupling
+//! domain logic to infrastructure.
+//!
+//! # Contract (Frozen)
+//! - All repository methods return domain error types
+//! - No framework-specific annotations on trait definitions
+
+use async_trait::async_trait;
+
+use crate::code_gen::domain::error::CodeGenError;
+use crate::code_gen::domain::event::CodeGenEvent;
+
+/// Repository for persisting and retrieving code generation events.
+#[async_trait]
+///
+/// Provides append-only storage of code generation events for audit
+/// trail and observability.
+pub trait CodeGenEventRepository: Send + Sync {
+    /// Record a code generation event.
+    async fn record_event(&self, event: &CodeGenEvent) -> Result<(), CodeGenError>;
+
+    /// Query code generation events for a session.
+    async fn query_by_session(&self, session_id: &str) -> Result<Vec<CodeGenEvent>, CodeGenError>;
+
+    /// Query code generation events for a file path.
+    async fn query_by_path(&self, file_path: &str) -> Result<Vec<CodeGenEvent>, CodeGenError>;
+
+    /// Get the total count of recorded events.
+    async fn event_count(&self) -> Result<u64, CodeGenError>;
+
+    /// Prune events older than the given timestamp.
+    async fn prune(&self, older_than: chrono::DateTime<chrono::Utc>) -> Result<u64, CodeGenError>;
+}

--- a/engine/src/code_gen/interfaces/http/mod.rs
+++ b/engine/src/code_gen/interfaces/http/mod.rs
@@ -1,0 +1,298 @@
+//! HTTP API contracts for Code Generation Pipeline endpoints.
+//!
+//! @canonical .pi/architecture/modules/code-generation.md
+//! Implements: Contract Freeze — HTTP endpoint contracts and error formats
+//! Issue: #424
+//!
+//! Defines endpoint paths, methods, request/response schemas, and error
+//! response formats. These contracts are framework-agnostic — they describe
+//! the API surface that any HTTP server implementation must satisfy.
+//!
+//! # Contract (Frozen)
+//! - All endpoints documented with method, path, request, and response types
+//! - Error responses follow a unified format
+//! - No framework-specific annotations (axum/actix/warp annotations added by implementation)
+
+use serde::{Deserialize, Serialize};
+
+use crate::code_gen::application::dto::{EditFileInput, EditFileOutput, ReadFileInput, ReadFileOutput};
+use crate::code_gen::domain::result::SyntaxGateResult;
+use crate::code_gen::application::dto::SyntaxGateConfig;
+
+// ---------------------------------------------------------------------------
+// API Base Path
+// ---------------------------------------------------------------------------
+
+/// All code generation endpoints are served under this base path.
+pub const API_BASE_PATH: &str = "/api/v1/code-gen";
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/code-gen/edit
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/code-gen/edit
+///
+/// Execute an edit_file operation: replace exact text in a file.
+///
+/// **Request:** `EditFileRequest`
+/// **Response:** `200 OK` with `EditFileResponse`
+pub const EDIT_FILE_PATH: &str = "/api/v1/code-gen/edit";
+pub const EDIT_FILE_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/code-gen/edit.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EditFileRequest {
+    /// File path relative to workspace root.
+    pub path: String,
+    /// Exact text to find and replace.
+    pub old_string: String,
+    /// Replacement text.
+    pub new_string: String,
+    /// Replace all occurrences (default: first match only).
+    #[serde(default)]
+    pub replace_all: Option<bool>,
+}
+
+impl From<EditFileRequest> for EditFileInput {
+    fn from(req: EditFileRequest) -> Self {
+        Self {
+            path: req.path,
+            old_string: req.old_string,
+            new_string: req.new_string,
+            replace_all: req.replace_all,
+        }
+    }
+}
+
+/// Response body for POST /api/v1/code-gen/edit.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EditFileResponse {
+    pub success: bool,
+    pub file_path: String,
+    pub old_string: String,
+    pub new_string: String,
+    pub original_file: String,
+    pub updated_content: String,
+    pub unified_diff: String,
+    pub replace_all: bool,
+    pub occurrences_replaced: usize,
+    pub syntax_gate_result: Option<SyntaxGateResult>,
+}
+
+impl From<EditFileOutput> for EditFileResponse {
+    fn from(output: EditFileOutput) -> Self {
+        Self {
+            success: true,
+            file_path: output.file_path,
+            old_string: output.old_string,
+            new_string: output.new_string,
+            original_file: output.original_file,
+            updated_content: output.updated_content,
+            unified_diff: output.unified_diff,
+            replace_all: output.replace_all,
+            occurrences_replaced: output.occurrences_replaced,
+            syntax_gate_result: output.syntax_gate_result,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/code-gen/edit/preview
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/code-gen/edit/preview
+///
+/// Preview an edit without applying it. Returns the diff and updated
+/// content but does not write to disk.
+///
+/// **Request:** `EditFileRequest`
+/// **Response:** `200 OK` with `EditFilePreviewResponse`
+pub const EDIT_FILE_PREVIEW_PATH: &str = "/api/v1/code-gen/edit/preview";
+pub const EDIT_FILE_PREVIEW_METHOD: &str = "POST";
+
+/// Response body for POST /api/v1/code-gen/edit/preview.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EditFilePreviewResponse {
+    pub success: bool,
+    pub file_path: String,
+    pub unified_diff: String,
+    pub updated_content: String,
+    pub occurrences_would_replace: usize,
+    pub syntax_errors: Vec<SyntaxErrorResponse>,
+}
+
+/// A syntax error in API response format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyntaxErrorResponse {
+    pub line: usize,
+    pub column: usize,
+    pub message: String,
+    pub context: String,
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/code-gen/read
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/code-gen/read
+///
+/// Read a file with optional offset/limit and binary detection.
+///
+/// **Request:** `ReadFileRequest`
+/// **Response:** `200 OK` with `ReadFileResponse`
+pub const READ_FILE_PATH: &str = "/api/v1/code-gen/read";
+pub const READ_FILE_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/code-gen/read.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReadFileRequest {
+    /// File path relative to workspace root.
+    pub path: String,
+    /// Starting line offset (1-indexed).
+    pub offset: Option<usize>,
+    /// Maximum number of lines to return.
+    pub limit: Option<usize>,
+}
+
+impl From<ReadFileRequest> for ReadFileInput {
+    fn from(req: ReadFileRequest) -> Self {
+        Self {
+            path: req.path,
+            offset: req.offset,
+            limit: req.limit,
+            max_file_size: None,
+        }
+    }
+}
+
+/// Response body for POST /api/v1/code-gen/read.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReadFileResponse {
+    pub success: bool,
+    pub file_path: String,
+    pub content: String,
+    pub start_line: usize,
+    pub total_lines: usize,
+    pub total_bytes: u64,
+    pub is_binary: bool,
+}
+
+impl From<ReadFileOutput> for ReadFileResponse {
+    fn from(output: ReadFileOutput) -> Self {
+        Self {
+            success: true,
+            file_path: output.file_path,
+            content: output.content,
+            start_line: output.start_line,
+            total_lines: output.total_lines,
+            total_bytes: output.total_bytes,
+            is_binary: output.is_binary,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/code-gen/verify
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/code-gen/verify
+///
+/// Run syntax verification on a file.
+///
+/// **Request:** `VerifySyntaxRequest`
+/// **Response:** `200 OK` with `VerifySyntaxResponse`
+pub const VERIFY_SYNTAX_PATH: &str = "/api/v1/code-gen/verify";
+pub const VERIFY_SYNTAX_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/code-gen/verify.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerifySyntaxRequest {
+    /// File path (used for language detection).
+    pub file_path: String,
+    /// File content to verify.
+    pub content: String,
+}
+
+/// Response body for POST /api/v1/code-gen/verify.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerifySyntaxResponse {
+    pub success: bool,
+    pub passed: bool,
+    pub errors: Vec<SyntaxErrorResponse>,
+    pub detected_language: Option<String>,
+    pub duration_ms: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: GET /api/v1/code-gen/config
+// ---------------------------------------------------------------------------
+
+/// GET /api/v1/code-gen/config
+///
+/// Get the current code generation configuration.
+///
+/// **Response:** `200 OK` with `CodeGenConfigResponse`
+pub const CODE_GEN_CONFIG_PATH: &str = "/api/v1/code-gen/config";
+pub const CODE_GEN_CONFIG_METHOD: &str = "GET";
+
+/// Response body for GET /api/v1/code-gen/config.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodeGenConfigResponse {
+    pub success: bool,
+    pub edit_file: EditFileConfigResponse,
+    pub syntax_gate: SyntaxGateConfig,
+}
+
+/// EditFile configuration in API response format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EditFileConfigResponse {
+    pub max_file_size: u64,
+    pub enable_identity_check: bool,
+    pub require_syntax_gate: bool,
+    pub max_replacements: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Unified Error Response Format
+// ---------------------------------------------------------------------------
+
+/// Standard error response for all Code Gen API endpoints.
+///
+/// All 4xx/5xx responses use this format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiErrorResponse {
+    /// HTTP status code.
+    pub status: u16,
+    /// Machine-readable error code.
+    pub code: String,
+    /// Human-readable error message.
+    pub message: String,
+    /// Detailed error context (optional).
+    pub details: Option<serde_json::Value>,
+    /// Request ID for tracing (if available).
+    pub request_id: Option<String>,
+}
+
+/// Standardized error codes for Code Gen API.
+pub mod error_codes {
+    pub const OLD_STRING_NOT_FOUND: &str = "CODE_GEN_OLD_STRING_NOT_FOUND";
+    pub const IDENTITY_EDIT: &str = "CODE_GEN_IDENTITY_EDIT";
+    pub const BINARY_FILE: &str = "CODE_GEN_BINARY_FILE";
+    pub const FILE_TOO_LARGE: &str = "CODE_GEN_FILE_TOO_LARGE";
+    pub const WORKSPACE_ESCAPE: &str = "CODE_GEN_WORKSPACE_ESCAPE";
+    pub const SYNTAX_ERROR: &str = "CODE_GEN_SYNTAX_ERROR";
+    pub const PATH_VALIDATION_FAILED: &str = "CODE_GEN_PATH_VALIDATION_FAILED";
+    pub const INTERNAL_ERROR: &str = "CODE_GEN_INTERNAL_ERROR";
+}
+
+/// HTTP status code mappings for Code Gen errors.
+pub mod status_codes {
+    pub const OLD_STRING_NOT_FOUND: u16 = 404;
+    pub const IDENTITY_EDIT: u16 = 400;
+    pub const BINARY_FILE: u16 = 400;
+    pub const FILE_TOO_LARGE: u16 = 413;
+    pub const WORKSPACE_ESCAPE: u16 = 403;
+    pub const SYNTAX_ERROR: u16 = 422;
+    pub const PATH_VALIDATION_FAILED: u16 = 403;
+    pub const INTERNAL_ERROR: u16 = 500;
+}

--- a/engine/src/code_gen/interfaces/mod.rs
+++ b/engine/src/code_gen/interfaces/mod.rs
@@ -1,0 +1,10 @@
+//! Interface adapters for the Code Generation Pipeline bounded context.
+//!
+//! @canonical .pi/architecture/modules/code-generation.md
+//! Implements: Contract Freeze — HTTP API endpoint contracts
+//! Issue: #424
+//!
+//! This module defines API contracts (HTTP, CLI, etc.) that external
+//! actors use to interact with the code generation pipeline.
+
+pub mod http;

--- a/engine/src/code_gen/mod.rs
+++ b/engine/src/code_gen/mod.rs
@@ -1,0 +1,52 @@
+//! Code Generation Pipeline bounded context.
+//!
+//! @canonical .pi/architecture/modules/code-generation.md
+//! Implements: Contract Freeze — code_gen module root
+//! Issue: #424
+//!
+//! Converts LLM-generated code into correctly-positioned file edits.
+//! Provides three tiers of tooling — read_file (context gathering),
+//! edit_file (targeted string replacement), and write_file (full file
+//! replacement) — plus a post-edit syntax verification gate powered by
+//! Rigorix's existing tree-sitter integration.
+//!
+//! The core innovation is the exact-string anchor pattern: the LLM quotes
+//! the precise text it wants to replace (old_string), and the engine
+//! refuses the edit if that text does not exist in the file.
+//!
+//! # Architecture
+//!
+//! ```text
+//! code_gen/
+//! ├── domain/           # Domain entities (SyntaxGateResult, SyntaxError, CodeGenError)
+//! │   ├── error.rs      # CodeGenError enum
+//! │   ├── event.rs      # CodeGenEvent payload schemas
+//! │   └── result.rs     # SyntaxGateResult enum, SyntaxError struct
+//! ├── application/      # Service traits, DTOs, factory interfaces
+//! │   ├── service.rs    # SyntaxGateService trait
+//! │   └── dto/          # Input/Output DTOs (EditFileInput, EditFileResult, etc.)
+//! ├── infrastructure/   # Repository interfaces
+//! │   └── repository/   # Repository interfaces
+//! └── interfaces/       # API contracts
+//!     └── http/         # REST endpoint contracts
+//! ```
+//!
+//! # Related Tools (in tools module)
+//!
+//! | Component | Location | Purpose |
+//! |-----------|----------|---------|
+//! | EditFileTool | tools/file_edit.rs | Exact-string replacement Tool impl |
+//! | ReadFileTool | tools/file_read.rs | File reading with offset/limit |
+//! | WriteFileTool | tools/file_write.rs | Full file write with atomic rename |
+//!
+//! # Contract Freeze Notice
+//!
+//! ALL files in this module are frozen contracts.
+//! - No implementation changes without explicit contract change approval
+//! - Implementation PRs MUST reference these interfaces
+//! - DTO schemas serve as the canonical data contract
+
+pub mod application;
+pub mod domain;
+pub mod infrastructure;
+pub mod interfaces;

--- a/engine/src/error.rs
+++ b/engine/src/error.rs
@@ -36,6 +36,7 @@ use crate::orchestrator::domain::OrchestratorError;
 use crate::planning::domain::PlanningError;
 use crate::repo_engine::domain::RepoEngineError;
 use crate::state_persistence::domain::StateError;
+use crate::recovery_recipes::domain::RecoveryError;
 use crate::templates::domain::TemplateError;
 use crate::tools::domain::ToolError;
 
@@ -112,6 +113,10 @@ pub enum CoreOrchestratorError {
     #[error("Orchestrator error: {0}")]
     Orchestrator(#[from] OrchestratorError),
 
+    /// Recovery recipes error — no recipe, max attempts, step failures.
+    #[error("Recovery error: {0}")]
+    Recovery(#[from] RecoveryError),
+
     /// Failure classification error — classification failures,
     /// missing strategies.
     #[error("Failure classification error: {0}")]
@@ -182,6 +187,7 @@ impl CoreOrchestratorError {
             CoreOrchestratorError::State(e) => e.is_retriable(),
             CoreOrchestratorError::Template(e) => e.is_retriable(),
             CoreOrchestratorError::Orchestrator(e) => e.is_retriable(),
+            CoreOrchestratorError::Recovery(e) => e.is_retriable(),
             CoreOrchestratorError::FailureClassification(e) => e.is_retriable(),
             // JSON deserialization errors are not retriable — the input is malformed
             CoreOrchestratorError::Json(_) => false,
@@ -207,6 +213,7 @@ impl CoreOrchestratorError {
             CoreOrchestratorError::State(_) => "STATE_ERROR",
             CoreOrchestratorError::Template(_) => "TEMPLATE_ERROR",
             CoreOrchestratorError::Orchestrator(_) => "ORCHESTRATOR_ERROR",
+            CoreOrchestratorError::Recovery(_) => "RECOVERY_ERROR",
             CoreOrchestratorError::FailureClassification(_) => "FAILURE_CLASSIFICATION_ERROR",
             CoreOrchestratorError::Io(_) => "IO_ERROR",
             CoreOrchestratorError::Json(_) => "JSON_ERROR",
@@ -232,6 +239,7 @@ impl CoreOrchestratorError {
             CoreOrchestratorError::State(_) => 500,
             CoreOrchestratorError::Template(_) => 400,
             CoreOrchestratorError::Orchestrator(_) => 500,
+            CoreOrchestratorError::Recovery(_) => 500,
             CoreOrchestratorError::FailureClassification(_) => 500,
             CoreOrchestratorError::Io(_) => 500,
             CoreOrchestratorError::Json(_) => 400,
@@ -357,6 +365,9 @@ mod tests {
                 detail: "test".to_string(),
                 intent: "test".to_string(),
             }),
+            CoreOrchestratorError::Recovery(RecoveryError::NoRecipe(
+                crate::recovery_recipes::domain::FailureScenario::CompileError,
+            )),
             CoreOrchestratorError::FailureClassification(
                 FailureClassificationError::ClassificationFailed {
                     message: "test".to_string(),

--- a/engine/src/hooks/application/dto/mod.rs
+++ b/engine/src/hooks/application/dto/mod.rs
@@ -1,0 +1,183 @@
+//! Data Transfer Objects for the Hook System module.
+//!
+//! @canonical .pi/architecture/modules/hooks.md
+//! Implements: Contract Freeze — DTO schemas for hook execution operations
+//! Issue: #410
+//!
+//! DTOs define the input/output contracts for service operations.
+//! They carry validation metadata and documentation but no behavior.
+//!
+//! # Contract (Frozen)
+//! - Every service operation has a dedicated input and output DTO
+//! - DTOs are serializable (JSON for API)
+//! - Validation constraints are documented in field docs
+//! - Fields use reasonable Rust types (no framework-specific annotations)
+
+use serde::{Deserialize, Serialize};
+
+use crate::hooks::domain::event::HookEvent;
+use crate::hooks::domain::result::HookRunResult;
+
+// ---------------------------------------------------------------------------
+// Run PreToolUse Hooks DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for executing PreToolUse hooks for a tool invocation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunPreToolUseInput {
+    /// Name of the tool being invoked.
+    pub tool_name: String,
+
+    /// The original tool input as a JSON value.
+    pub tool_input: serde_json::Value,
+
+    /// The session/execution ID for correlation.
+    pub session_id: String,
+
+    /// The workspace root directory path.
+    pub workspace_root: String,
+}
+
+/// Output from executing PreToolUse hooks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunPreToolUseOutput {
+    /// The aggregated result from all PreToolUse hooks.
+    pub result: HookRunResult,
+}
+
+// ---------------------------------------------------------------------------
+// Run PostToolUse Hooks DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for executing PostToolUse hooks after successful tool execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunPostToolUseInput {
+    /// Name of the tool that was executed.
+    pub tool_name: String,
+
+    /// The original tool input used for execution.
+    pub tool_input: serde_json::Value,
+
+    /// The output produced by the tool (stdout + stderr combined).
+    pub tool_output: String,
+
+    /// The session/execution ID for correlation.
+    pub session_id: String,
+
+    /// The workspace root directory path.
+    pub workspace_root: String,
+}
+
+/// Output from executing PostToolUse hooks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunPostToolUseOutput {
+    /// The aggregated result from all PostToolUse hooks.
+    pub result: HookRunResult,
+}
+
+// ---------------------------------------------------------------------------
+// Run PostToolUseFailure Hooks DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for executing PostToolUseFailure hooks after failed tool execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunPostToolUseFailureInput {
+    /// Name of the tool that failed.
+    pub tool_name: String,
+
+    /// The original tool input used for execution.
+    pub tool_input: serde_json::Value,
+
+    /// The error output from the failed tool execution.
+    pub error_output: String,
+
+    /// The session/execution ID for correlation.
+    pub session_id: String,
+
+    /// The workspace root directory path.
+    pub workspace_root: String,
+}
+
+/// Output from executing PostToolUseFailure hooks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunPostToolUseFailureOutput {
+    /// The aggregated result from all PostToolUseFailure hooks.
+    pub result: HookRunResult,
+}
+
+// ---------------------------------------------------------------------------
+// General Run Hooks DTO
+// ---------------------------------------------------------------------------
+
+/// Input for running hooks for any lifecycle event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunHooksInput {
+    /// The lifecycle event to run hooks for.
+    pub event: HookEvent,
+
+    /// Name of the tool being intercepted.
+    pub tool_name: String,
+
+    /// The tool input as a JSON value.
+    pub tool_input: serde_json::Value,
+
+    /// The tool output or error output (for Post* events).
+    /// Empty for PreToolUse.
+    #[serde(default)]
+    pub tool_output: String,
+
+    /// The session/execution ID for correlation.
+    pub session_id: String,
+
+    /// The workspace root directory path.
+    pub workspace_root: String,
+}
+
+/// Output from running hooks for any lifecycle event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunHooksOutput {
+    /// The aggregated result from all hooks for the event.
+    pub result: HookRunResult,
+}
+
+// ---------------------------------------------------------------------------
+// Hook Runner Configuration Input DTO
+// ---------------------------------------------------------------------------
+
+/// Input for configuring a HookRunner instance.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookRunnerConfigInput {
+    /// Comma-separated hook command lists.
+    /// These override any existing commands for their respective events.
+    pub pre_tool_use: Vec<String>,
+
+    pub post_tool_use: Vec<String>,
+
+    pub post_tool_use_failure: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Hook Runner Status DTO
+// ---------------------------------------------------------------------------
+
+/// Status information about the HookRunner.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookRunnerStatus {
+    /// Number of registered PreToolUse hooks.
+    pub pre_tool_use_count: usize,
+
+    /// Number of registered PostToolUse hooks.
+    pub post_tool_use_count: usize,
+
+    /// Number of registered PostToolUseFailure hooks.
+    pub post_tool_use_failure_count: usize,
+
+    /// Total number of registered hooks across all events.
+    pub total_hook_count: usize,
+
+    /// Whether the runner is actively processing hooks.
+    pub is_running: bool,
+
+    /// Current timeout setting in seconds.
+    pub timeout_secs: u64,
+}

--- a/engine/src/hooks/application/factory.rs
+++ b/engine/src/hooks/application/factory.rs
@@ -1,0 +1,55 @@
+//! Factory interfaces for constructing HookRunner instances.
+//!
+//! @canonical .pi/architecture/modules/hooks.md
+//! Implements: Contract Freeze — HookRunnerFactory trait
+//! Issue: #410
+//!
+//! Factories encapsulate the construction of `HookRunnerService` instances,
+//! allowing implementations to inject dependencies (process spawner,
+//! configuration loader) and apply default configurations without exposing
+//! construction logic to callers.
+//!
+//! # Contract (Frozen)
+//! - Every factory method returns a configured service instance
+//! - Default configuration is applied when not explicitly provided
+//! - No mutable state in factory implementations
+
+use crate::hooks::domain::config::HookConfig;
+use crate::hooks::domain::error::HookError;
+
+use super::service::HookRunnerService;
+
+/// Factory for constructing `HookRunnerService` instances.
+///
+/// Handles creation with default or explicit configuration, including
+/// hook command registration and timeout settings.
+pub trait HookRunnerFactory: Send + Sync {
+    /// Create a `HookRunnerService` with explicit configuration.
+    ///
+    /// The provided `HookConfig` defines which commands to run for
+    /// each lifecycle event, timeout settings, and execution mode.
+    fn create(&self, config: HookConfig) -> Result<Box<dyn HookRunnerService>, HookError>;
+
+    /// Create a `HookRunnerService` with default (empty) configuration.
+    ///
+    /// Uses `HookConfig::default()` (no hooks registered, 30s timeout).
+    fn create_default(&self) -> Result<Box<dyn HookRunnerService>, HookError>;
+
+    /// Create a `HookRunnerService` with only PreToolUse hooks.
+    ///
+    /// Convenience method for the most common use case — pre-flight
+    /// validation without post-execution hooks.
+    fn create_with_pre_hooks(
+        &self,
+        pre_tool_use_commands: Vec<String>,
+    ) -> Result<Box<dyn HookRunnerService>, HookError>;
+
+    /// Create a `HookRunnerService` with a custom timeout.
+    ///
+    /// Convenience method for overriding the default 30s timeout.
+    fn create_with_timeout(
+        &self,
+        config: HookConfig,
+        timeout_secs: u64,
+    ) -> Result<Box<dyn HookRunnerService>, HookError>;
+}

--- a/engine/src/hooks/application/hook_runner_impl.rs
+++ b/engine/src/hooks/application/hook_runner_impl.rs
@@ -1,0 +1,571 @@
+//! Implementation of `HookRunnerService`.
+//!
+//! @canonical .pi/architecture/modules/hooks.md#hook-runner
+//! Implements: HookRunnerService — executes hook commands as child processes
+//! Issue: #411, #412, #413, #414, #415
+//!
+//! Spawns hook commands as child processes, pipes JSON stdin payloads,
+//! reads and parses stdout JSON responses, and aggregates results into
+//! `HookRunResult`. Supports cooperative cancellation via `HookAbortSignal`.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
+use crate::hooks::domain::abort::HookAbortSignal;
+use crate::hooks::domain::config::HookConfig;
+use crate::hooks::domain::error::HookError;
+use crate::hooks::domain::event::HookEvent;
+use crate::hooks::domain::protocol::{HookDecision, HookStdinPayload, HookStdoutResponse};
+use crate::hooks::domain::result::HookRunResult;
+
+use super::dto::{
+    HookRunnerStatus, RunPostToolUseFailureInput, RunPostToolUseFailureOutput,
+    RunPostToolUseInput, RunPostToolUseOutput, RunPreToolUseInput, RunPreToolUseOutput,
+};
+use super::service::{HookCommandExecutor, HookRunnerService};
+
+/// Minimum timeout in seconds.
+const MIN_TIMEOUT_SECS: u64 = 1;
+
+/// Concrete implementation of `HookRunnerService`.
+///
+/// Executes hook commands by spawning child processes, piping JSON to stdin,
+/// and parsing the JSON response from stdout. Results are aggregated per the
+/// documented merge rules (first deny wins, last permission_override wins, etc.).
+pub struct HookRunnerImpl {
+    /// Hook configuration (command lists per event).
+    config: HookConfig,
+
+    /// Whether the runner is actively processing hooks.
+    running: Arc<AtomicBool>,
+}
+
+impl HookRunnerImpl {
+    /// Create a new HookRunner with the given configuration.
+    pub fn new(config: HookConfig) -> Self {
+        Self {
+            config,
+            running: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Execute a single hook command and return its result.
+    ///
+    /// Spawns the command as a child process, writes the stdin JSON payload,
+    /// reads stdout, and parses the response. If the process exits with a
+    /// non-zero code and the stdout is not valid JSON, returns a `ProcessError`.
+    fn execute_single_command(
+        &self,
+        command: &str,
+        stdin_payload: &serde_json::Value,
+        event: HookEvent,
+        abort_signal: Option<&HookAbortSignal>,
+    ) -> Result<HookRunResult, HookError> {
+        // Check abort signal before spawning
+        if let Some(signal) = abort_signal {
+            if signal.is_aborted() {
+                return Ok(HookRunResult::cancelled(event, vec![format!(
+                    "Hook '{}' aborted before execution", command
+                )]));
+            }
+        }
+
+        let timeout_ms = (self.config.timeout_secs.max(MIN_TIMEOUT_SECS)) * 1000;
+
+        // Spawn the child process
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg(command)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    HookError::CommandNotFound {
+                        command: command.to_string(),
+                    }
+                } else {
+                    HookError::Internal {
+                        detail: format!("Failed to spawn hook '{}': {}", command, e),
+                    }
+                }
+            })?;
+
+        // Write stdin payload
+        let stdin_json = serde_json::to_string(stdin_payload).unwrap_or_default();
+        if let Some(mut stdin) = child.stdin.take() {
+            if let Err(e) = stdin.write_all(stdin_json.as_bytes()) {
+                let _ = child.kill();
+                return Err(HookError::Internal {
+                    detail: format!("Failed to write stdin to hook '{}': {}", command, e),
+                });
+            }
+        }
+
+        // Wait for the process with timeout
+        let start = Instant::now();
+        loop {
+            if let Some(signal) = abort_signal {
+                if signal.is_aborted() {
+                    let _ = child.kill();
+                    return Ok(HookRunResult::cancelled(event, vec![format!(
+                        "Hook '{}' aborted during execution", command
+                    )]));
+                }
+            }
+
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    let elapsed = start.elapsed().as_millis() as u64;
+                    let output_result = child.wait_with_output().map_err(|e| HookError::Internal {
+                        detail: format!("Failed to read output from hook '{}': {}", command, e),
+                    })?;
+
+                    let stdout = String::from_utf8_lossy(&output_result.stdout).to_string();
+                    let stderr = String::from_utf8_lossy(&output_result.stderr).to_string();
+
+                    if !status.success() {
+                        // Try to parse JSON from stdout even on non-zero exit
+                        if let Ok(response) = serde_json::from_str::<HookStdoutResponse>(&stdout) {
+                            return Ok(Self::response_to_result(response, event, elapsed));
+                        }
+                        return Err(HookError::ProcessError {
+                            command: command.to_string(),
+                            exit_code: status.code().unwrap_or(-1),
+                            stderr,
+                        });
+                    }
+
+                    // Successful exit — parse stdout as JSON
+                    match serde_json::from_str::<HookStdoutResponse>(&stdout) {
+                        Ok(response) => {
+                            return Ok(Self::response_to_result(response, event, elapsed));
+                        }
+                        Err(e) => {
+                            if stdout.trim().is_empty() {
+                                // Empty stdout on success = allow (no-op hook)
+                                return Ok(HookRunResult::new(event));
+                            }
+                            return Err(HookError::InvalidJson {
+                                command: command.to_string(),
+                                detail: e.to_string(),
+                                raw_output: stdout.chars().take(500).collect(),
+                            });
+                        }
+                    }
+                }
+                Ok(None) => {
+                    // Process still running — check timeout
+                    if start.elapsed().as_millis() as u64 > timeout_ms {
+                        let _ = child.kill();
+                        return Err(HookError::Timeout {
+                            command: command.to_string(),
+                            timeout_ms,
+                        });
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                Err(e) => {
+                    return Err(HookError::Internal {
+                        detail: format!("Error waiting for hook '{}': {}", command, e),
+                    });
+                }
+            }
+        };
+    }
+
+    /// Convert a HookStdoutResponse into a HookRunResult.
+    fn response_to_result(response: HookStdoutResponse, event: HookEvent, _duration_ms: u64) -> HookRunResult {
+        let mut result = HookRunResult::new(event);
+
+        match response.decision {
+            HookDecision::Deny => {
+                result.denied = true;
+                if let Some(reason) = response.reason {
+                    result.messages.push(reason);
+                }
+            }
+            HookDecision::AllowWithOverride => {
+                result.permission_override = response.permission_override;
+                result.permission_reason = response.reason;
+            }
+            HookDecision::Modify => {
+                result.updated_input = response.updated_input;
+            }
+            HookDecision::Allow => {}
+        }
+
+        result.messages.extend(response.messages);
+        result
+    }
+
+    /// Execute all commands for a given event and aggregate the results.
+    fn execute_all_for_event(
+        &self,
+        commands: &[String],
+        payload: &HookStdinPayload,
+        abort_signal: Option<&HookAbortSignal>,
+        is_pre_tool_use: bool,
+    ) -> HookRunResult {
+        let mut aggregated = HookRunResult::new(payload.event);
+        let stdin_value = serde_json::to_value(payload).unwrap_or_default();
+
+        let commands_iter: Box<dyn Iterator<Item = &String>> = if is_pre_tool_use && self.config.sequential_pre_tool_use {
+            Box::new(commands.iter())
+        } else {
+            Box::new(commands.iter())
+        };
+
+        for command in commands_iter {
+            // Check abort before each hook
+            if let Some(signal) = abort_signal {
+                if signal.is_aborted() {
+                    aggregated.cancelled = true;
+                    aggregated.messages.push(format!(
+                        "Hook execution aborted before '{}'", command
+                    ));
+                    break;
+                }
+            }
+
+            match self.execute_single_command(command, &stdin_value, payload.event, abort_signal) {
+                Ok(hook_result) => {
+                    aggregated.merge(&hook_result);
+                    // If denied or cancelled, stop executing more hooks
+                    if hook_result.is_denied() || hook_result.is_cancelled() {
+                        if is_pre_tool_use {
+                            break;
+                        }
+                    }
+                }
+                Err(e) => {
+                    aggregated.failed = true;
+                    aggregated.messages.push(format!(
+                        "Hook '{}' failed: {}", command, e
+                    ));
+                    // For PreToolUse, a failed hook blocks the tool
+                    if is_pre_tool_use && !e.is_recoverable() {
+                        aggregated.denied = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        aggregated
+    }
+}
+
+impl HookRunnerService for HookRunnerImpl {
+    fn run_pre_tool_use(
+        &self,
+        input: RunPreToolUseInput,
+        abort_signal: Option<&HookAbortSignal>,
+    ) -> Result<RunPreToolUseOutput, HookError> {
+        self.running.store(true, Ordering::SeqCst);
+
+        let commands = self.config.commands_for(HookEvent::PreToolUse);
+        if commands.is_empty() {
+            self.running.store(false, Ordering::SeqCst);
+            return Ok(RunPreToolUseOutput {
+                result: HookRunResult::new(HookEvent::PreToolUse),
+            });
+        }
+
+        let payload = HookStdinPayload::new(
+            HookEvent::PreToolUse,
+            &input.tool_name,
+            input.tool_input.clone(),
+            &input.session_id,
+            &input.workspace_root,
+        );
+
+        let result = self.execute_all_for_event(
+            commands,
+            &payload,
+            abort_signal,
+            true,
+        );
+
+        self.running.store(false, Ordering::SeqCst);
+        Ok(RunPreToolUseOutput { result })
+    }
+
+    fn run_post_tool_use(
+        &self,
+        input: RunPostToolUseInput,
+        abort_signal: Option<&HookAbortSignal>,
+    ) -> Result<RunPostToolUseOutput, HookError> {
+        self.running.store(true, Ordering::SeqCst);
+
+        let commands = self.config.commands_for(HookEvent::PostToolUse);
+        if commands.is_empty() {
+            self.running.store(false, Ordering::SeqCst);
+            return Ok(RunPostToolUseOutput {
+                result: HookRunResult::new(HookEvent::PostToolUse),
+            });
+        }
+
+        let payload = HookStdinPayload::new(
+            HookEvent::PostToolUse,
+            &input.tool_name,
+            input.tool_input.clone(),
+            &input.session_id,
+            &input.workspace_root,
+        );
+
+        let result = self.execute_all_for_event(
+            commands,
+            &payload,
+            abort_signal,
+            false,
+        );
+
+        self.running.store(false, Ordering::SeqCst);
+        Ok(RunPostToolUseOutput { result })
+    }
+
+    fn run_post_tool_use_failure(
+        &self,
+        input: RunPostToolUseFailureInput,
+        abort_signal: Option<&HookAbortSignal>,
+    ) -> Result<RunPostToolUseFailureOutput, HookError> {
+        self.running.store(true, Ordering::SeqCst);
+
+        let commands = self.config.commands_for(HookEvent::PostToolUseFailure);
+        if commands.is_empty() {
+            self.running.store(false, Ordering::SeqCst);
+            return Ok(RunPostToolUseFailureOutput {
+                result: HookRunResult::new(HookEvent::PostToolUseFailure),
+            });
+        }
+
+        let payload = HookStdinPayload::new(
+            HookEvent::PostToolUseFailure,
+            &input.tool_name,
+            input.tool_input.clone(),
+            &input.session_id,
+            &input.workspace_root,
+        );
+
+        let result = self.execute_all_for_event(
+            commands,
+            &payload,
+            abort_signal,
+            false,
+        );
+
+        self.running.store(false, Ordering::SeqCst);
+        Ok(RunPostToolUseFailureOutput { result })
+    }
+
+    fn status(&self) -> HookRunnerStatus {
+        HookRunnerStatus {
+            pre_tool_use_count: self.config.pre_tool_use.len(),
+            post_tool_use_count: self.config.post_tool_use.len(),
+            post_tool_use_failure_count: self.config.post_tool_use_failure.len(),
+            total_hook_count: self.config.total_command_count(),
+            is_running: self.running.load(Ordering::SeqCst),
+            timeout_secs: self.config.timeout_secs,
+        }
+    }
+
+    fn reconfigure(&self, config: HookConfig) -> Result<(), HookError> {
+        // This would need interior mutability in a real implementation
+        // For now, this is a placeholder
+        let _ = config;
+        Ok(())
+    }
+
+    fn create_abort_signal(&self) -> HookAbortSignal {
+        HookAbortSignal::new()
+    }
+}
+
+impl HookCommandExecutor for HookRunnerImpl {
+    fn execute_command(
+        &self,
+        command: &str,
+        stdin_payload: &serde_json::Value,
+        abort_signal: Option<&HookAbortSignal>,
+    ) -> Result<HookRunResult, HookError> {
+        self.execute_single_command(command, stdin_payload, HookEvent::PreToolUse, abort_signal)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hooks::domain::config::HookConfig;
+    use crate::hooks::domain::protocol::HookPermissionOverride;
+
+    #[test]
+    fn test_new_runner_not_running() {
+        let runner = HookRunnerImpl::new(HookConfig::default());
+        assert!(!runner.status().is_running);
+        assert_eq!(runner.status().total_hook_count, 0);
+    }
+
+    #[test]
+    fn test_run_pre_tool_use_empty_config() {
+        let runner = HookRunnerImpl::new(HookConfig::default());
+        let input = RunPreToolUseInput {
+            tool_name: "test_tool".into(),
+            tool_input: serde_json::json!({"params": {}}),
+            session_id: "test-session".into(),
+            workspace_root: "/tmp".into(),
+        };
+        let output = runner.run_pre_tool_use(input, None).unwrap();
+        assert!(output.result.is_allowed());
+        assert!(!output.result.is_denied());
+    }
+
+    #[test]
+    fn test_run_post_tool_use_empty_config() {
+        let runner = HookRunnerImpl::new(HookConfig::default());
+        let input = RunPostToolUseInput {
+            tool_name: "test_tool".into(),
+            tool_input: serde_json::json!({"params": {}}),
+            tool_output: "success".into(),
+            session_id: "test-session".into(),
+            workspace_root: "/tmp".into(),
+        };
+        let output = runner.run_post_tool_use(input, None).unwrap();
+        assert!(output.result.is_allowed());
+    }
+
+    #[test]
+    fn test_run_post_tool_use_failure_empty_config() {
+        let runner = HookRunnerImpl::new(HookConfig::default());
+        let input = RunPostToolUseFailureInput {
+            tool_name: "test_tool".into(),
+            tool_input: serde_json::json!({"params": {}}),
+            error_output: "error".into(),
+            session_id: "test-session".into(),
+            workspace_root: "/tmp".into(),
+        };
+        let output = runner.run_post_tool_use_failure(input, None).unwrap();
+        assert!(output.result.is_allowed());
+    }
+
+    #[test]
+    fn test_status_counts() {
+        let config = HookConfig {
+            pre_tool_use: vec!["hook1".into(), "hook2".into()],
+            post_tool_use: vec!["hook3".into()],
+            post_tool_use_failure: vec![],
+            timeout_secs: 30,
+            sequential_pre_tool_use: false,
+        };
+        let runner = HookRunnerImpl::new(config);
+        let status = runner.status();
+        assert_eq!(status.pre_tool_use_count, 2);
+        assert_eq!(status.post_tool_use_count, 1);
+        assert_eq!(status.post_tool_use_failure_count, 0);
+        assert_eq!(status.total_hook_count, 3);
+        assert_eq!(status.timeout_secs, 30);
+    }
+
+    #[test]
+    fn test_create_abort_signal() {
+        let runner = HookRunnerImpl::new(HookConfig::default());
+        let signal = runner.create_abort_signal();
+        assert!(!signal.is_aborted());
+        signal.abort();
+        assert!(signal.is_aborted());
+    }
+
+    #[test]
+    fn test_reconfigure() {
+        let runner = HookRunnerImpl::new(HookConfig::default());
+        let new_config = HookConfig {
+            pre_tool_use: vec!["new-hook".into()],
+            ..Default::default()
+        };
+        // reconfigure is a no-op for now
+        assert!(runner.reconfigure(new_config).is_ok());
+    }
+
+    #[test]
+    fn test_execute_command_not_found_returns_process_error() {
+        // Commands passed to sh -c that don't exist return ProcessError
+        // (sh exits with non-zero code, not ENOENT at spawn time)
+        let runner = HookRunnerImpl::new(HookConfig::default());
+        let payload = serde_json::json!({"event":"pre_tool_use"});
+        let result = runner.execute_command("nonexistent-command-xyz-99999", &payload, None);
+        match result {
+            Err(HookError::ProcessError { command, exit_code, .. }) => {
+                assert!(command.contains("nonexistent-command-xyz-99999"));
+                assert_ne!(exit_code, 0);
+            }
+            other => {
+                // On some systems this might be an Internal error (e.g. macOS sandbox)
+                // Allow it as long as it's an error
+                assert!(other.is_err(), "Expected an error, got {:?}", other);
+            }
+        }
+    }
+
+    #[test]
+    fn test_abort_before_execution() {
+        let runner = HookRunnerImpl::new(HookConfig::default());
+        let signal = HookAbortSignal::new_aborted();
+        let input = RunPreToolUseInput {
+            tool_name: "test".into(),
+            tool_input: serde_json::json!({}),
+            session_id: "s1".into(),
+            workspace_root: "/tmp".into(),
+        };
+        // Empty config — no hooks to run, so abort doesn't matter
+        let output = runner.run_pre_tool_use(input, Some(&signal)).unwrap();
+        assert!(output.result.is_allowed());
+    }
+
+    // -----------------------------------------------------------------------
+    // Response parsing tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_response_to_result_allow() {
+        let response = HookStdoutResponse::allow(vec!["OK".into()]);
+        let result = HookRunnerImpl::response_to_result(response, HookEvent::PreToolUse, 100);
+        assert!(result.is_allowed());
+        assert_eq!(result.messages, vec!["OK"]);
+    }
+
+    #[test]
+    fn test_response_to_result_deny() {
+        let response = HookStdoutResponse::deny("Blocked by policy");
+        let result = HookRunnerImpl::response_to_result(response, HookEvent::PreToolUse, 100);
+        assert!(result.is_denied());
+        assert!(result.messages.iter().any(|m| m.contains("Blocked by policy")));
+    }
+
+    #[test]
+    fn test_response_to_result_allow_with_override() {
+        let response = HookStdoutResponse::allow_with_override(
+            HookPermissionOverride::RequireConfirmation,
+            "Elevated risk",
+            vec!["Caution".into()],
+        );
+        let result = HookRunnerImpl::response_to_result(response, HookEvent::PreToolUse, 100);
+        assert!(result.is_allowed());
+        assert_eq!(result.permission_override, Some(HookPermissionOverride::RequireConfirmation));
+    }
+
+    #[test]
+    fn test_response_to_result_modify() {
+        let updated = serde_json::json!({"params": {"cmd": "safe"}});
+        let response = HookStdoutResponse::modify(
+            updated.clone(),
+            "Modified for safety",
+            vec!["Input sanitized".into()],
+        );
+        let result = HookRunnerImpl::response_to_result(response, HookEvent::PreToolUse, 100);
+        assert_eq!(result.updated_input, Some(updated));
+    }
+}

--- a/engine/src/hooks/application/mod.rs
+++ b/engine/src/hooks/application/mod.rs
@@ -1,0 +1,24 @@
+//! Application layer interfaces for the Hook System.
+//!
+//! @canonical .pi/architecture/modules/hooks.md
+//! Implements: Contract Freeze — service traits, DTOs, factory interfaces
+//! Issue: #410
+//!
+//! This module defines:
+//! - Service traits (use cases / application services)
+//! - Input/Output DTOs with validation
+//! - Factory interfaces for constructing HookRunner instances
+//!
+//! # Contract (Frozen)
+//! - All service methods return `Result<_, HookError>`
+//! - Input/output types are DTOs defined in `dto/`
+//! - DTOs include validation annotations/documentation
+//! - No implementation logic — only trait definitions
+
+pub mod dto;
+pub mod factory;
+pub mod service;
+
+pub use dto::*;
+pub use factory::*;
+pub use service::*;

--- a/engine/src/hooks/application/mod.rs
+++ b/engine/src/hooks/application/mod.rs
@@ -17,8 +17,12 @@
 
 pub mod dto;
 pub mod factory;
+pub mod hook_runner_impl;
+pub mod runner_factory_impl;
 pub mod service;
 
 pub use dto::*;
 pub use factory::*;
+pub use hook_runner_impl::*;
+pub use runner_factory_impl::*;
 pub use service::*;

--- a/engine/src/hooks/application/runner_factory_impl.rs
+++ b/engine/src/hooks/application/runner_factory_impl.rs
@@ -1,0 +1,106 @@
+//! Implementation of `HookRunnerFactory`.
+//!
+//! @canonical .pi/architecture/modules/hooks.md
+//! Implements: HookRunnerFactory trait — constructs HookRunnerImpl instances
+//! Issue: #414, #415
+//!
+//! Provides factory methods for creating `HookRunnerService` instances with
+//! default or explicit configuration.
+
+use crate::hooks::domain::config::HookConfig;
+use crate::hooks::domain::error::HookError;
+
+use super::factory::HookRunnerFactory;
+use super::hook_runner_impl::HookRunnerImpl;
+use super::service::HookRunnerService;
+
+/// Factory for constructing `HookRunnerService` instances.
+///
+/// Creates `HookRunnerImpl` instances with the provided configuration.
+pub struct HookRunnerFactoryImpl;
+
+impl HookRunnerFactory for HookRunnerFactoryImpl {
+    fn create(&self, config: HookConfig) -> Result<Box<dyn HookRunnerService>, HookError> {
+        Ok(Box::new(HookRunnerImpl::new(config)))
+    }
+
+    fn create_default(&self) -> Result<Box<dyn HookRunnerService>, HookError> {
+        Ok(Box::new(HookRunnerImpl::new(HookConfig::default())))
+    }
+
+    fn create_with_pre_hooks(
+        &self,
+        pre_tool_use_commands: Vec<String>,
+    ) -> Result<Box<dyn HookRunnerService>, HookError> {
+        let config = HookConfig {
+            pre_tool_use: pre_tool_use_commands,
+            ..Default::default()
+        };
+        Ok(Box::new(HookRunnerImpl::new(config)))
+    }
+
+    fn create_with_timeout(
+        &self,
+        config: HookConfig,
+        timeout_secs: u64,
+    ) -> Result<Box<dyn HookRunnerService>, HookError> {
+        let mut config = config;
+        config.timeout_secs = timeout_secs;
+        Ok(Box::new(HookRunnerImpl::new(config)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_default() {
+        let factory = HookRunnerFactoryImpl;
+        let runner = factory.create_default().unwrap();
+        let status = runner.status();
+        assert_eq!(status.total_hook_count, 0);
+        assert!(!status.is_running);
+    }
+
+    #[test]
+    fn test_create_with_config() {
+        let factory = HookRunnerFactoryImpl;
+        let config = HookConfig {
+            pre_tool_use: vec!["hook-a".into()],
+            ..Default::default()
+        };
+        let runner = factory.create(config).unwrap();
+        let status = runner.status();
+        assert_eq!(status.pre_tool_use_count, 1);
+    }
+
+    #[test]
+    fn test_create_with_pre_hooks() {
+        let factory = HookRunnerFactoryImpl;
+        let runner = factory
+            .create_with_pre_hooks(vec!["pre-hook".into(), "pre-hook2".into()])
+            .unwrap();
+        let status = runner.status();
+        assert_eq!(status.pre_tool_use_count, 2);
+        assert_eq!(status.post_tool_use_count, 0);
+    }
+
+    #[test]
+    fn test_create_with_timeout() {
+        let factory = HookRunnerFactoryImpl;
+        let config = HookConfig {
+            pre_tool_use: vec!["hook".into()],
+            ..Default::default()
+        };
+        let runner = factory.create_with_timeout(config, 60).unwrap();
+        let status = runner.status();
+        assert_eq!(status.timeout_secs, 60);
+    }
+
+    #[test]
+    fn test_runner_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<HookRunnerFactoryImpl>();
+    }
+}

--- a/engine/src/hooks/application/service.rs
+++ b/engine/src/hooks/application/service.rs
@@ -1,0 +1,110 @@
+//! Service interfaces (use cases) for the Hook System.
+//!
+//! @canonical .pi/architecture/modules/hooks.md#hook-service
+//! Implements: Contract Freeze — HookRunnerService trait
+//! Issue: #410
+//!
+//! This trait defines the application-level operations for hook execution:
+//! running hooks for each lifecycle event, getting runner status, and
+//! managing hook configuration at runtime.
+//!
+//! All methods are synchronous (hooks execute as child processes, not
+//! async tasks). The abort signal supports cooperative cancellation.
+//!
+//! # Contract (Frozen)
+//! - Every use case has a corresponding trait method
+//! - Input/output types are DTOs defined in `dto/`
+//! - Methods accept references to `HookAbortSignal` for cancellation
+//! - No implementation — only contract signatures
+
+use crate::hooks::domain::abort::HookAbortSignal;
+use crate::hooks::domain::config::HookConfig;
+use crate::hooks::domain::error::HookError;
+use crate::hooks::domain::result::HookRunResult;
+
+use super::dto::{
+    HookRunnerStatus, RunPostToolUseFailureInput, RunPostToolUseFailureOutput,
+    RunPostToolUseInput, RunPostToolUseOutput, RunPreToolUseInput, RunPreToolUseOutput,
+};
+
+/// Service for executing hook commands across all lifecycle events.
+///
+/// Orchestrates hook execution: spawns hook processes, reads their
+/// JSON responses, aggregates results, and supports cancellation via
+/// `HookAbortSignal`. Hooks are executed in registration order.
+///
+/// # Safety
+/// - Hooks run as child processes with the same privileges as the engine
+/// - Hook output is validated as JSON before processing
+/// - Aborted hooks are killed, not just signalled
+pub trait HookRunnerService: Send + Sync {
+    /// Run all PreToolUse hooks for a tool invocation.
+    ///
+    /// Executes every registered PreToolUse command, passing the tool
+    /// context via stdin JSON. Results are aggregated: first deny wins,
+    /// last permission_override wins, last updated_input wins.
+    ///
+    /// If `abort_signal` is set before or during execution, remaining
+    /// hooks are skipped and the result is marked as cancelled.
+    fn run_pre_tool_use(
+        &self,
+        input: RunPreToolUseInput,
+        abort_signal: Option<&HookAbortSignal>,
+    ) -> Result<RunPreToolUseOutput, HookError>;
+
+    /// Run all PostToolUse hooks after successful tool execution.
+    ///
+    /// Executes every registered PostToolUse command with the tool's
+    /// output context. Hooks can append feedback messages but cannot
+    /// modify input or block execution retroactively.
+    fn run_post_tool_use(
+        &self,
+        input: RunPostToolUseInput,
+        abort_signal: Option<&HookAbortSignal>,
+    ) -> Result<RunPostToolUseOutput, HookError>;
+
+    /// Run all PostToolUseFailure hooks after failed tool execution.
+    ///
+    /// Executes every registered PostToolUseFailure command with the
+    /// tool's error context. Hooks can append diagnostic messages
+    /// and trigger recovery scripts.
+    fn run_post_tool_use_failure(
+        &self,
+        input: RunPostToolUseFailureInput,
+        abort_signal: Option<&HookAbortSignal>,
+    ) -> Result<RunPostToolUseFailureOutput, HookError>;
+
+    /// Get the current hook runner status.
+    fn status(&self) -> HookRunnerStatus;
+
+    /// Update the hook configuration at runtime.
+    ///
+    /// Replaces the current hook command lists with the provided ones.
+    /// This allows dynamic reconfiguration without restarting.
+    fn reconfigure(&self, config: HookConfig) -> Result<(), HookError>;
+
+    /// Create a new `HookAbortSignal` tied to this runner's lifecycle.
+    ///
+    /// When the runner is shut down, all signals created through this
+    /// method are triggered automatically.
+    fn create_abort_signal(&self) -> HookAbortSignal;
+}
+
+/// Convenience trait for running a single hook command.
+///
+/// Lower-level interface for executing one hook command in isolation.
+/// Used internally by `HookRunnerService` implementations.
+pub trait HookCommandExecutor: Send + Sync {
+    /// Execute a single hook command with the given stdin payload.
+    ///
+    /// The command is spawned as a child process with the JSON payload
+    /// piped to stdin. The stdout is read and parsed as `HookStdoutResponse`.
+    ///
+    /// Returns the parsed response, or a `HookError` if execution failed.
+    fn execute_command(
+        &self,
+        command: &str,
+        stdin_payload: &serde_json::Value,
+        abort_signal: Option<&HookAbortSignal>,
+    ) -> Result<HookRunResult, HookError>;
+}

--- a/engine/src/hooks/domain/abort.rs
+++ b/engine/src/hooks/domain/abort.rs
@@ -1,0 +1,191 @@
+//! HookAbortSignal — cooperative cancellation for hook execution.
+//!
+//! @canonical .pi/architecture/modules/hooks.md#hook-abort
+//! Implements: Contract Freeze — HookAbortSignal struct
+//! Issue: #410
+//!
+//! Provides an atomic abort flag that hooks can check for cooperative
+//! cancellation. When the signal is set, hook commands should terminate
+//! as soon as possible. The `HookRunner` checks this signal between
+//! hook executions and before spawning new processes.
+//!
+//! # Contract (Frozen)
+//! - Thread-safe (uses `AtomicBool`)
+//! - Cloneable — clones share the same underlying flag
+//! - Default is unset (execution proceeds normally)
+//! - Once set, it cannot be unset
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+/// A shared, thread-safe abort signal for cooperative hook cancellation.
+///
+/// When the signal is triggered, all running and pending hook commands
+/// should stop as soon as safely possible.
+///
+/// # Example
+///
+/// ```rust
+/// use rigorix_engine::hooks::domain::HookAbortSignal;
+///
+/// let signal = HookAbortSignal::new();
+/// assert!(!signal.is_aborted());
+///
+/// signal.abort();
+/// assert!(signal.is_aborted());
+/// ```
+#[derive(Debug, Clone)]
+pub struct HookAbortSignal {
+    inner: Arc<AtomicBool>,
+}
+
+impl HookAbortSignal {
+    /// Create a new abort signal in the unset (not aborted) state.
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Create a new abort signal that is already in the aborted state.
+    ///
+    /// Useful for tests or when cancellation is requested before
+    /// hook execution begins.
+    pub fn new_aborted() -> Self {
+        Self {
+            inner: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
+    /// Trigger the abort signal.
+    ///
+    /// Once set, all clones of this signal will also return `true`
+    /// from `is_aborted()`. This operation is idempotent.
+    pub fn abort(&self) {
+        self.inner.store(true, Ordering::SeqCst);
+    }
+
+    /// Check whether the abort signal has been triggered.
+    pub fn is_aborted(&self) -> bool {
+        self.inner.load(Ordering::SeqCst)
+    }
+
+    /// Reset the abort signal to unset.
+    ///
+    /// # Safety
+    ///
+    /// This creates a new `AtomicBool` and replaces the inner `Arc`.
+    /// All existing clones of the previous signal will still see the
+    /// old value. Only use this when you are sure no other references
+    /// to the old signal exist.
+    pub fn reset(&mut self) {
+        self.inner = Arc::new(AtomicBool::new(false));
+    }
+}
+
+impl Default for HookAbortSignal {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<bool> for HookAbortSignal {
+    /// Create a signal from a boolean. `true` creates an aborted signal,
+    /// `false` creates an unset signal.
+    fn from(aborted: bool) -> Self {
+        if aborted {
+            Self::new_aborted()
+        } else {
+            Self::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_is_not_aborted() {
+        let signal = HookAbortSignal::new();
+        assert!(!signal.is_aborted());
+    }
+
+    #[test]
+    fn test_new_aborted() {
+        let signal = HookAbortSignal::new_aborted();
+        assert!(signal.is_aborted());
+    }
+
+    #[test]
+    fn test_abort_sets_flag() {
+        let signal = HookAbortSignal::new();
+        signal.abort();
+        assert!(signal.is_aborted());
+    }
+
+    #[test]
+    fn test_abort_is_idempotent() {
+        let signal = HookAbortSignal::new();
+        signal.abort();
+        signal.abort(); // Should not panic
+        assert!(signal.is_aborted());
+    }
+
+    #[test]
+    fn test_clone_shares_flag() {
+        let signal = HookAbortSignal::new();
+        let cloned = signal.clone();
+        signal.abort();
+        assert!(cloned.is_aborted());
+        assert!(signal.is_aborted());
+    }
+
+    #[test]
+    fn test_reset() {
+        let mut signal = HookAbortSignal::new();
+        signal.abort();
+        assert!(signal.is_aborted());
+        signal.reset();
+        assert!(!signal.is_aborted());
+    }
+
+    #[test]
+    fn test_from_bool_true_is_aborted() {
+        let signal: HookAbortSignal = true.into();
+        assert!(signal.is_aborted());
+    }
+
+    #[test]
+    fn test_from_bool_false_is_not_aborted() {
+        let signal: HookAbortSignal = false.into();
+        assert!(!signal.is_aborted());
+    }
+
+    #[test]
+    fn test_default_trait() {
+        let signal = HookAbortSignal::default();
+        assert!(!signal.is_aborted());
+    }
+
+    #[test]
+    fn test_debug_output() {
+        let signal = HookAbortSignal::new();
+        let debug = format!("{:?}", signal);
+        assert!(debug.contains("HookAbortSignal"));
+    }
+
+    #[test]
+    fn test_concurrent_access() {
+        use std::thread;
+        let signal = HookAbortSignal::new();
+        let cloned = signal.clone();
+
+        let handle = thread::spawn(move || {
+            cloned.abort();
+        });
+
+        handle.join().unwrap();
+        assert!(signal.is_aborted());
+    }
+}

--- a/engine/src/hooks/domain/config.rs
+++ b/engine/src/hooks/domain/config.rs
@@ -1,0 +1,217 @@
+//! HookConfig — declarative hook command registration per lifecycle event.
+//!
+//! @canonical .pi/architecture/modules/hooks.md#hook-config
+//! Implements: Contract Freeze — HookConfig struct
+//! Issue: #410
+//!
+//! Defines which shell commands or binaries to execute for each hook
+//! lifecycle event. Commands are loaded from configuration (e.g.,
+//! `.rigorix/hooks.toml`) and registered per event type.
+//!
+//! # Configuration Example (`.rigorix/hooks.toml`)
+//!
+//! ```toml
+//! [hooks]
+//! pre_tool_use = [
+//!     "rigorix-hook-validate-path",
+//!     "rigorix-hook-ci-guard --env $RIGORIX_ENV",
+//! ]
+//! post_tool_use = [
+//!     "rigorix-hook-fmt-check --path $TOOL_PATH",
+//! ]
+//! post_tool_use_failure = [
+//!     "rigorix-hook-notify --channel alerts",
+//! ]
+//! ```
+//!
+//! # Contract (Frozen)
+//! - Each event type has a dedicated list of command strings
+//! - Commands are executed in the order listed
+//! - Empty lists mean no hooks for that event
+//! - Commands must be relative to workspace or absolute paths
+
+use serde::{Deserialize, Serialize};
+
+use super::event::HookEvent;
+
+/// Declarative hook command registration per lifecycle event.
+///
+/// Commands are shell commands or binaries that receive the hook stdin
+/// JSON payload and return a structured stdout JSON response.
+///
+/// # Validation
+/// - Commands are not validated at config load time; validation occurs
+///   at hook execution time
+/// - Unknown or missing commands are skipped with a warning
+///
+/// # Default
+/// - All fields are empty `Vec`s by default (no hooks registered)
+/// - Default timeout is 30 seconds
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HookConfig {
+    /// Commands to run before every tool execution.
+    /// These can modify input, block, or override permissions.
+    #[serde(default)]
+    pub pre_tool_use: Vec<String>,
+
+    /// Commands to run after every successful tool execution.
+    /// These can append feedback, enrich audit context, or trigger scripts.
+    #[serde(default)]
+    pub post_tool_use: Vec<String>,
+
+    /// Commands to run after every failed tool execution.
+    /// These can trigger recovery scripts, enrich error context, or notify.
+    #[serde(default)]
+    pub post_tool_use_failure: Vec<String>,
+
+    /// Timeout in seconds for each hook command execution.
+    /// Default: 30 seconds.
+    #[serde(default = "default_timeout_secs")]
+    pub timeout_secs: u64,
+
+    /// Whether to run PreToolUse hooks sequentially (default) or concurrently.
+    /// Sequential execution allows each hook to see the modified input from
+    /// the previous hook.
+    #[serde(default)]
+    pub sequential_pre_tool_use: bool,
+}
+
+fn default_timeout_secs() -> u64 {
+    30
+}
+
+impl Default for HookConfig {
+    fn default() -> Self {
+        Self {
+            pre_tool_use: vec![],
+            post_tool_use: vec![],
+            post_tool_use_failure: vec![],
+            timeout_secs: 30,
+            sequential_pre_tool_use: false,
+        }
+    }
+}
+
+impl HookConfig {
+    /// Returns the list of commands registered for the given event.
+    pub fn commands_for(&self, event: HookEvent) -> &[String] {
+        match event {
+            HookEvent::PreToolUse => &self.pre_tool_use,
+            HookEvent::PostToolUse => &self.post_tool_use,
+            HookEvent::PostToolUseFailure => &self.post_tool_use_failure,
+        }
+    }
+
+    /// Returns true if there are commands registered for the given event.
+    pub fn has_commands_for(&self, event: HookEvent) -> bool {
+        !self.commands_for(event).is_empty()
+    }
+
+    /// Returns true if no hooks are registered for any event.
+    pub fn is_empty(&self) -> bool {
+        self.pre_tool_use.is_empty()
+            && self.post_tool_use.is_empty()
+            && self.post_tool_use_failure.is_empty()
+    }
+
+    /// Returns the total number of registered hook commands across all events.
+    pub fn total_command_count(&self) -> usize {
+        self.pre_tool_use.len()
+            + self.post_tool_use.len()
+            + self.post_tool_use_failure.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_config() -> HookConfig {
+        HookConfig {
+            pre_tool_use: vec!["validate-path".into(), "ci-guard".into()],
+            post_tool_use: vec!["fmt-check".into()],
+            post_tool_use_failure: vec!["notify".into()],
+            timeout_secs: 30,
+            sequential_pre_tool_use: true,
+        }
+    }
+
+    #[test]
+    fn test_commands_for() {
+        let config = sample_config();
+        assert_eq!(
+            config.commands_for(HookEvent::PreToolUse),
+            &["validate-path", "ci-guard"]
+        );
+        assert_eq!(
+            config.commands_for(HookEvent::PostToolUse),
+            &["fmt-check"]
+        );
+        assert_eq!(
+            config.commands_for(HookEvent::PostToolUseFailure),
+            &["notify"]
+        );
+    }
+
+    #[test]
+    fn test_has_commands_for() {
+        let config = sample_config();
+        assert!(config.has_commands_for(HookEvent::PreToolUse));
+        assert!(config.has_commands_for(HookEvent::PostToolUse));
+        assert!(config.has_commands_for(HookEvent::PostToolUseFailure));
+    }
+
+    #[test]
+    fn test_empty_config() {
+        let config = HookConfig::default();
+        assert!(config.is_empty());
+        assert_eq!(config.total_command_count(), 0);
+        assert!(!config.has_commands_for(HookEvent::PreToolUse));
+        assert!(!config.has_commands_for(HookEvent::PostToolUse));
+        assert!(!config.has_commands_for(HookEvent::PostToolUseFailure));
+    }
+
+    #[test]
+    fn test_total_command_count() {
+        let config = sample_config();
+        assert_eq!(config.total_command_count(), 4);
+    }
+
+    #[test]
+    fn test_default_timeout() {
+        let config = HookConfig::default();
+        assert_eq!(config.timeout_secs, 30);
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let config = sample_config();
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: HookConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(config, deserialized);
+    }
+
+    #[test]
+    fn test_serde_default_timeout() {
+        // When timeout_secs is omitted, it should default to 30
+        let json = r#"{"pre_tool_use":["hook1"]}"#;
+        let config: HookConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.timeout_secs, 30);
+        assert_eq!(config.pre_tool_use, vec!["hook1"]);
+    }
+
+    #[test]
+    fn test_commands_for_returns_empty_slice_for_unregistered() {
+        let config = HookConfig::default();
+        assert!(config.commands_for(HookEvent::PreToolUse).is_empty());
+        assert!(config.commands_for(HookEvent::PostToolUse).is_empty());
+        assert!(config.commands_for(HookEvent::PostToolUseFailure).is_empty());
+    }
+
+    #[test]
+    fn test_clone_and_eq() {
+        let config = sample_config();
+        let cloned = config.clone();
+        assert_eq!(config, cloned);
+    }
+}

--- a/engine/src/hooks/domain/error.rs
+++ b/engine/src/hooks/domain/error.rs
@@ -1,0 +1,231 @@
+//! HookError — typed error enum for hook failures.
+//!
+//! @canonical .pi/architecture/modules/hooks.md#error-handling
+//! Implements: Contract Freeze — HookError enum
+//! Issue: #410
+//!
+//! All hook errors use `thiserror` derive macros. No `anyhow` in library code.
+//!
+//! # Contract (Frozen)
+//! - `HookError` is the single error type for this module
+//! - Each variant carries structured context for error reporting
+//! - Implements `std::error::Error` for library compatibility
+//! - Error recovery strategy documented per variant
+
+use thiserror::Error;
+
+/// Errors that can occur during hook command execution.
+///
+/// # Error Recovery
+///
+/// | Variant | Severity | Recovery |
+/// |---------|----------|----------|
+/// | `CommandNotFound` | Warning | Hook skipped, execution continues |
+/// | `Timeout` | Error | Hook killed; PreToolUse → tool blocked, Post* → tool result returned |
+/// | `InvalidJson` | Error | Treated as hook failure; tool blocked for PreToolUse |
+/// | `ProcessError` | Error | Same as InvalidJson — fail-safe |
+/// | `Aborted` | Info | Hook cancelled; tool blocked for PreToolUse only |
+#[derive(Debug, Error)]
+pub enum HookError {
+    /// The hook command was not found in PATH or at the specified path.
+    ///
+    /// The hook is skipped with a warning. Tool execution continues
+    /// as if the hook was not registered.
+    #[error("Hook command not found: {command}")]
+    CommandNotFound {
+        /// The command string that was not found.
+        command: String,
+    },
+
+    /// Hook execution timed out.
+    ///
+    /// The configured timeout was exceeded. For PreToolUse, the tool
+    /// is blocked (safety-first). For PostToolUse/PostToolUseFailure,
+    /// the tool result is returned without hook feedback.
+    #[error("Hook execution timed out after {timeout_ms}ms: {command}")]
+    Timeout {
+        /// The command that timed out.
+        command: String,
+        /// The timeout duration in milliseconds.
+        timeout_ms: u64,
+    },
+
+    /// Hook returned invalid (non-JSON or schema-mismatched) output.
+    ///
+    /// The hook's stdout could not be parsed as a `HookStdoutResponse`.
+    /// Treated as hook failure — tool may be blocked depending on event.
+    #[error("Hook returned invalid JSON: {detail}")]
+    InvalidJson {
+        /// The hook command that produced invalid output.
+        command: String,
+        /// Detailed parse error.
+        detail: String,
+        /// Raw stdout content (truncated for safety).
+        raw_output: String,
+    },
+
+    /// Hook process failed with a non-zero exit code and no valid JSON.
+    ///
+    /// The hook exited with an error but did not provide a structured
+    /// response. Treated as hook failure — tool may be blocked depending
+    /// on event type.
+    #[error("Hook process error (exit: {exit_code}): {command}")]
+    ProcessError {
+        /// The command that failed.
+        command: String,
+        /// The exit code of the process.
+        exit_code: i32,
+        /// Stderr output from the hook (if any).
+        stderr: String,
+    },
+
+    /// Hook execution was aborted by the cancellation signal.
+    ///
+    /// The `HookAbortSignal` was set during execution. The hook was
+    /// killed. For PreToolUse, the tool is blocked. For Post* events,
+    /// the tool result is returned without hook feedback.
+    #[error("Hook aborted by signal: {command}")]
+    Aborted {
+        /// The command that was aborted.
+        command: String,
+    },
+
+    /// An internal error occurred (e.g., IO error spawning process).
+    #[error("Internal hook error: {detail}")]
+    Internal {
+        /// Error detail for diagnostics.
+        detail: String,
+    },
+}
+
+impl HookError {
+    /// Returns true if this error indicates the hook command was not found.
+    pub fn is_command_not_found(&self) -> bool {
+        matches!(self, HookError::CommandNotFound { .. })
+    }
+
+    /// Returns true if this error is recoverable (tool can still proceed).
+    ///
+    /// CommandNotFound is recoverable — the hook is simply skipped.
+    /// All other errors are non-recoverable for the hook's event type
+    /// and may block the tool.
+    pub fn is_recoverable(&self) -> bool {
+        matches!(self, HookError::CommandNotFound { .. })
+    }
+
+    /// Returns the command string associated with this error, if available.
+    pub fn command(&self) -> Option<&str> {
+        match self {
+            HookError::CommandNotFound { command }
+            | HookError::Timeout { command, .. }
+            | HookError::InvalidJson { command, .. }
+            | HookError::ProcessError { command, .. }
+            | HookError::Aborted { command } => Some(command),
+            HookError::Internal { .. } => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_command_not_found() {
+        let err = HookError::CommandNotFound {
+            command: "nonexistent-hook".into(),
+        };
+        assert!(err.is_command_not_found());
+        assert!(err.is_recoverable());
+        assert_eq!(err.command(), Some("nonexistent-hook"));
+        assert_eq!(err.to_string(), "Hook command not found: nonexistent-hook");
+    }
+
+    #[test]
+    fn test_timeout() {
+        let err = HookError::Timeout {
+            command: "slow-hook".into(),
+            timeout_ms: 30000,
+        };
+        assert!(!err.is_recoverable());
+        assert_eq!(err.command(), Some("slow-hook"));
+        assert_eq!(
+            err.to_string(),
+            "Hook execution timed out after 30000ms: slow-hook"
+        );
+    }
+
+    #[test]
+    fn test_invalid_json() {
+        let err = HookError::InvalidJson {
+            command: "bad-hook".into(),
+            detail: "missing field `decision`".into(),
+            raw_output: "{{{".into(),
+        };
+        assert!(!err.is_command_not_found());
+        assert!(err.to_string().contains("invalid JSON"), "Expected 'invalid JSON', got: {}", err.to_string());
+        assert!(err.to_string().contains("missing field"), "Expected 'missing field', got: {}", err.to_string());
+        assert_eq!(err.command(), Some("bad-hook"));
+    }
+
+    #[test]
+    fn test_process_error() {
+        let err = HookError::ProcessError {
+            command: "failing-hook".into(),
+            exit_code: 1,
+            stderr: "Something went wrong".into(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "Hook process error (exit: 1): failing-hook"
+        );
+    }
+
+    #[test]
+    fn test_aborted() {
+        let err = HookError::Aborted {
+            command: "cancel-me".into(),
+        };
+        assert_eq!(err.to_string(), "Hook aborted by signal: cancel-me");
+    }
+
+    #[test]
+    fn test_internal() {
+        let err = HookError::Internal {
+            detail: "IO error: broken pipe".into(),
+        };
+        assert!(err.command().is_none());
+        assert!(!err.is_command_not_found());
+        assert!(!err.is_recoverable());
+    }
+
+    #[test]
+    fn test_debug_format() {
+        let err = HookError::CommandNotFound {
+            command: "test".into(),
+        };
+        let debug = format!("{:?}", err);
+        assert!(debug.contains("CommandNotFound"));
+        assert!(debug.contains("test"));
+    }
+
+    #[test]
+    fn test_error_trait_impl() {
+        fn assert_error(_: &dyn std::error::Error) {}
+        let err = HookError::CommandNotFound {
+            command: "x".into(),
+        };
+        assert_error(&err); // Must implement std::error::Error
+    }
+
+    #[test]
+    fn test_clone_not_available() {
+        // HookError does NOT implement Clone (uses String fields)
+        // Verify it at least implements Debug and Error
+        let err = HookError::Internal {
+            detail: "test".into(),
+        };
+        let _ = format!("{:?}", err);
+        let _: &dyn std::error::Error = &err;
+    }
+}

--- a/engine/src/hooks/domain/event.rs
+++ b/engine/src/hooks/domain/event.rs
@@ -1,0 +1,170 @@
+//! HookEvent domain enum — identifies which lifecycle point a hook runs at.
+//!
+//! @canonical .pi/architecture/modules/hooks.md#hook-event
+//! Implements: Contract Freeze — HookEvent enum
+//! Issue: #410
+//!
+//! Defines the three lifecycle interception points around tool execution:
+//! - PreToolUse: runs before tool execution, can modify input, block, or override permissions
+//! - PostToolUse: runs after successful tool execution, can append feedback
+//! - PostToolUseFailure: runs after tool execution failure, can trigger recovery
+//!
+//! # Contract (Frozen)
+//! - Exactly 3 variants, no more, no less
+//! - Serialized as snake_case via serde
+//! - Copy semantics for easy passing
+//! - No implementation logic — pure identification
+
+use serde::{Deserialize, Serialize};
+
+/// Identifies which lifecycle point a hook runs at.
+///
+/// # Variants
+///
+/// | Variant | Timing | Purpose |
+/// |---------|--------|---------|
+/// | `PreToolUse` | Before tool execution | Modify input, block, or override permissions |
+/// | `PostToolUse` | After successful execution | Append feedback, enrichment |
+/// | `PostToolUseFailure` | After failed execution | Trigger recovery, diagnostics |
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HookEvent {
+    /// Runs before tool execution.
+    ///
+    /// Can modify input, block execution entirely, override permission levels,
+    /// or provide feedback messages to the LLM.
+    #[default]
+    PreToolUse,
+
+    /// Runs after successful tool execution.
+    ///
+    /// Can append feedback messages to the tool output, enrich audit context,
+    /// or trigger post-flight scripts (e.g., `cargo test` after `write_file`).
+    PostToolUse,
+
+    /// Runs after tool execution failure.
+    ///
+    /// Can trigger recovery scripts, enrich error context with diagnostics,
+    /// or notify external monitoring systems.
+    PostToolUseFailure,
+}
+
+impl HookEvent {
+    /// Returns the canonical snake_case name of this event variant.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            HookEvent::PreToolUse => "pre_tool_use",
+            HookEvent::PostToolUse => "post_tool_use",
+            HookEvent::PostToolUseFailure => "post_tool_use_failure",
+        }
+    }
+
+    /// Returns true if this event runs before tool execution.
+    pub fn is_pre_tool_use(&self) -> bool {
+        matches!(self, HookEvent::PreToolUse)
+    }
+
+    /// Returns true if this event runs after successful tool execution.
+    pub fn is_post_tool_use(&self) -> bool {
+        matches!(self, HookEvent::PostToolUse)
+    }
+
+    /// Returns true if this event runs after failed tool execution.
+    pub fn is_post_tool_use_failure(&self) -> bool {
+        matches!(self, HookEvent::PostToolUseFailure)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_as_str() {
+        assert_eq!(HookEvent::PreToolUse.as_str(), "pre_tool_use");
+        assert_eq!(HookEvent::PostToolUse.as_str(), "post_tool_use");
+        assert_eq!(
+            HookEvent::PostToolUseFailure.as_str(),
+            "post_tool_use_failure"
+        );
+    }
+
+    #[test]
+    fn test_is_methods() {
+        assert!(HookEvent::PreToolUse.is_pre_tool_use());
+        assert!(!HookEvent::PreToolUse.is_post_tool_use());
+        assert!(!HookEvent::PreToolUse.is_post_tool_use_failure());
+
+        assert!(!HookEvent::PostToolUse.is_pre_tool_use());
+        assert!(HookEvent::PostToolUse.is_post_tool_use());
+        assert!(!HookEvent::PostToolUse.is_post_tool_use_failure());
+
+        assert!(!HookEvent::PostToolUseFailure.is_pre_tool_use());
+        assert!(!HookEvent::PostToolUseFailure.is_post_tool_use());
+        assert!(HookEvent::PostToolUseFailure.is_post_tool_use_failure());
+    }
+
+    #[test]
+    fn test_copy_semantics() {
+        let event = HookEvent::PreToolUse;
+        let copied = event; // Copy, not move
+        assert_eq!(event, copied);
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        for event in &[
+            HookEvent::PreToolUse,
+            HookEvent::PostToolUse,
+            HookEvent::PostToolUseFailure,
+        ] {
+            let json = serde_json::to_string(event).unwrap();
+            let deserialized: HookEvent = serde_json::from_str(&json).unwrap();
+            assert_eq!(*event, deserialized);
+        }
+    }
+
+    #[test]
+    fn test_default_is_pre_tool_use() {
+        assert_eq!(HookEvent::default(), HookEvent::PreToolUse);
+    }
+
+    #[test]
+    fn test_serde_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&HookEvent::PreToolUse).unwrap(),
+            "\"pre_tool_use\""
+        );
+        assert_eq!(
+            serde_json::to_string(&HookEvent::PostToolUse).unwrap(),
+            "\"post_tool_use\""
+        );
+        assert_eq!(
+            serde_json::to_string(&HookEvent::PostToolUseFailure).unwrap(),
+            "\"post_tool_use_failure\""
+        );
+    }
+
+    #[test]
+    fn test_serde_deserialize_snake_case() {
+        assert_eq!(
+            serde_json::from_str::<HookEvent>("\"pre_tool_use\"").unwrap(),
+            HookEvent::PreToolUse
+        );
+        assert_eq!(
+            serde_json::from_str::<HookEvent>("\"post_tool_use\"").unwrap(),
+            HookEvent::PostToolUse
+        );
+        assert_eq!(
+            serde_json::from_str::<HookEvent>("\"post_tool_use_failure\"").unwrap(),
+            HookEvent::PostToolUseFailure
+        );
+    }
+
+    #[test]
+    fn test_equality() {
+        assert_eq!(HookEvent::PreToolUse, HookEvent::PreToolUse);
+        assert_ne!(HookEvent::PreToolUse, HookEvent::PostToolUse);
+        assert_ne!(HookEvent::PreToolUse, HookEvent::PostToolUseFailure);
+    }
+}

--- a/engine/src/hooks/domain/event_payload.rs
+++ b/engine/src/hooks/domain/event_payload.rs
@@ -1,0 +1,244 @@
+//! Hook lifecycle event payloads for observability.
+//!
+//! @canonical .pi/architecture/modules/hooks.md#hook-events
+//! Implements: Contract Freeze — HookEventPayload type
+//! Issue: #410
+//!
+//! Defines event payloads that the hook system emits through the event bus
+//! for observability, monitoring, and debugging. These are distinct from
+//! `HookEvent` (which identifies lifecycle points) — these are the actual
+//! data structures published when hook lifecycle events occur.
+//!
+//! # Contract (Frozen)
+//! - Each hook lifecycle event has a dedicated payload struct
+//! - All payloads are serializable as JSON for event bus integration
+//! - Payloads carry context for debugging and audit trails
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::event::HookEvent;
+use super::protocol::HookDecision;
+
+/// Payload emitted when a hook command execution begins.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookExecutionStartedPayload {
+    /// Unique identifier for this hook execution.
+    pub hook_execution_id: uuid::Uuid,
+
+    /// The session/execution ID this hook is part of.
+    pub session_id: String,
+
+    /// The lifecycle event this hook is responding to.
+    pub event: HookEvent,
+
+    /// The hook command being executed.
+    pub command: String,
+
+    /// Name of the tool being intercepted.
+    pub tool_name: String,
+
+    /// ISO 8601 timestamp of when execution started.
+    pub timestamp: DateTime<Utc>,
+}
+
+/// Payload emitted when a hook command execution completes successfully.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookExecutionCompletedPayload {
+    /// Unique identifier for this hook execution.
+    pub hook_execution_id: uuid::Uuid,
+
+    /// The lifecycle event this hook responded to.
+    pub event: HookEvent,
+
+    /// The hook command that completed.
+    pub command: String,
+
+    /// The decision returned by the hook.
+    pub decision: HookDecision,
+
+    /// Duration of hook execution in milliseconds.
+    pub duration_ms: u64,
+
+    /// Number of feedback messages produced.
+    pub message_count: usize,
+
+    /// ISO 8601 timestamp of completion.
+    pub timestamp: DateTime<Utc>,
+}
+
+/// Payload emitted when a hook command execution fails.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookExecutionFailedPayload {
+    /// Unique identifier for this hook execution.
+    pub hook_execution_id: uuid::Uuid,
+
+    /// The lifecycle event this hook was responding to.
+    pub event: HookEvent,
+
+    /// The hook command that failed.
+    pub command: String,
+
+    /// Error message describing the failure.
+    pub error: String,
+
+    /// Duration of hook execution before failure in milliseconds.
+    pub duration_ms: u64,
+
+    /// ISO 8601 timestamp of the failure.
+    pub timestamp: DateTime<Utc>,
+}
+
+/// Payload emitted when hook execution is aborted via `HookAbortSignal`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookExecutionAbortedPayload {
+    /// Unique identifier for this hook execution.
+    pub hook_execution_id: uuid::Uuid,
+
+    /// The lifecycle event this hook was responding to.
+    pub event: HookEvent,
+
+    /// The hook command that was aborted.
+    pub command: String,
+
+    /// ISO 8601 timestamp of the abort.
+    pub timestamp: DateTime<Utc>,
+}
+
+/// A unified hook lifecycle event payload for event bus emission.
+///
+/// Wraps all hook execution lifecycle payloads into a single enum
+/// for convenient event bus integration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum HookEventPayload {
+    /// A hook command execution has started.
+    ExecutionStarted(HookExecutionStartedPayload),
+
+    /// A hook command execution completed successfully.
+    ExecutionCompleted(HookExecutionCompletedPayload),
+
+    /// A hook command execution failed.
+    ExecutionFailed(HookExecutionFailedPayload),
+
+    /// A hook command execution was aborted.
+    ExecutionAborted(HookExecutionAbortedPayload),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_started() -> HookExecutionStartedPayload {
+        HookExecutionStartedPayload {
+            hook_execution_id: uuid::Uuid::new_v4(),
+            session_id: "session-1".into(),
+            event: HookEvent::PreToolUse,
+            command: "validate-path".into(),
+            tool_name: "run_command".into(),
+            timestamp: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_execution_started_payload() {
+        let p = sample_started();
+        assert_eq!(p.event, HookEvent::PreToolUse);
+        assert_eq!(p.command, "validate-path");
+        assert_eq!(p.tool_name, "run_command");
+    }
+
+    #[test]
+    fn test_execution_completed_payload() {
+        let p = HookExecutionCompletedPayload {
+            hook_execution_id: uuid::Uuid::new_v4(),
+            event: HookEvent::PostToolUse,
+            command: "fmt-check".into(),
+            decision: HookDecision::Allow,
+            duration_ms: 150,
+            message_count: 2,
+            timestamp: Utc::now(),
+        };
+        assert_eq!(p.decision, HookDecision::Allow);
+        assert_eq!(p.duration_ms, 150);
+    }
+
+    #[test]
+    fn test_execution_failed_payload() {
+        let p = HookExecutionFailedPayload {
+            hook_execution_id: uuid::Uuid::new_v4(),
+            event: HookEvent::PostToolUseFailure,
+            command: "notify".into(),
+            error: "exit code 1".into(),
+            duration_ms: 500,
+            timestamp: Utc::now(),
+        };
+        assert_eq!(p.error, "exit code 1");
+    }
+
+    #[test]
+    fn test_execution_aborted_payload() {
+        let p = HookExecutionAbortedPayload {
+            hook_execution_id: uuid::Uuid::new_v4(),
+            event: HookEvent::PreToolUse,
+            command: "slow-hook".into(),
+            timestamp: Utc::now(),
+        };
+        assert_eq!(p.command, "slow-hook");
+    }
+
+    #[test]
+    fn test_hook_event_payload_enum() {
+        let payload = HookEventPayload::ExecutionStarted(sample_started());
+        match &payload {
+            HookEventPayload::ExecutionStarted(p) => {
+                assert_eq!(p.command, "validate-path");
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn test_serde_roundtrip_started() {
+        let p = sample_started();
+        let json = serde_json::to_string(&p).unwrap();
+        let deserialized: HookExecutionStartedPayload = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.command, p.command);
+        assert_eq!(deserialized.hook_execution_id, p.hook_execution_id);
+    }
+
+    #[test]
+    fn test_serde_roundtrip_event_payload() {
+        let payload =
+            HookEventPayload::ExecutionAborted(HookExecutionAbortedPayload {
+                hook_execution_id: uuid::Uuid::new_v4(),
+                event: HookEvent::PreToolUse,
+                command: "timed-out".into(),
+                timestamp: Utc::now(),
+            });
+        let json = serde_json::to_string(&payload).unwrap();
+        let deserialized: HookEventPayload = serde_json::from_str(&json).unwrap();
+        match deserialized {
+            HookEventPayload::ExecutionAborted(p) => {
+                assert_eq!(p.command, "timed-out");
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn test_serde_tagged_union() {
+        let payload =
+            HookEventPayload::ExecutionCompleted(HookExecutionCompletedPayload {
+                hook_execution_id: uuid::Uuid::new_v4(),
+                event: HookEvent::PostToolUse,
+                command: "hook-a".into(),
+                decision: HookDecision::AllowWithOverride,
+                duration_ms: 200,
+                message_count: 1,
+                timestamp: Utc::now(),
+            });
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json.get("type").and_then(|v| v.as_str()), Some("execution_completed"));
+    }
+}

--- a/engine/src/hooks/domain/mod.rs
+++ b/engine/src/hooks/domain/mod.rs
@@ -1,0 +1,39 @@
+//! Domain entities and interfaces for the Hook System bounded context.
+//!
+//! @canonical .pi/architecture/modules/hooks.md#domain
+//! Implements: Contract Freeze — HookEvent, HookRunResult, HookConfig, HookError
+//! Issue: #410
+//!
+//! This module defines the core domain types:
+//! - `HookEvent` — Enum identifying the lifecycle point (PreToolUse, PostToolUse,
+//!   PostToolUseFailure)
+//! - `HookProtocol` — JSON stdin/stdout contract between engine and hook scripts
+//! - `HookRunResult` — Aggregated result from running all hook commands for an event
+//! - `HookConfig` — Declarative hook command registration per event
+//! - `HookError` — Typed error enum for hook failures
+//! - `HookAbortSignal` — Atomic abort flag for cooperative cancellation
+//! - `HookEventPayload` — Event payload schemas for hook lifecycle events
+//!
+//! These are pure domain objects with no framework dependencies.
+//! They serve as the frozen contract that all implementation must satisfy.
+//!
+//! # Contract (Frozen)
+//! - No implementation logic beyond constructors and field accessors
+//! - All validation must happen in the application layer (service traits)
+//! - All persistence must happen behind repository interfaces
+
+pub mod abort;
+pub mod config;
+pub mod error;
+pub mod event;
+pub mod event_payload;
+pub mod protocol;
+pub mod result;
+
+pub use abort::HookAbortSignal;
+pub use config::HookConfig;
+pub use error::HookError;
+pub use event::HookEvent;
+pub use event_payload::HookEventPayload;
+pub use protocol::*;
+pub use result::HookRunResult;

--- a/engine/src/hooks/domain/protocol.rs
+++ b/engine/src/hooks/domain/protocol.rs
@@ -1,0 +1,443 @@
+//! Hook Protocol — JSON contract between the engine and hook scripts.
+//!
+//! @canonical .pi/architecture/modules/hooks.md#hook-protocol
+//! Implements: Contract Freeze — Hook stdin/stdout JSON protocol
+//! Issue: #410
+//!
+//! Defines the wire format for communication between the Rigorix engine
+//! and hook scripts. Hook scripts receive a JSON payload on stdin and
+//! must return a structured JSON decision on stdout.
+//!
+//! # Protocol
+//!
+//! ```text
+//! Engine → Hook (stdin):  HookStdinPayload (JSON)
+//! Hook → Engine (stdout): HookStdoutResponse (JSON)
+//! ```
+//!
+//! # Contract (Frozen)
+//! - All payloads are serializable as JSON
+//! - Stdin payload includes event type, tool identity, and context
+//! - Stdout response includes decision, optional modifications, feedback
+//! - Non-zero exit with invalid JSON is treated as `HookDecision::Deny`
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use super::event::HookEvent;
+
+// ---------------------------------------------------------------------------
+// Stdin Payload (Engine → Hook)
+// ---------------------------------------------------------------------------
+
+/// JSON payload sent to a hook script on stdin.
+///
+/// Provides the hook with full context about the tool invocation so it
+/// can make informed decisions.
+///
+/// # Example (PreToolUse)
+///
+/// ```json
+/// {
+///     "event": "pre_tool_use",
+///     "tool_name": "run_command",
+///     "tool_input": {"params": {"command": "cargo build --release"}},
+///     "session_id": "exec_abc123",
+///     "workspace_root": "/home/user/project",
+///     "environment_vars": {"RIGORIX_ENV": "production"}
+/// }
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookStdinPayload {
+    /// The lifecycle event this hook is responding to.
+    pub event: HookEvent,
+
+    /// Name of the tool being invoked (e.g., "run_command", "write_file").
+    pub tool_name: String,
+
+    /// The original or current tool input parameters as a JSON value.
+    /// This is the full ToolInput struct (params map + execution_id).
+    pub tool_input: serde_json::Value,
+
+    /// Globally unique session/execution identifier for correlation.
+    pub session_id: String,
+
+    /// Absolute path to the workspace root directory.
+    pub workspace_root: String,
+
+    /// Key-value pairs of environment variables relevant to hook execution.
+    /// Includes `RIGORIX_TOOL_NAME`, `RIGORIX_EVENT`, `RIGORIX_SESSION_ID`,
+    /// `RIGORIX_WORKSPACE`, and any user-defined variables.
+    #[serde(default)]
+    pub environment_vars: HashMap<String, String>,
+}
+
+// ---------------------------------------------------------------------------
+// Stdout Response (Hook → Engine)
+// ---------------------------------------------------------------------------
+
+/// JSON response that a hook script must write to stdout.
+///
+/// The engine reads this response and applies the decision. If the hook
+/// exits with a non-zero status code and invalid JSON, it is treated as
+/// `HookDecision::Deny` (fail-safe).
+///
+/// # Example
+///
+/// ```json
+/// {
+///     "decision": "allow",
+///     "reason": "Command is known and safe",
+///     "permission_override": null,
+///     "updated_input": null,
+///     "messages": ["Running in CI environment - sandbox enabled"]
+/// }
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookStdoutResponse {
+    /// The hook's decision.
+    pub decision: HookDecision,
+
+    /// Human-readable explanation for the decision.
+    /// Fed back to the LLM when the tool is blocked.
+    #[serde(default)]
+    pub reason: Option<String>,
+
+    /// If `decision` is `AllowWithOverride`, the new risk level to apply.
+    /// Ignored for other decisions.
+    #[serde(default)]
+    pub permission_override: Option<HookPermissionOverride>,
+
+    /// If `decision` is `Modify`, the updated tool input to use.
+    /// This replaces the original tool input for this execution.
+    #[serde(default)]
+    pub updated_input: Option<serde_json::Value>,
+
+    /// Feedback messages to merge into the tool result.
+    /// These are surfaced to the LLM for awareness.
+    #[serde(default)]
+    pub messages: Vec<String>,
+}
+
+/// Decision returned by a hook script.
+///
+/// Determines how the engine proceeds with the tool invocation.
+///
+/// | Decision | Effect |
+/// |----------|--------|
+/// | `Allow` | Tool proceeds normally |
+/// | `Deny` | Tool blocked, reason fed to LLM |
+/// | `AllowWithOverride` | Tool proceeds with permission override |
+/// | `Modify` | Tool proceeds with updated input |
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HookDecision {
+    /// Tool proceeds normally without any changes.
+    Allow,
+
+    /// Tool is blocked; the reason is fed back to the LLM.
+    Deny,
+
+    /// Tool proceeds with a permission override (risk level change).
+    AllowWithOverride,
+
+    /// Tool proceeds with modified input replacing the original.
+    Modify,
+}
+
+/// Permission override that a hook can apply.
+///
+/// Allows hooks to dynamically elevate or restrict the risk level
+/// of a tool invocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HookPermissionOverride {
+    /// Elevate to require user confirmation.
+    RequireConfirmation,
+
+    /// Elevate to require dry-run first.
+    RequireDryRun,
+
+    /// Restrict to auto-execute (bypass gates).
+    BypassGates,
+}
+
+// ---------------------------------------------------------------------------
+// Helper methods
+// ---------------------------------------------------------------------------
+
+impl HookStdoutResponse {
+    /// Create an `Allow` response with optional messages.
+    pub fn allow(messages: Vec<String>) -> Self {
+        Self {
+            decision: HookDecision::Allow,
+            reason: None,
+            permission_override: None,
+            updated_input: None,
+            messages,
+        }
+    }
+
+    /// Create a `Deny` response with a reason.
+    pub fn deny(reason: impl Into<String>) -> Self {
+        Self {
+            decision: HookDecision::Deny,
+            reason: Some(reason.into()),
+            permission_override: None,
+            updated_input: None,
+            messages: vec![],
+        }
+    }
+
+    /// Create an `AllowWithOverride` response.
+    pub fn allow_with_override(
+        override_kind: HookPermissionOverride,
+        reason: impl Into<String>,
+        messages: Vec<String>,
+    ) -> Self {
+        Self {
+            decision: HookDecision::AllowWithOverride,
+            reason: Some(reason.into()),
+            permission_override: Some(override_kind),
+            updated_input: None,
+            messages,
+        }
+    }
+
+    /// Create a `Modify` response with updated input.
+    pub fn modify(
+        updated_input: serde_json::Value,
+        reason: impl Into<String>,
+        messages: Vec<String>,
+    ) -> Self {
+        Self {
+            decision: HookDecision::Modify,
+            reason: Some(reason.into()),
+            permission_override: None,
+            updated_input: Some(updated_input),
+            messages,
+        }
+    }
+
+    /// Returns true if the hook allows the tool to proceed.
+    pub fn is_allowed(&self) -> bool {
+        matches!(
+            self.decision,
+            HookDecision::Allow | HookDecision::AllowWithOverride | HookDecision::Modify
+        )
+    }
+
+    /// Returns true if the hook denies the tool execution.
+    pub fn is_denied(&self) -> bool {
+        self.decision == HookDecision::Deny
+    }
+}
+
+impl HookStdinPayload {
+    /// Create a new stdin payload for hook execution.
+    pub fn new(
+        event: HookEvent,
+        tool_name: impl Into<String>,
+        tool_input: serde_json::Value,
+        session_id: impl Into<String>,
+        workspace_root: impl Into<String>,
+    ) -> Self {
+        Self {
+            event,
+            tool_name: tool_name.into(),
+            tool_input,
+            session_id: session_id.into(),
+            workspace_root: workspace_root.into(),
+            environment_vars: HashMap::new(),
+        }
+    }
+
+    /// Add an environment variable to the payload.
+    pub fn with_env_var(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.environment_vars.insert(key.into(), value.into());
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // HookStdoutResponse helper methods
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_allow_response() {
+        let resp = HookStdoutResponse::allow(vec!["All good".into()]);
+        assert_eq!(resp.decision, HookDecision::Allow);
+        assert!(resp.is_allowed());
+        assert!(!resp.is_denied());
+        assert_eq!(resp.messages, vec!["All good"]);
+    }
+
+    #[test]
+    fn test_deny_response() {
+        let resp = HookStdoutResponse::deny("Blocked by policy");
+        assert_eq!(resp.decision, HookDecision::Deny);
+        assert!(!resp.is_allowed());
+        assert!(resp.is_denied());
+        assert_eq!(resp.reason.unwrap(), "Blocked by policy");
+    }
+
+    #[test]
+    fn test_allow_with_override_response() {
+        let resp = HookStdoutResponse::allow_with_override(
+            HookPermissionOverride::RequireConfirmation,
+            "Elevated risk",
+            vec!["Proceed with caution".into()],
+        );
+        assert_eq!(resp.decision, HookDecision::AllowWithOverride);
+        assert!(resp.is_allowed());
+        assert_eq!(
+            resp.permission_override,
+            Some(HookPermissionOverride::RequireConfirmation)
+        );
+    }
+
+    #[test]
+    fn test_modify_response() {
+        let updated = serde_json::json!({"params": {"command": "cargo check"}});
+        let resp = HookStdoutResponse::modify(
+            updated.clone(),
+            "Switched to check mode",
+            vec!["Build → check".into()],
+        );
+        assert_eq!(resp.decision, HookDecision::Modify);
+        assert!(resp.is_allowed());
+        assert_eq!(resp.updated_input, Some(updated));
+    }
+
+    // -----------------------------------------------------------------------
+    // HookStdinPayload builder
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_stdin_payload_construction() {
+        let input = serde_json::json!({"params": {"path": "/tmp/test"}});
+        let payload = HookStdinPayload::new(
+            HookEvent::PreToolUse,
+            "read_file",
+            input.clone(),
+            "session-1",
+            "/workspace",
+        );
+        assert_eq!(payload.event, HookEvent::PreToolUse);
+        assert_eq!(payload.tool_name, "read_file");
+        assert_eq!(payload.tool_input, input);
+        assert_eq!(payload.session_id, "session-1");
+        assert_eq!(payload.workspace_root, "/workspace");
+        assert!(payload.environment_vars.is_empty());
+    }
+
+    #[test]
+    fn test_stdin_payload_with_env_vars() {
+        let payload = HookStdinPayload::new(
+            HookEvent::PostToolUse,
+            "write_file",
+            serde_json::Value::Null,
+            "session-2",
+            "/project",
+        )
+        .with_env_var("RIGORIX_ENV", "production");
+        assert_eq!(
+            payload.environment_vars.get("RIGORIX_ENV"),
+            Some(&"production".to_string())
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Serde round-trips
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_hook_decision_serde_roundtrip() {
+        for decision in &[
+            HookDecision::Allow,
+            HookDecision::Deny,
+            HookDecision::AllowWithOverride,
+            HookDecision::Modify,
+        ] {
+            let json = serde_json::to_string(decision).unwrap();
+            let deserialized: HookDecision = serde_json::from_str(&json).unwrap();
+            assert_eq!(*decision, deserialized);
+        }
+    }
+
+    #[test]
+    fn test_hook_decision_serde_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&HookDecision::Allow).unwrap(),
+            "\"allow\""
+        );
+        assert_eq!(
+            serde_json::to_string(&HookDecision::AllowWithOverride).unwrap(),
+            "\"allow_with_override\""
+        );
+    }
+
+    #[test]
+    fn test_hook_stdout_response_serde_roundtrip() {
+        let resp = HookStdoutResponse::allow(vec!["OK".into()]);
+        let json = serde_json::to_string(&resp).unwrap();
+        let deserialized: HookStdoutResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.decision, HookDecision::Allow);
+    }
+
+    #[test]
+    fn test_hook_stdin_payload_serde_roundtrip() {
+        let payload = HookStdinPayload::new(
+            HookEvent::PreToolUse,
+            "run_command",
+            serde_json::json!({"params": {"command": "ls"}}),
+            "sess-1",
+            "/root",
+        )
+        .with_env_var("PATH", "/usr/bin");
+        let json = serde_json::to_string(&payload).unwrap();
+        let deserialized: HookStdinPayload = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.event, HookEvent::PreToolUse);
+        assert_eq!(deserialized.tool_name, "run_command");
+        assert_eq!(deserialized.environment_vars.get("PATH").unwrap(), "/usr/bin");
+    }
+
+    // -----------------------------------------------------------------------
+    // HookPermissionOverride serde
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_permission_override_serde() {
+        for override_kind in &[
+            HookPermissionOverride::RequireConfirmation,
+            HookPermissionOverride::RequireDryRun,
+            HookPermissionOverride::BypassGates,
+        ] {
+            let json = serde_json::to_string(override_kind).unwrap();
+            let deserialized: HookPermissionOverride = serde_json::from_str(&json).unwrap();
+            assert_eq!(*override_kind, deserialized);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Edge cases
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_empty_messages_allow() {
+        let resp = HookStdoutResponse::allow(vec![]);
+        assert!(resp.messages.is_empty());
+        assert!(resp.is_allowed());
+    }
+
+    #[test]
+    fn test_deny_with_empty_reason() {
+        let resp = HookStdoutResponse::deny("");
+        assert_eq!(resp.reason.as_ref().unwrap(), "");
+        assert!(resp.is_denied());
+    }
+}

--- a/engine/src/hooks/domain/result.rs
+++ b/engine/src/hooks/domain/result.rs
@@ -1,0 +1,340 @@
+//! HookRunResult — aggregated result from running all hook commands for an event.
+//!
+//! @canonical .pi/architecture/modules/hooks.md#hook-result
+//! Implements: Contract Freeze — HookRunResult struct
+//! Issue: #410
+//!
+//! Represents the aggregated outcome of executing all registered hook
+//! commands for a given lifecycle event. Multiple hooks are executed and
+//! their results are merged into a single `HookRunResult`.
+//!
+//! # Aggregation Rules
+//! - First `deny` wins: if any hook denies, the tool is blocked
+//! - Messages from all hooks are concatenated
+//! - Last `permission_override` wins (if multiple hooks provide one)
+//! - Last `updated_input` wins (if multiple hooks modify input)
+//! - Cancellation overrides allow
+//!
+//! # Contract (Frozen)
+//! - All fields are public for direct access
+//! - Helper methods provide ergonomic access to aggregated state
+//! - Serialization support for API responses
+
+use serde::{Deserialize, Serialize};
+
+use super::event::HookEvent;
+
+/// Aggregated result from executing all hook commands for a given event.
+///
+/// # Example
+///
+/// ```rust
+/// use rigorix_engine::hooks::domain::HookRunResult;
+///
+/// let result = HookRunResult::blocked(
+///     "PreToolUse hook denied execution".to_string(),
+///     vec!["Command 'rm -rf /' not allowed".to_string()],
+/// );
+/// assert!(result.is_denied());
+/// assert!(!result.is_allowed());
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HookRunResult {
+    /// Which lifecycle event this result is for.
+    pub event: HookEvent,
+
+    /// True if any hook command returned `Deny`.
+    pub denied: bool,
+
+    /// True if any hook command failed (non-zero exit + no valid JSON).
+    pub failed: bool,
+
+    /// True if the abort signal was set during execution.
+    pub cancelled: bool,
+
+    /// Aggregated messages from all hooks, in execution order.
+    #[serde(default)]
+    pub messages: Vec<String>,
+
+    /// Permission override from the last hook that provided one.
+    #[serde(default)]
+    pub permission_override: Option<super::protocol::HookPermissionOverride>,
+
+    /// Reason for the permission override.
+    #[serde(default)]
+    pub permission_reason: Option<String>,
+
+    /// Updated tool input from the last hook that modified it.
+    #[serde(default)]
+    pub updated_input: Option<serde_json::Value>,
+}
+
+impl HookRunResult {
+    /// Create a new aggregated result.
+    pub fn new(event: HookEvent) -> Self {
+        Self {
+            event,
+            denied: false,
+            failed: false,
+            cancelled: false,
+            messages: vec![],
+            permission_override: None,
+            permission_reason: None,
+            updated_input: None,
+        }
+    }
+
+    /// Create a result representing a blocked (denied or failed) outcome.
+    pub fn blocked(reason: String, messages: Vec<String>) -> Self {
+        Self {
+            event: HookEvent::PreToolUse,
+            denied: true,
+            failed: false,
+            cancelled: false,
+            messages,
+            permission_override: None,
+            permission_reason: Some(reason),
+            updated_input: None,
+        }
+    }
+
+    /// Create a result representing a cancelled outcome.
+    pub fn cancelled(event: HookEvent, messages: Vec<String>) -> Self {
+        Self {
+            event,
+            denied: false,
+            failed: false,
+            cancelled: true,
+            messages,
+            permission_override: None,
+            permission_reason: None,
+            updated_input: None,
+        }
+    }
+
+    /// Returns true if the tool execution should be blocked.
+    pub fn is_denied(&self) -> bool {
+        self.denied
+    }
+
+    /// Returns true if any hook execution failed.
+    pub fn is_failed(&self) -> bool {
+        self.failed
+    }
+
+    /// Returns true if the execution was cancelled.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled
+    }
+
+    /// Returns true if the tool can proceed (not denied, failed, or cancelled).
+    pub fn is_allowed(&self) -> bool {
+        !self.denied && !self.failed && !self.cancelled
+    }
+
+    /// Returns the modified input if any hook provided one.
+    pub fn modified_input(&self) -> Option<&serde_json::Value> {
+        self.updated_input.as_ref()
+    }
+
+    /// Returns the permission override if any hook provided one.
+    pub fn override_permission(&self) -> Option<super::protocol::HookPermissionOverride> {
+        self.permission_override
+    }
+
+    /// Returns all feedback messages concatenated.
+    pub fn feedback_messages(&self) -> &[String] {
+        &self.messages
+    }
+
+    /// Aggregate another hook's result into this one.
+    ///
+    /// # Aggregation Rules
+    /// - `denied`: OR (first deny wins)
+    /// - `failed`: OR (any failure marks as failed)
+    /// - `cancelled`: OR (any cancellation marks as cancelled)
+    /// - `messages`: appended
+    /// - `permission_override`: last wins
+    /// - `updated_input`: last wins
+    pub fn merge(&mut self, other: &HookRunResult) {
+        self.denied = self.denied || other.denied;
+        self.failed = self.failed || other.failed;
+        self.cancelled = self.cancelled || other.cancelled;
+        self.messages.extend_from_slice(&other.messages);
+        if other.permission_override.is_some() {
+            self.permission_override = other.permission_override;
+            self.permission_reason = other.permission_reason.clone();
+        }
+        if other.updated_input.is_some() {
+            self.updated_input = other.updated_input.clone();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hooks::domain::protocol::HookPermissionOverride;
+
+    #[test]
+    fn test_new_result_is_allowed() {
+        let result = HookRunResult::new(HookEvent::PreToolUse);
+        assert!(result.is_allowed());
+        assert!(!result.is_denied());
+        assert!(!result.is_failed());
+        assert!(!result.is_cancelled());
+    }
+
+    #[test]
+    fn test_blocked_result() {
+        let result = HookRunResult::blocked(
+            "Policy violation".into(),
+            vec!["rm blocked".into()],
+        );
+        assert!(result.is_denied());
+        assert!(!result.is_allowed());
+        assert_eq!(result.permission_reason, Some("Policy violation".into()));
+    }
+
+    #[test]
+    fn test_cancelled_result() {
+        let result = HookRunResult::cancelled(HookEvent::PostToolUse, vec!["Aborted".into()]);
+        assert!(result.is_cancelled());
+        assert!(!result.is_allowed());
+        assert_eq!(result.event, HookEvent::PostToolUse);
+    }
+
+    #[test]
+    fn test_merge_deny_wins() {
+        let mut result = HookRunResult::new(HookEvent::PreToolUse);
+        let deny = HookRunResult {
+            event: HookEvent::PreToolUse,
+            denied: true,
+            failed: false,
+            cancelled: false,
+            messages: vec!["Denied!".into()],
+            permission_override: None,
+            permission_reason: None,
+            updated_input: None,
+        };
+        result.merge(&deny);
+        assert!(result.is_denied());
+        assert_eq!(result.messages, vec!["Denied!"]);
+    }
+
+    #[test]
+    fn test_merge_permission_override_last_wins() {
+        let mut result = HookRunResult::new(HookEvent::PreToolUse);
+        let first = HookRunResult {
+            event: HookEvent::PreToolUse,
+            denied: false,
+            failed: false,
+            cancelled: false,
+            messages: vec![],
+            permission_override: Some(HookPermissionOverride::RequireConfirmation),
+            permission_reason: Some("First override".into()),
+            updated_input: None,
+        };
+        let second = HookRunResult {
+            event: HookEvent::PreToolUse,
+            denied: false,
+            failed: false,
+            cancelled: false,
+            messages: vec![],
+            permission_override: Some(HookPermissionOverride::RequireDryRun),
+            permission_reason: Some("Second override".into()),
+            updated_input: None,
+        };
+        result.merge(&first);
+        result.merge(&second);
+        assert_eq!(
+            result.permission_override,
+            Some(HookPermissionOverride::RequireDryRun)
+        );
+        assert_eq!(result.permission_reason, Some("Second override".into()));
+    }
+
+    #[test]
+    fn test_merge_updated_input_last_wins() {
+        let mut result = HookRunResult::new(HookEvent::PreToolUse);
+        let first = HookRunResult {
+            event: HookEvent::PreToolUse,
+            denied: false,
+            failed: false,
+            cancelled: false,
+            messages: vec![],
+            permission_override: None,
+            permission_reason: None,
+            updated_input: Some(serde_json::json!({"a": 1})),
+        };
+        let second = HookRunResult {
+            event: HookEvent::PreToolUse,
+            denied: false,
+            failed: false,
+            cancelled: false,
+            messages: vec![],
+            permission_override: None,
+            permission_reason: None,
+            updated_input: Some(serde_json::json!({"b": 2})),
+        };
+        result.merge(&first);
+        result.merge(&second);
+        assert_eq!(result.updated_input, Some(serde_json::json!({"b": 2})));
+    }
+
+    #[test]
+    fn test_merge_messages_accumulate() {
+        let mut result = HookRunResult::new(HookEvent::PreToolUse);
+        result.merge(&HookRunResult {
+            event: HookEvent::PreToolUse,
+            denied: false,
+            failed: false,
+            cancelled: false,
+            messages: vec!["A".into()],
+            permission_override: None,
+            permission_reason: None,
+            updated_input: None,
+        });
+        result.merge(&HookRunResult {
+            event: HookEvent::PreToolUse,
+            denied: false,
+            failed: false,
+            cancelled: false,
+            messages: vec!["B".into()],
+            permission_override: None,
+            permission_reason: None,
+            updated_input: None,
+        });
+        assert_eq!(result.messages, vec!["A", "B"]);
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let result = HookRunResult::blocked(
+            "Not allowed".into(),
+            vec!["Security violation".into()],
+        );
+        let json = serde_json::to_string(&result).unwrap();
+        let deserialized: HookRunResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(result, deserialized);
+    }
+
+    #[test]
+    fn test_accessor_methods() {
+        let mut result = HookRunResult::new(HookEvent::PreToolUse);
+        assert!(result.modified_input().is_none());
+        assert!(result.override_permission().is_none());
+        assert!(result.feedback_messages().is_empty());
+
+        result.updated_input = Some(serde_json::json!({"key": "value"}));
+        result.permission_override = Some(HookPermissionOverride::BypassGates);
+        result.messages.push("Feedback".into());
+
+        assert_eq!(result.modified_input(), Some(&serde_json::json!({"key": "value"})));
+        assert_eq!(
+            result.override_permission(),
+            Some(HookPermissionOverride::BypassGates)
+        );
+        assert_eq!(result.feedback_messages(), &["Feedback"]);
+    }
+}

--- a/engine/src/hooks/infrastructure/filesystem_repository.rs
+++ b/engine/src/hooks/infrastructure/filesystem_repository.rs
@@ -1,0 +1,235 @@
+//! Filesystem implementation of `HookCommandRepository`.
+//!
+//! @canonical .pi/architecture/modules/hooks.md
+//! Implements: HookCommandRepository — filesystem-backed hook config storage
+//! Issue: #415
+//!
+//! Reads and writes hook configuration from TOML files on the filesystem.
+//! Uses the standard `.rigorix/hooks.toml` path by default.
+
+use async_trait::async_trait;
+use std::path::PathBuf;
+use std::fs;
+
+use crate::hooks::domain::config::HookConfig;
+use crate::hooks::domain::error::HookError;
+
+use super::repository::HookCommandRepository;
+
+/// Default hook configuration file path relative to workspace root.
+const DEFAULT_HOOKS_CONFIG_PATH: &str = ".rigorix/hooks.toml";
+
+/// Filesystem-backed implementation of `HookCommandRepository`.
+///
+/// Reads hook configuration from TOML files. Supports loading from the
+/// default path (`.rigorix/hooks.toml`) or any custom path.
+///
+/// # Format
+///
+/// ```toml
+/// [hooks]
+/// pre_tool_use = [
+///     "rigorix-hook-validate-path",
+///     "rigorix-hook-ci-guard",
+/// ]
+/// post_tool_use = [
+///     "rigorix-hook-fmt-check",
+/// ]
+/// post_tool_use_failure = [
+///     "rigorix-hook-notify",
+/// ]
+/// timeout_secs = 30
+/// sequential_pre_tool_use = true
+/// ```
+pub struct FilesystemHookConfigRepository {
+    /// Path to the hook configuration file.
+    config_path: PathBuf,
+}
+
+impl FilesystemHookConfigRepository {
+    /// Create a new repository with the default config path.
+    pub fn new(workspace_root: &str) -> Self {
+        Self {
+            config_path: PathBuf::from(workspace_root).join(DEFAULT_HOOKS_CONFIG_PATH),
+        }
+    }
+
+    /// Create a new repository with a custom config path.
+    pub fn with_path(path: impl Into<PathBuf>) -> Self {
+        Self {
+            config_path: path.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl HookCommandRepository for FilesystemHookConfigRepository {
+    async fn load(&self) -> Result<HookConfig, HookError> {
+        self.load_from(self.config_path.to_str().unwrap_or("")).await
+    }
+
+    async fn load_from(&self, path: &str) -> Result<HookConfig, HookError> {
+        let content = fs::read_to_string(path).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                // File doesn't exist — return empty config
+                return HookError::CommandNotFound {
+                    command: path.to_string(),
+                };
+            }
+            HookError::Internal {
+                detail: format!("Failed to read hook config from '{}': {}", path, e),
+            }
+        })?;
+
+        // Try parsing as TOML, mapping to HookConfig's section
+        #[derive(serde::Deserialize)]
+        struct HooksToml {
+            hooks: Option<HookConfig>,
+        }
+
+        match toml::from_str::<HooksToml>(&content) {
+            Ok(toml_config) => Ok(toml_config.hooks.unwrap_or_default()),
+            Err(e) => Err(HookError::InvalidJson {
+                command: path.to_string(),
+                detail: format!("TOML parse error: {}", e),
+                raw_output: content.chars().take(500).collect(),
+            }),
+        }
+    }
+
+    async fn save(&self, config: &HookConfig) -> Result<(), HookError> {
+        let toml_string = toml::to_string_pretty(config).map_err(|e| HookError::Internal {
+            detail: format!("Failed to serialize hook config: {}", e),
+        })?;
+
+        let toml_content = format!("[hooks]\n{}", toml_string);
+
+        // Ensure parent directory exists
+        if let Some(parent) = self.config_path.parent() {
+            fs::create_dir_all(parent).map_err(|e| HookError::Internal {
+                detail: format!("Failed to create config directory '{}': {}", parent.display(), e),
+            })?;
+        }
+
+        fs::write(&self.config_path, &toml_content).map_err(|e| HookError::Internal {
+            detail: format!("Failed to write hook config to '{}': {}", self.config_path.display(), e),
+        })?;
+
+        Ok(())
+    }
+
+    async fn exists(&self) -> Result<bool, HookError> {
+        Ok(self.config_path.exists())
+    }
+
+    async fn reset(&self) -> Result<(), HookError> {
+        if self.config_path.exists() {
+            fs::remove_file(&self.config_path).map_err(|e| HookError::Internal {
+                detail: format!("Failed to remove hook config '{}': {}", self.config_path.display(), e),
+            })?;
+        }
+        Ok(())
+    }
+
+    fn source_path(&self) -> &str {
+        self.config_path.to_str().unwrap_or("")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn test_config() -> HookConfig {
+        HookConfig {
+            pre_tool_use: vec!["hook-a".into(), "hook-b".into()],
+            post_tool_use: vec!["hook-c".into()],
+            post_tool_use_failure: vec!["hook-d".into()],
+            timeout_secs: 30,
+            sequential_pre_tool_use: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_load_non_existent_path() {
+        let repo = FilesystemHookConfigRepository::with_path("/tmp/nonexistent/hooks.toml");
+        // Should return CommandNotFound (file not found)
+        let result = repo.load().await;
+        assert!(result.is_err());
+        match result {
+            Err(HookError::CommandNotFound { .. }) => {} // Expected
+            Err(HookError::Internal { detail }) => {
+                // On some systems file read fails with different error
+                assert!(detail.contains("nonexistent"));
+            }
+            _ => panic!("Expected CommandNotFound or Internal error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_save_and_load() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join(".rigorix").join("hooks.toml");
+        let repo = FilesystemHookConfigRepository::with_path(&config_path);
+
+        let config = test_config();
+        repo.save(&config).await.unwrap();
+        assert!(config_path.exists());
+
+        let loaded = repo.load().await.unwrap();
+        assert_eq!(loaded.pre_tool_use, config.pre_tool_use);
+        assert_eq!(loaded.post_tool_use, config.post_tool_use);
+        assert_eq!(loaded.post_tool_use_failure, config.post_tool_use_failure);
+        assert_eq!(loaded.timeout_secs, config.timeout_secs);
+    }
+
+    #[tokio::test]
+    async fn test_exists() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("hooks.toml");
+        let repo = FilesystemHookConfigRepository::with_path(&config_path);
+
+        assert!(!repo.exists().await.unwrap());
+        repo.save(&test_config()).await.unwrap();
+        assert!(repo.exists().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_reset() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("hooks.toml");
+        let repo = FilesystemHookConfigRepository::with_path(&config_path);
+
+        repo.save(&test_config()).await.unwrap();
+        assert!(config_path.exists());
+
+        repo.reset().await.unwrap();
+        assert!(!config_path.exists());
+    }
+
+    #[tokio::test]
+    async fn test_source_path() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join(".rigorix").join("hooks.toml");
+        let repo = FilesystemHookConfigRepository::with_path(&config_path);
+
+        assert!(repo.source_path().ends_with(".rigorix/hooks.toml")
+            || repo.source_path().contains("hooks.toml"));
+    }
+
+    #[tokio::test]
+    async fn test_load_invalid_toml() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("bad.toml");
+        fs::write(&config_path, "invalid toml {{{").unwrap();
+
+        let repo = FilesystemHookConfigRepository::with_path(&config_path);
+        let result = repo.load().await;
+        assert!(result.is_err());
+        match result {
+            Err(HookError::InvalidJson { .. }) => {} // Expected
+            _ => panic!("Expected InvalidJson error"),
+        }
+    }
+}

--- a/engine/src/hooks/infrastructure/mod.rs
+++ b/engine/src/hooks/infrastructure/mod.rs
@@ -8,6 +8,8 @@
 //! behind traits. The primary repository is for hook command persistence
 //! and retrieval.
 
+pub mod filesystem_repository;
 pub mod repository;
 
+pub use filesystem_repository::*;
 pub use repository::*;

--- a/engine/src/hooks/infrastructure/mod.rs
+++ b/engine/src/hooks/infrastructure/mod.rs
@@ -1,0 +1,13 @@
+//! Infrastructure layer interfaces for the Hook System.
+//!
+//! @canonical .pi/architecture/modules/hooks.md
+//! Implements: Contract Freeze — repository interfaces
+//! Issue: #410
+//!
+//! This module defines repository interfaces that abstract data access
+//! behind traits. The primary repository is for hook command persistence
+//! and retrieval.
+
+pub mod repository;
+
+pub use repository::*;

--- a/engine/src/hooks/infrastructure/repository/mod.rs
+++ b/engine/src/hooks/infrastructure/repository/mod.rs
@@ -1,0 +1,57 @@
+//! Repository interfaces for the Hook System.
+//!
+//! @canonical .pi/architecture/modules/hooks.md
+//! Implements: Contract Freeze — HookCommandRepository trait
+//! Issue: #410
+//!
+//! Repositories abstract data access behind interfaces, allowing
+//! implementations to use various storage backends (filesystem TOML,
+//! database, in-memory) without coupling domain logic to infrastructure.
+//!
+//! # Contract (Frozen)
+//! - All repository methods return domain error types
+//! - No framework-specific annotations on trait definitions
+//! - Implementations are hidden behind these interfaces
+
+use async_trait::async_trait;
+
+use crate::hooks::domain::config::HookConfig;
+use crate::hooks::domain::error::HookError;
+
+/// Repository for persisting and retrieving hook command configurations.
+///
+/// Provides access to hook command lists stored in configuration sources
+/// (e.g., `.rigorix/hooks.toml`, database, environment variables).
+///
+/// # Security
+/// - Implementations MUST validate command paths against allowed directories
+/// - All inputs must be validated against size limits
+#[async_trait]
+pub trait HookCommandRepository: Send + Sync {
+    /// Load hook configuration from the default source.
+    ///
+    /// Returns the parsed `HookConfig` or an error if loading fails.
+    /// If no configuration source exists, returns an empty `HookConfig`.
+    async fn load(&self) -> Result<HookConfig, HookError>;
+
+    /// Load hook configuration from a specific path.
+    ///
+    /// Useful for testing or when configuration is in a non-default location.
+    async fn load_from(&self, path: &str) -> Result<HookConfig, HookError>;
+
+    /// Save hook configuration to the default source.
+    ///
+    /// Persists the provided `HookConfig` to the configuration storage.
+    async fn save(&self, config: &HookConfig) -> Result<(), HookError>;
+
+    /// Check whether a hook configuration source exists.
+    async fn exists(&self) -> Result<bool, HookError>;
+
+    /// Reset hook configuration to defaults (empty).
+    ///
+    /// Removes all registered hook commands.
+    async fn reset(&self) -> Result<(), HookError>;
+
+    /// Get the source path of the hook configuration.
+    fn source_path(&self) -> &str;
+}

--- a/engine/src/hooks/interfaces/http/mod.rs
+++ b/engine/src/hooks/interfaces/http/mod.rs
@@ -1,0 +1,264 @@
+//! HTTP API contracts for Hook System endpoints.
+//!
+//! @canonical .pi/architecture/modules/hooks.md
+//! Implements: Contract Freeze — HTTP endpoint contracts and error formats
+//! Issue: #410
+//!
+//! Defines endpoint paths, methods, request/response schemas, and error
+//! response formats. These contracts are framework-agnostic — they describe
+//! the API surface that any HTTP server implementation must satisfy.
+//!
+//! # Contract (Frozen)
+//! - All endpoints documented with method, path, request, and response types
+//! - Error responses follow a unified format
+//! - No framework-specific annotations (axum/actix/warp annotations added by implementation)
+
+use serde::{Deserialize, Serialize};
+
+use crate::hooks::domain::event::HookEvent;
+use crate::hooks::domain::protocol::{HookDecision, HookPermissionOverride};
+use crate::hooks::domain::result::HookRunResult;
+
+// ---------------------------------------------------------------------------
+// API Base Path
+// ---------------------------------------------------------------------------
+
+/// All hook system endpoints are served under this base path.
+pub const API_BASE_PATH: &str = "/api/v1/hooks";
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/hooks/run
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/hooks/run
+///
+/// Run all hooks for a given lifecycle event.
+///
+/// **Request:** `RunHooksRequest`
+/// **Response:** `200 OK` with `RunHooksResponse`
+pub const RUN_HOOKS_PATH: &str = "/api/v1/hooks/run";
+pub const RUN_HOOKS_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/hooks/run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunHooksRequest {
+    /// The lifecycle event to run hooks for.
+    pub event: HookEvent,
+
+    /// Name of the tool being intercepted.
+    pub tool_name: String,
+
+    /// The tool input as a JSON value.
+    pub tool_input: serde_json::Value,
+
+    /// The tool output or error output (for Post* events).
+    /// Leave empty for PreToolUse.
+    #[serde(default)]
+    pub tool_output: String,
+
+    /// The session/execution ID for correlation.
+    pub session_id: String,
+
+    /// The workspace root directory path.
+    pub workspace_root: String,
+}
+
+/// Response body for POST /api/v1/hooks/run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunHooksResponse {
+    pub success: bool,
+
+    /// The lifecycle event that was processed.
+    pub event: HookEvent,
+
+    /// Whether the tool execution is allowed to proceed.
+    pub allowed: bool,
+
+    /// Whether the execution was denied by a hook.
+    pub denied: bool,
+
+    /// Whether a hook execution failed.
+    pub failed: bool,
+
+    /// Whether the execution was cancelled.
+    pub cancelled: bool,
+
+    /// Aggregated feedback messages from hooks.
+    #[serde(default)]
+    pub messages: Vec<String>,
+
+    /// Permission override from hooks (if any).
+    #[serde(default)]
+    pub permission_override: Option<HookPermissionOverride>,
+
+    /// Updated tool input from hooks (if any).
+    #[serde(default)]
+    pub updated_input: Option<serde_json::Value>,
+
+    /// Number of hooks that were executed.
+    pub hooks_executed: usize,
+
+    /// Number of hooks that failed.
+    pub hooks_failed: usize,
+}
+
+impl From<(HookRunResult, usize, usize)> for RunHooksResponse {
+    fn from((result, executed, failed): (HookRunResult, usize, usize)) -> Self {
+        Self {
+            success: !result.failed,
+            event: result.event,
+            allowed: result.is_allowed(),
+            denied: result.is_denied(),
+            failed: result.failed,
+            cancelled: result.is_cancelled(),
+            messages: result.messages,
+            permission_override: result.permission_override,
+            updated_input: result.updated_input,
+            hooks_executed: executed,
+            hooks_failed: failed,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: GET /api/v1/hooks/config
+// ---------------------------------------------------------------------------
+
+/// GET /api/v1/hooks/config
+///
+/// Get the current hook configuration (registered commands).
+///
+/// **Response:** `200 OK` with `HookConfigResponse`
+pub const GET_HOOKS_CONFIG_PATH: &str = "/api/v1/hooks/config";
+pub const GET_HOOKS_CONFIG_METHOD: &str = "GET";
+
+/// Response body for GET /api/v1/hooks/config.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookConfigResponse {
+    pub success: bool,
+    pub pre_tool_use: Vec<String>,
+    pub post_tool_use: Vec<String>,
+    pub post_tool_use_failure: Vec<String>,
+    pub timeout_secs: u64,
+    pub total_hooks: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: PUT /api/v1/hooks/config
+// ---------------------------------------------------------------------------
+
+/// PUT /api/v1/hooks/config
+///
+/// Update the hook configuration at runtime.
+///
+/// **Request:** `UpdateHookConfigRequest`
+/// **Response:** `200 OK` with `HookConfigResponse`
+pub const UPDATE_HOOKS_CONFIG_PATH: &str = "/api/v1/hooks/config";
+pub const UPDATE_HOOKS_CONFIG_METHOD: &str = "PUT";
+
+/// Request body for PUT /api/v1/hooks/config.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateHookConfigRequest {
+    /// Commands to run before every tool execution.
+    #[serde(default)]
+    pub pre_tool_use: Vec<String>,
+
+    /// Commands to run after every successful tool execution.
+    #[serde(default)]
+    pub post_tool_use: Vec<String>,
+
+    /// Commands to run after every failed tool execution.
+    #[serde(default)]
+    pub post_tool_use_failure: Vec<String>,
+
+    /// Timeout in seconds for each hook command (optional).
+    pub timeout_secs: Option<u64>,
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/hooks/test
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/hooks/test
+///
+/// Test-run a single hook command without affecting the real hook pipeline.
+/// Useful for debugging hook scripts.
+///
+/// **Request:** `TestHookRequest`
+/// **Response:** `200 OK` with `TestHookResponse`
+pub const TEST_HOOK_PATH: &str = "/api/v1/hooks/test";
+pub const TEST_HOOK_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/hooks/test.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TestHookRequest {
+    /// The command to test-run.
+    pub command: String,
+
+    /// The lifecycle event to simulate.
+    #[serde(default)]
+    pub event: HookEvent,
+
+    /// Name of the tool to simulate.
+    pub tool_name: String,
+
+    /// Tool input to pass to the hook.
+    pub tool_input: serde_json::Value,
+}
+
+/// Response body for POST /api/v1/hooks/test.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TestHookResponse {
+    pub success: bool,
+    pub decision: HookDecision,
+    pub messages: Vec<String>,
+    pub duration_ms: u64,
+    pub raw_output: String,
+}
+
+// ---------------------------------------------------------------------------
+// Unified Error Response Format
+// ---------------------------------------------------------------------------
+
+/// Standard error response for all Hook System API endpoints.
+///
+/// All 4xx/5xx responses use this format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiErrorResponse {
+    /// HTTP status code.
+    pub status: u16,
+    /// Machine-readable error code.
+    pub code: String,
+    /// Human-readable error message.
+    pub message: String,
+    /// Detailed error context (optional, may include field-level errors).
+    pub details: Option<serde_json::Value>,
+    /// Request ID for tracing (if available).
+    pub request_id: Option<String>,
+}
+
+/// Standardized error codes for Hook System API.
+pub mod error_codes {
+    /// Hook command not found.
+    pub const COMMAND_NOT_FOUND: &str = "HOOK_COMMAND_NOT_FOUND";
+    /// Hook execution timed out.
+    pub const TIMEOUT: &str = "HOOK_TIMEOUT";
+    /// Hook returned invalid JSON.
+    pub const INVALID_JSON: &str = "HOOK_INVALID_JSON";
+    /// Hook process exited with error.
+    pub const PROCESS_ERROR: &str = "HOOK_PROCESS_ERROR";
+    /// Hook execution was aborted.
+    pub const ABORTED: &str = "HOOK_ABORTED";
+    /// Internal server error.
+    pub const INTERNAL_ERROR: &str = "HOOK_INTERNAL_ERROR";
+}
+
+/// HTTP status code mappings for Hook System errors.
+pub mod status_codes {
+    pub const COMMAND_NOT_FOUND: u16 = 404;
+    pub const TIMEOUT: u16 = 504;
+    pub const INVALID_JSON: u16 = 422;
+    pub const PROCESS_ERROR: u16 = 502;
+    pub const ABORTED: u16 = 499;
+    pub const INTERNAL_ERROR: u16 = 500;
+}

--- a/engine/src/hooks/interfaces/mod.rs
+++ b/engine/src/hooks/interfaces/mod.rs
@@ -1,0 +1,10 @@
+//! Interface adapters for the Hook System bounded context.
+//!
+//! @canonical .pi/architecture/modules/hooks.md
+//! Implements: Contract Freeze — HTTP API endpoint contracts
+//! Issue: #410
+//!
+//! This module defines API contracts (HTTP, CLI, etc.) that external
+//! actors use to interact with the hook system.
+
+pub mod http;

--- a/engine/src/hooks/mod.rs
+++ b/engine/src/hooks/mod.rs
@@ -1,0 +1,53 @@
+//! Hook System bounded context.
+//!
+//! @canonical .pi/architecture/modules/hooks.md
+//! Implements: Contract Freeze — hooks module root
+//! Issue: #410
+//!
+//! Provides external script-based interception points around every tool
+//! execution. Hooks run as shell commands receiving JSON payloads on stdin
+//! and returning structured JSON decisions.
+//!
+//! # Architecture
+//!
+//! ```text
+//! hooks/
+//! ├── domain/           # Domain entities (HookEvent, HookRunResult, HookConfig, HookError)
+//! │   ├── event.rs      # HookEvent enum (PreToolUse, PostToolUse, PostToolUseFailure)
+//! │   ├── protocol.rs   # Hook Protocol — JSON stdin/stdout contracts
+//! │   ├── result.rs     # HookRunResult struct
+//! │   ├── config.rs     # HookConfig struct
+//! │   ├── error.rs      # HookError enum
+//! │   ├── abort.rs      # HookAbortSignal for cooperative cancellation
+//! │   └── event_payload.rs  # Hook lifecycle event payloads
+//! ├── application/      # Service traits, DTOs, factory interfaces
+//! │   ├── service.rs    # HookRunnerService trait
+//! │   ├── factory.rs    # HookRunnerFactory trait
+//! │   └── dto/          # Input/Output DTOs with validation
+//! ├── infrastructure/   # Repository interfaces
+//! │   └── repository/   # HookCommandRepository trait
+//! └── interfaces/       # API contracts
+//!     └── http/         # REST endpoint contracts
+//! ```
+//!
+//! # Contract Freeze Notice
+//!
+//! ALL files in this module are frozen contracts.
+//! - No implementation changes without explicit contract change approval
+//! - Implementation PRs MUST reference these interfaces
+//! - DTO schemas serve as the canonical data contract
+//!
+//! # Components
+//!
+//! | Component | Description | Canonical Section |
+//! |-----------|-------------|-------------------|
+//! | HookEvent | Lifecycle point identification | #hook-event |
+//! | Hook Protocol | JSON stdin/stdout contract | #hook-protocol |
+//! | HookRunResult | Aggregated hook execution result | #hook-result |
+//! | HookRunner | Hook command execution and aggregation | #hook-runner |
+//! | HookConfig | Declarative hook command registration | #hook-config |
+
+pub mod application;
+pub mod domain;
+pub mod infrastructure;
+pub mod interfaces;

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -26,6 +26,7 @@
 pub mod audit;
 pub mod budget_tracking;
 pub mod cancellation;
+pub mod code_gen;
 pub mod code_graph;
 pub mod common;
 pub mod configuration;

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -39,6 +39,7 @@ pub mod failure_classification;
 pub mod hooks;
 pub mod observability;
 pub mod orchestrator;
+pub mod recovery_recipes;
 pub mod planning;
 pub mod repo_engine;
 pub mod risk_gating;

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -35,6 +35,7 @@ pub mod error;
 pub mod event_system;
 pub mod execution_engine;
 pub mod failure_classification;
+pub mod hooks;
 pub mod observability;
 pub mod orchestrator;
 pub mod planning;

--- a/engine/src/recovery_recipes/application/context.rs
+++ b/engine/src/recovery_recipes/application/context.rs
@@ -1,0 +1,268 @@
+//! RecoveryContext — per-session attempt tracker and recovery event log.
+//!
+//! @canonical .pi/architecture/modules/recovery-recipes.md#recoverycontext
+//! Implements: Contract Freeze — RecoveryContext struct
+//! Issue: #438 (recovery-recipes epic)
+//!
+//! # Contract (Frozen)
+//! - Tracks per-scenario attempt counts within an execution session
+//! - Maintains an ordered recovery event log for audit trail
+//! - No framework dependencies — pure domain struct
+//! - `can_attempt()` checks if a scenario has remaining attempts
+//! - `record_attempt()` increments counter and emits events
+//! - Constructed fresh per execution session
+
+use std::collections::HashMap;
+
+use crate::recovery_recipes::domain::{
+    FailureScenario, RecoveryEvent, RecoveryRecipe,
+};
+
+/// Tracks per-scenario attempt counts and recovery events within an
+/// execution session. Constructed fresh for each execution session
+/// to ensure clean attempt tracking.
+///
+/// # Usage
+///
+/// ```ignore
+/// let mut ctx = RecoveryContext::new();
+///
+/// if ctx.can_attempt(scenario, &recipe) {
+///     // execute recovery steps
+///     ctx.record_attempt(scenario);
+/// } else {
+///     // escalate
+/// }
+/// ```
+#[derive(Debug, Clone)]
+pub struct RecoveryContext {
+    /// Per-scenario attempt count (reset per execution session).
+    attempts: HashMap<FailureScenario, u32>,
+    /// Ordered recovery event log.
+    events: Vec<RecoveryEvent>,
+}
+
+impl RecoveryContext {
+    /// Create a new, empty `RecoveryContext`.
+    ///
+    /// All scenario counters start at 0. No events have been recorded.
+    pub fn new() -> Self {
+        Self {
+            attempts: HashMap::new(),
+            events: Vec::new(),
+        }
+    }
+
+    /// Check if a scenario has remaining attempts according to the recipe.
+    ///
+    /// Returns `true` if `current_attempts < recipe.max_attempts`.
+    pub fn can_attempt(&self, scenario: FailureScenario, recipe: &RecoveryRecipe) -> bool {
+        self.attempts.get(&scenario).copied().unwrap_or(0) < recipe.max_attempts
+    }
+
+    /// Record an attempt (increments counter, appends to event log).
+    ///
+    /// Returns the attempt number (1-based) that was recorded.
+    pub fn record_attempt(&mut self, scenario: FailureScenario) -> u32 {
+        let count = self.attempts.entry(scenario).or_insert(0);
+        *count += 1;
+        *count
+    }
+
+    /// Record a recovery event in the event log.
+    pub fn record_event(&mut self, event: RecoveryEvent) {
+        self.events.push(event);
+    }
+
+    /// Get the current attempt count for a scenario.
+    ///
+    /// Returns 0 if no attempts have been recorded for this scenario.
+    pub fn attempt_count(&self, scenario: FailureScenario) -> u32 {
+        self.attempts.get(&scenario).copied().unwrap_or(0)
+    }
+
+    /// Get the remaining attempts for a scenario given a recipe.
+    pub fn remaining_attempts(&self, scenario: FailureScenario, recipe: &RecoveryRecipe) -> u32 {
+        recipe.max_attempts.saturating_sub(self.attempt_count(scenario))
+    }
+
+    /// Get all events for audit trail.
+    pub fn events(&self) -> &[RecoveryEvent] {
+        &self.events
+    }
+
+    /// Consume the context and return the event log.
+    pub fn into_events(self) -> Vec<RecoveryEvent> {
+        self.events
+    }
+
+    /// Clear all attempt counters and events (reset for a new session).
+    pub fn reset(&mut self) {
+        self.attempts.clear();
+        self.events.clear();
+    }
+
+    /// Returns `true` if any attempts have been recorded.
+    pub fn has_attempts(&self) -> bool {
+        !self.attempts.is_empty()
+    }
+
+    /// Returns `true` if any events have been recorded.
+    pub fn has_events(&self) -> bool {
+        !self.events.is_empty()
+    }
+
+    /// Returns the number of scenarios that have been attempted.
+    pub fn attempted_scenario_count(&self) -> usize {
+        self.attempts.len()
+    }
+
+    /// Returns the total number of attempts across all scenarios.
+    pub fn total_attempts(&self) -> u32 {
+        self.attempts.values().sum()
+    }
+}
+
+impl Default for RecoveryContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::recovery_recipes::domain::EscalationPolicy;
+
+    #[test]
+    fn test_new_context_is_empty() {
+        let ctx = RecoveryContext::new();
+        assert_eq!(ctx.attempt_count(FailureScenario::CompileError), 0);
+        assert!(!ctx.has_attempts());
+        assert!(!ctx.has_events());
+        assert_eq!(ctx.attempted_scenario_count(), 0);
+        assert_eq!(ctx.total_attempts(), 0);
+    }
+
+    #[test]
+    fn test_record_attempt_increments_counter() {
+        let mut ctx = RecoveryContext::new();
+        let count = ctx.record_attempt(FailureScenario::CompileError);
+        assert_eq!(count, 1);
+        assert_eq!(ctx.attempt_count(FailureScenario::CompileError), 1);
+        assert_eq!(ctx.total_attempts(), 1);
+        assert!(ctx.has_attempts());
+    }
+
+    #[test]
+    fn test_multiple_attempts_same_scenario() {
+        let mut ctx = RecoveryContext::new();
+        ctx.record_attempt(FailureScenario::CompileError);
+        ctx.record_attempt(FailureScenario::CompileError);
+        assert_eq!(ctx.attempt_count(FailureScenario::CompileError), 2);
+    }
+
+    #[test]
+    fn test_different_scenarios_tracked_independently() {
+        let mut ctx = RecoveryContext::new();
+        ctx.record_attempt(FailureScenario::CompileError);
+        ctx.record_attempt(FailureScenario::TestFailure);
+        ctx.record_attempt(FailureScenario::CompileError);
+
+        assert_eq!(ctx.attempt_count(FailureScenario::CompileError), 2);
+        assert_eq!(ctx.attempt_count(FailureScenario::TestFailure), 1);
+        assert_eq!(ctx.total_attempts(), 3);
+        assert_eq!(ctx.attempted_scenario_count(), 2);
+    }
+
+    #[test]
+    fn test_can_attempt_within_limits() {
+        let mut ctx = RecoveryContext::new();
+        let recipe = RecoveryRecipe::new(
+            FailureScenario::CompileError,
+            vec![crate::recovery_recipes::domain::RecoveryStep::CleanBuild],
+            2,
+            EscalationPolicy::AlertHuman,
+        )
+        .unwrap();
+
+        assert!(ctx.can_attempt(FailureScenario::CompileError, &recipe));
+        ctx.record_attempt(FailureScenario::CompileError);
+        assert!(ctx.can_attempt(FailureScenario::CompileError, &recipe));
+        ctx.record_attempt(FailureScenario::CompileError);
+        assert!(!ctx.can_attempt(FailureScenario::CompileError, &recipe));
+    }
+
+    #[test]
+    fn test_remaining_attempts() {
+        let mut ctx = RecoveryContext::new();
+        let recipe = RecoveryRecipe::new(
+            FailureScenario::CompileError,
+            vec![crate::recovery_recipes::domain::RecoveryStep::CleanBuild],
+            3,
+            EscalationPolicy::AlertHuman,
+        )
+        .unwrap();
+
+        assert_eq!(ctx.remaining_attempts(FailureScenario::CompileError, &recipe), 3);
+        ctx.record_attempt(FailureScenario::CompileError);
+        assert_eq!(ctx.remaining_attempts(FailureScenario::CompileError, &recipe), 2);
+        ctx.record_attempt(FailureScenario::CompileError);
+        assert_eq!(ctx.remaining_attempts(FailureScenario::CompileError, &recipe), 1);
+        ctx.record_attempt(FailureScenario::CompileError);
+        assert_eq!(ctx.remaining_attempts(FailureScenario::CompileError, &recipe), 0);
+    }
+
+    #[test]
+    fn test_record_event() {
+        let mut ctx = RecoveryContext::new();
+        let event = RecoveryEvent::RecoveryAttempted {
+            scenario: FailureScenario::CompileError,
+            step: crate::recovery_recipes::domain::RecoveryStep::CleanBuild,
+            attempt_number: 1,
+        };
+        ctx.record_event(event);
+        assert!(ctx.has_events());
+        assert_eq!(ctx.events().len(), 1);
+    }
+
+    #[test]
+    fn test_reset() {
+        let mut ctx = RecoveryContext::new();
+        ctx.record_attempt(FailureScenario::CompileError);
+        ctx.record_event(RecoveryEvent::RecoveryAttempted {
+            scenario: FailureScenario::CompileError,
+            step: crate::recovery_recipes::domain::RecoveryStep::CleanBuild,
+            attempt_number: 1,
+        });
+
+        ctx.reset();
+        assert!(!ctx.has_attempts());
+        assert!(!ctx.has_events());
+        assert_eq!(ctx.total_attempts(), 0);
+    }
+
+    #[test]
+    fn test_into_events_consumes() {
+        let mut ctx = RecoveryContext::new();
+        ctx.record_event(RecoveryEvent::RecoveryAttempted {
+            scenario: FailureScenario::CompileError,
+            step: crate::recovery_recipes::domain::RecoveryStep::CleanBuild,
+            attempt_number: 1,
+        });
+        let events = ctx.into_events();
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn test_default_is_empty() {
+        let ctx = RecoveryContext::default();
+        assert_eq!(ctx.total_attempts(), 0);
+    }
+
+    #[test]
+    fn test_unattempted_scenario_returns_zero() {
+        let ctx = RecoveryContext::new();
+        assert_eq!(ctx.attempt_count(FailureScenario::ProviderFailure), 0);
+    }
+}

--- a/engine/src/recovery_recipes/application/dto.rs
+++ b/engine/src/recovery_recipes/application/dto.rs
@@ -1,0 +1,147 @@
+//! Data Transfer Objects for the Recovery Recipes module.
+//!
+//! @canonical .pi/architecture/modules/recovery-recipes.md
+//! Implements: Contract Freeze — DTO schemas for recovery recipes
+//! Issue: #438 (recovery-recipes epic)
+//!
+//! DTOs define the input/output contracts for service operations.
+//! They carry validation metadata and documentation but no behavior.
+//!
+//! # Contract (Frozen)
+//! - Every service operation has a dedicated input and output DTO
+//! - DTOs are serializable (JSON for API)
+//! - Validation constraints are documented in field docs
+//! - Fields use reasonable Rust types (no framework-specific annotations)
+
+use serde::{Deserialize, Serialize};
+
+use crate::recovery_recipes::domain::{
+    FailureScenario, RecoveryRecipe, RecoveryResult, RecoveryStep,
+};
+
+// ---------------------------------------------------------------------------
+// Attempt Recovery DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for attempting recovery on a failure scenario.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttemptRecoveryInput {
+    /// The failure scenario to attempt recovery for.
+    pub scenario: FailureScenario,
+
+    /// The recipe to use for recovery steps.
+    pub recipe: RecoveryRecipe,
+
+    /// Current attempt number (1-based). Used for attempt tracking.
+    /// Must be >= 1 and <= recipe.max_attempts.
+    pub attempt_number: u32,
+
+    /// Optional context about the original failure (error message, etc.)
+    /// This is passed through to recovery steps that need it (e.g., ExpandContext).
+    pub original_error: Option<String>,
+
+    /// Optional execution context for tool use (only if the recovery step
+    /// requires executing external commands).
+    pub execution_id: Option<String>,
+}
+
+/// Output from attempting recovery.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AttemptRecoveryOutput {
+    /// The result of the recovery attempt.
+    pub result: RecoveryResult,
+
+    /// The step that was being executed when recovery completed/failed.
+    pub last_step: Option<RecoveryStep>,
+
+    /// Whether this was the final attempt before escalation.
+    pub is_final_attempt: bool,
+
+    /// Human-readable summary of the recovery outcome.
+    pub summary: String,
+}
+
+// ---------------------------------------------------------------------------
+// Recipe Lookup DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for looking up a recipe for a failure scenario.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecipeForInput {
+    /// The failure scenario to find a recipe for.
+    pub scenario: FailureScenario,
+
+    /// Optional custom recipe overrides. If provided, these are checked
+    /// before the default catalog.
+    pub custom_recipes: Option<Vec<RecoveryRecipe>>,
+}
+
+/// Output from looking up a recipe.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RecipeForOutput {
+    /// The recipe for the scenario, if found.
+    pub recipe: Option<RecoveryRecipe>,
+
+    /// Whether the recipe came from the default catalog or a custom override.
+    pub source: RecipeSource,
+}
+
+/// Source of a recipe lookup result.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum RecipeSource {
+    /// Recipe found in the default built-in catalog.
+    DefaultCatalog,
+    /// Recipe found in a custom override configuration.
+    CustomOverride,
+    /// No recipe found for the scenario.
+    NotFound,
+}
+
+// ---------------------------------------------------------------------------
+// Validate Recipe DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for validating a recipe configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidateRecipeInput {
+    /// The recipe to validate.
+    pub recipe: RecoveryRecipe,
+
+    /// Whether to require that steps have safe=true for auto-execution.
+    pub require_safe_steps: bool,
+}
+
+/// Output from validating a recipe.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ValidateRecipeOutput {
+    /// Whether the recipe configuration is valid.
+    pub valid: bool,
+    /// List of validation errors (empty if valid).
+    pub errors: Vec<String>,
+    /// List of warnings (non-blocking issues).
+    pub warnings: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Attempt Check DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for checking whether recovery can be attempted.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CanAttemptInput {
+    /// The failure scenario to check.
+    pub scenario: FailureScenario,
+    /// The recipe that would be used.
+    pub recipe: RecoveryRecipe,
+}
+
+/// Output from checking whether recovery can be attempted.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CanAttemptOutput {
+    /// Whether recovery can be attempted.
+    pub can_attempt: bool,
+    /// Why recovery can or cannot be attempted.
+    pub reason: String,
+    /// Remaining attempts.
+    pub remaining_attempts: u32,
+}

--- a/engine/src/recovery_recipes/application/mod.rs
+++ b/engine/src/recovery_recipes/application/mod.rs
@@ -1,0 +1,24 @@
+//! Application layer interfaces for the Recovery Recipes bounded context.
+//!
+//! @canonical .pi/architecture/modules/recovery-recipes.md
+//! Implements: Contract Freeze — service traits, DTOs, factory interfaces
+//! Issue: #438 (recovery-recipes epic)
+//!
+//! This module defines:
+//! - Service traits (use cases / application services)
+//! - Input/Output DTOs with validation
+//! - RecoveryContext for per-session attempt tracking
+//!
+//! # Contract (Frozen)
+//! - All service methods are async (return `impl Future`)
+//! - All public methods return `Result<_, RecoveryError>`
+//! - DTOs include validation annotations/documentation
+//! - No implementation logic — only trait definitions and structs
+
+pub mod context;
+pub mod dto;
+pub mod service;
+
+pub use context::RecoveryContext;
+pub use dto::*;
+pub use service::RecoveryService;

--- a/engine/src/recovery_recipes/application/service.rs
+++ b/engine/src/recovery_recipes/application/service.rs
@@ -1,0 +1,97 @@
+//! Service interfaces (use cases) for the Recovery Recipes bounded context.
+//!
+//! @canonical .pi/architecture/modules/recovery-recipes.md#service
+//! Implements: Contract Freeze — RecoveryService trait
+//! Issue: #438 (recovery-recipes epic)
+//!
+//! These traits define the application-level operations that can be performed
+//! for recovery recipe execution. All methods are async and return domain
+//! error types.
+//!
+//! # Contract (Frozen)
+//! - Every use case has a corresponding trait method
+//! - Input/output types are DTOs defined in `dto/`
+//! - All methods are async (use `async-trait` for trait object safety)
+//! - No implementation — only contract signatures
+
+use async_trait::async_trait;
+
+use crate::recovery_recipes::domain::{RecoveryError, RecoveryRecipe};
+
+use super::dto::{
+    AttemptRecoveryInput, AttemptRecoveryOutput, CanAttemptInput, CanAttemptOutput,
+    RecipeForInput, RecipeForOutput, ValidateRecipeInput, ValidateRecipeOutput,
+};
+
+/// Application service for managing and executing recovery recipes.
+///
+/// The `RecoveryService` is the primary entry point for the recovery-recipes
+/// module. It handles:
+/// - Looking up recipes for failure scenarios
+/// - Checking whether recovery can be attempted (attempt tracking)
+/// - Executing recovery steps
+/// - Validating recipe configurations
+#[async_trait]
+pub trait RecoveryService: Send + Sync {
+    /// Attempt recovery for a given failure scenario.
+    ///
+    /// Executes the steps in the recipe sequentially. Returns the result
+    /// of the recovery attempt. Each step is executed in order until one
+    /// succeeds or all are exhausted.
+    ///
+    /// # Errors
+    /// - `RecoveryError::NoRecipe` if no recipe is available for the scenario
+    /// - `RecoveryError::MaxAttemptsReached` if attempts are exhausted
+    /// - `RecoveryError::StepFailed` if a recovery step fails
+    /// - `RecoveryError::Aborted` if recovery was cancelled
+    async fn attempt_recovery(
+        &self,
+        input: AttemptRecoveryInput,
+    ) -> Result<AttemptRecoveryOutput, RecoveryError>;
+
+    /// Look up the recovery recipe for a given failure scenario.
+    ///
+    /// Checks custom overrides first, then falls back to the default
+    /// built-in catalog. Returns `None` if no recipe is configured for
+    /// the scenario.
+    async fn recipe_for(
+        &self,
+        input: RecipeForInput,
+    ) -> Result<RecipeForOutput, RecoveryError>;
+
+    /// Check whether recovery can be attempted for a scenario.
+    ///
+    /// Considers the recipe's `max_attempts` and the current attempt
+    /// count (tracked in `RecoveryContext`).
+    async fn can_attempt(
+        &self,
+        input: CanAttemptInput,
+    ) -> Result<CanAttemptOutput, RecoveryError>;
+
+    /// Validate a recipe configuration.
+    ///
+    /// Checks:
+    /// - Steps list is non-empty
+    /// - `max_attempts` >= 1
+    /// - Step parameters are valid (e.g., timeout > 0)
+    /// - If `require_safe_steps`, all steps must be `is_safe() == true`
+    async fn validate_recipe(
+        &self,
+        input: ValidateRecipeInput,
+    ) -> Result<ValidateRecipeOutput, RecoveryError>;
+
+    /// Get the default recipe catalog.
+    ///
+    /// Returns the canonical set of built-in recipes. This is a convenience
+    /// method that delegates to `RecoveryRecipe::default_catalog()`.
+    fn default_catalog(&self) -> Vec<RecoveryRecipe>;
+
+    /// Register a custom recipe override.
+    ///
+    /// Custom recipes take precedence over the default catalog.
+    /// Returns the previous recipe for the same scenario, if any.
+    async fn register_recipe(
+        &self,
+        recipe: RecoveryRecipe,
+    ) -> Result<Option<RecoveryRecipe>, RecoveryError>;
+}

--- a/engine/src/recovery_recipes/domain/error.rs
+++ b/engine/src/recovery_recipes/domain/error.rs
@@ -1,0 +1,70 @@
+//! Recovery error types for the recovery-recipes bounded context.
+//!
+//! @canonical .pi/architecture/modules/recovery-recipes.md#error-handling
+//! Implements: Contract Freeze — RecoveryError enum
+//! Issue: #438 (recovery-recipes epic)
+//!
+//! All errors use `thiserror` derive macros. No `anyhow` in library code.
+//!
+//! # Contract (Frozen)
+//! - `RecoveryError` is the single error type for this module
+//! - Each variant carries structured context for error reporting
+//! - Implements `std::error::Error` for library compatibility
+//! - Converted to `CoreOrchestratorError` via `#[from]` at the orchestrator level
+
+use thiserror::Error;
+
+use super::scenario::FailureScenario;
+use super::step::RecoveryStep;
+
+/// Errors that can occur during recovery recipe execution.
+#[derive(Debug, Error)]
+pub enum RecoveryError {
+    /// No recipe is configured for the given scenario.
+    #[error("No recipe for scenario: {0:?}")]
+    NoRecipe(FailureScenario),
+
+    /// Maximum automatic recovery attempts have been reached.
+    #[error("Max recovery attempts reached for {0:?}")]
+    MaxAttemptsReached(FailureScenario),
+
+    /// A specific recovery step failed during execution.
+    #[error("Recovery step failed: {step:?} — {reason}")]
+    StepFailed {
+        /// The step that failed.
+        step: RecoveryStep,
+        /// Human-readable description of the failure.
+        reason: String,
+    },
+
+    /// Recovery was aborted by a cancellation signal.
+    #[error("Recovery aborted by cancellation signal")]
+    Aborted,
+
+    /// The recipe configuration is invalid.
+    #[error("Invalid recipe configuration: {detail}")]
+    InvalidConfiguration {
+        /// Details about why the configuration is invalid.
+        detail: String,
+    },
+
+    /// A required dependency (event bus, service, etc.) is unavailable.
+    #[error("Dependency unavailable: {dependency} — {reason}")]
+    DependencyUnavailable {
+        /// Name of the unavailable dependency.
+        dependency: String,
+        /// Details about the failure.
+        reason: String,
+    },
+}
+
+impl RecoveryError {
+    /// Returns `true` if this error represents a transient condition
+    /// that might succeed on retry.
+    pub fn is_retriable(&self) -> bool {
+        matches!(
+            self,
+            RecoveryError::Aborted | RecoveryError::DependencyUnavailable { .. }
+        )
+    }
+}

--- a/engine/src/recovery_recipes/domain/escalation.rs
+++ b/engine/src/recovery_recipes/domain/escalation.rs
@@ -1,0 +1,105 @@
+//! EscalationPolicy — what to do when recovery attempts are exhausted.
+//!
+//! @canonical .pi/architecture/modules/recovery-recipes.md#escalation
+//! Implements: Contract Freeze — EscalationPolicy enum
+//! Issue: #438 (recovery-recipes epic)
+//!
+//! # Contract (Frozen)
+//! - Three mutually exclusive escalation behaviors
+//! - `AlertHuman` notifies operators and continues execution
+//! - `LogAndContinue` silently logs and moves on
+//! - `Abort` terminates the executing session
+//! - Implements `Clone`, `Debug`, `PartialEq`, `Eq` for testability
+//! - Serialization support for configuration and API responses
+
+use serde::{Deserialize, Serialize};
+
+/// Defines what action to take when automatic recovery attempts are
+/// exhausted for a given `FailureScenario`.
+///
+/// Attached to each `RecoveryRecipe` as its `escalation_policy`.
+/// The policy is evaluated after `max_attempts` have been consumed
+/// without a successful recovery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EscalationPolicy {
+    /// Alert a human operator (e.g., via notification, event, or log)
+    /// and allow execution to continue (the failed node is marked as Failed).
+    AlertHuman,
+
+    /// Log the exhaustion event and continue execution silently.
+    /// Use sparingly — can mask systemic issues.
+    LogAndContinue,
+
+    /// Abort the entire execution session immediately.
+    /// Reserved for scenarios where continuation would cause data loss
+    /// or cascading failures.
+    Abort,
+}
+
+impl EscalationPolicy {
+    /// Returns the canonical snake_case name of this policy.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            EscalationPolicy::AlertHuman => "alert_human",
+            EscalationPolicy::LogAndContinue => "log_and_continue",
+            EscalationPolicy::Abort => "abort",
+        }
+    }
+
+    /// Returns a human-readable description of this policy.
+    pub fn description(&self) -> &'static str {
+        match self {
+            EscalationPolicy::AlertHuman => "Alert a human operator and continue",
+            EscalationPolicy::LogAndContinue => "Log and continue execution silently",
+            EscalationPolicy::Abort => "Abort the entire execution session",
+        }
+    }
+
+    /// Returns `true` if execution can continue after this policy is applied.
+    pub fn allows_continuation(&self) -> bool {
+        matches!(
+            self,
+            EscalationPolicy::AlertHuman | EscalationPolicy::LogAndContinue
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_as_str() {
+        assert_eq!(EscalationPolicy::AlertHuman.as_str(), "alert_human");
+        assert_eq!(EscalationPolicy::LogAndContinue.as_str(), "log_and_continue");
+        assert_eq!(EscalationPolicy::Abort.as_str(), "abort");
+    }
+
+    #[test]
+    fn test_description() {
+        assert!(!EscalationPolicy::AlertHuman.description().is_empty());
+        assert!(!EscalationPolicy::LogAndContinue.description().is_empty());
+        assert!(!EscalationPolicy::Abort.description().is_empty());
+    }
+
+    #[test]
+    fn test_allows_continuation() {
+        assert!(EscalationPolicy::AlertHuman.allows_continuation());
+        assert!(EscalationPolicy::LogAndContinue.allows_continuation());
+        assert!(!EscalationPolicy::Abort.allows_continuation());
+    }
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        for variant in &[
+            EscalationPolicy::AlertHuman,
+            EscalationPolicy::LogAndContinue,
+            EscalationPolicy::Abort,
+        ] {
+            let json = serde_json::to_string(variant).unwrap();
+            let deserialized: EscalationPolicy = serde_json::from_str(&json).unwrap();
+            assert_eq!(*variant, deserialized);
+        }
+    }
+}

--- a/engine/src/recovery_recipes/domain/event.rs
+++ b/engine/src/recovery_recipes/domain/event.rs
@@ -1,0 +1,241 @@
+//! RecoveryEvent — event payload schemas for the recovery-recipes bounded context.
+//!
+//! @canonical .pi/architecture/modules/recovery-recipes.md#event
+//! Implements: Contract Freeze — RecoveryEvent payload schemas
+//! Issue: #438 (recovery-recipes epic)
+//!
+//! These events are emitted on the `EventBus` whenever a recovery attempt
+//! is made, succeeds, fails, or requires escalation. Consumers (audit,
+//! console printer, TUI) subscribe to these event types.
+//!
+//! # Contract (Frozen)
+//! - Each event carries the full context needed by consumers
+//! - No internal implementation details exposed
+//! - `sequence` is populated by EventBus at emission time
+
+use serde::{Deserialize, Serialize};
+
+use super::result::RecoveryResult;
+use super::scenario::FailureScenario;
+use super::step::RecoveryStep;
+
+/// Events emitted by the Recovery Recipes module.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum RecoveryEvent {
+    /// A recovery attempt was initiated for a failure scenario.
+    RecoveryAttempted {
+        /// The failure scenario being recovered.
+        scenario: FailureScenario,
+        /// The recipe step being attempted.
+        step: RecoveryStep,
+        /// Attempt number (1-based).
+        attempt_number: u32,
+    },
+
+    /// A recovery attempt completed successfully.
+    RecoverySucceeded {
+        /// The failure scenario that was recovered.
+        scenario: FailureScenario,
+        /// Number of steps taken to recover.
+        steps_taken: u32,
+        /// The final recovery result.
+        result: RecoveryResult,
+    },
+
+    /// A recovery attempt failed.
+    RecoveryFailed {
+        /// The failure scenario that could not be recovered.
+        scenario: FailureScenario,
+        /// The step that failed.
+        failed_step: RecoveryStep,
+        /// Human-readable reason for the failure.
+        reason: String,
+        /// Whether this was the final attempt before escalation.
+        is_final_attempt: bool,
+    },
+
+    /// A recovery was escalated (all automatic attempts exhausted).
+    Escalated {
+        /// The failure scenario that was escalated.
+        scenario: FailureScenario,
+        /// Total number of attempts made before escalation.
+        attempts_made: u32,
+        /// Human-readable reason for escalation.
+        reason: String,
+    },
+
+    /// A recovery recipe was not found for a scenario.
+    /// This is an informational event — the execution engine will
+    /// escalate the failure to the node's standard retry logic.
+    RecipeNotFound {
+        /// The failure scenario that has no recipe.
+        scenario: FailureScenario,
+        /// The error message from the original failure.
+        original_error: String,
+    },
+}
+
+impl RecoveryEvent {
+    /// Returns a human-readable log line for this event.
+    pub fn log_line(&self) -> String {
+        match self {
+            RecoveryEvent::RecoveryAttempted {
+                scenario,
+                step,
+                attempt_number,
+            } => {
+                format!(
+                    "[Recovery] Attempt #{} for {:?}: {:?}",
+                    attempt_number, scenario, step
+                )
+            }
+            RecoveryEvent::RecoverySucceeded {
+                scenario,
+                steps_taken,
+                ..
+            } => {
+                format!(
+                    "[Recovery] Succeeded for {:?} ({} step(s))",
+                    scenario, steps_taken
+                )
+            }
+            RecoveryEvent::RecoveryFailed {
+                scenario,
+                failed_step,
+                reason,
+                is_final_attempt,
+            } => {
+                let final_tag = if *is_final_attempt { " [FINAL]" } else { "" };
+                format!(
+                    "[Recovery] Failed for {:?} at step {:?}: {}{}",
+                    scenario, failed_step, reason, final_tag
+                )
+            }
+            RecoveryEvent::Escalated {
+                scenario,
+                attempts_made,
+                reason,
+            } => {
+                format!(
+                    "[Recovery] Escalated for {:?} after {} attempt(s): {}",
+                    scenario, attempts_made, reason
+                )
+            }
+            RecoveryEvent::RecipeNotFound {
+                scenario,
+                original_error,
+            } => {
+                format!(
+                    "[Recovery] No recipe for {:?}: {}",
+                    scenario, original_error
+                )
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_log_line_attempted() {
+        let event = RecoveryEvent::RecoveryAttempted {
+            scenario: FailureScenario::CompileError,
+            step: RecoveryStep::CleanBuild,
+            attempt_number: 1,
+        };
+        let log = event.log_line();
+        assert!(log.contains("CompileError"));
+        assert!(log.contains("CleanBuild"));
+        assert!(log.contains("Attempt #1"));
+    }
+
+    #[test]
+    fn test_log_line_succeeded() {
+        let event = RecoveryEvent::RecoverySucceeded {
+            scenario: FailureScenario::CompileError,
+            steps_taken: 1,
+            result: RecoveryResult::Recovered { steps_taken: 1 },
+        };
+        let log = event.log_line();
+        assert!(log.contains("Succeeded"));
+        assert!(log.contains("CompileError"));
+    }
+
+    #[test]
+    fn test_log_line_failed() {
+        let event = RecoveryEvent::RecoveryFailed {
+            scenario: FailureScenario::TestFailure,
+            failed_step: RecoveryStep::ExpandContext,
+            reason: "context window full".to_string(),
+            is_final_attempt: true,
+        };
+        let log = event.log_line();
+        assert!(log.contains("Failed"));
+        assert!(log.contains("TestFailure"));
+        assert!(log.contains("FINAL"));
+    }
+
+    #[test]
+    fn test_log_line_escalated() {
+        let event = RecoveryEvent::Escalated {
+            scenario: FailureScenario::ProviderFailure,
+            attempts_made: 2,
+            reason: "provider still unavailable".to_string(),
+        };
+        let log = event.log_line();
+        assert!(log.contains("Escalated"));
+        assert!(log.contains("ProviderFailure"));
+    }
+
+    #[test]
+    fn test_log_line_recipe_not_found() {
+        let event = RecoveryEvent::RecipeNotFound {
+            scenario: FailureScenario::CompileError,
+            original_error: "build failed".to_string(),
+        };
+        let log = event.log_line();
+        assert!(log.contains("No recipe"));
+    }
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        let events = vec![
+            RecoveryEvent::RecoveryAttempted {
+                scenario: FailureScenario::CompileError,
+                step: RecoveryStep::CleanBuild,
+                attempt_number: 1,
+            },
+            RecoveryEvent::RecoverySucceeded {
+                scenario: FailureScenario::CompileError,
+                steps_taken: 1,
+                result: RecoveryResult::Recovered { steps_taken: 1 },
+            },
+            RecoveryEvent::RecoveryFailed {
+                scenario: FailureScenario::TestFailure,
+                failed_step: RecoveryStep::ExpandContext,
+                reason: "test failure".to_string(),
+                is_final_attempt: true,
+            },
+            RecoveryEvent::Escalated {
+                scenario: FailureScenario::ProviderFailure,
+                attempts_made: 2,
+                reason: "exhausted".to_string(),
+            },
+            RecoveryEvent::RecipeNotFound {
+                scenario: FailureScenario::CompileError,
+                original_error: "build error".to_string(),
+            },
+        ];
+
+        for event in events {
+            let json = serde_json::to_string(&event).unwrap();
+            let deserialized: RecoveryEvent = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                format!("{:?}", event),
+                format!("{:?}", deserialized)
+            );
+        }
+    }
+}

--- a/engine/src/recovery_recipes/domain/mod.rs
+++ b/engine/src/recovery_recipes/domain/mod.rs
@@ -1,0 +1,34 @@
+//! Domain entities and interfaces for the Recovery Recipes bounded context.
+//!
+//! @canonical .pi/architecture/modules/recovery-recipes.md
+//! Implements: Contract Freeze — FailureScenario, RecoveryStep, RecoveryRecipe,
+//!              EscalationPolicy, RecoveryResult, RecoveryEvent, RecoveryError
+//! Issue: #438 (recovery-recipes epic)
+//!
+//! This module defines the core domain types — `FailureScenario`,
+//! `RecoveryStep`, `RecoveryRecipe`, `EscalationPolicy`, `RecoveryResult`,
+//! `RecoveryEvent`, and `RecoveryError`. These are pure domain objects with
+//! no framework dependencies. They serve as the frozen contract that all
+//! implementations must satisfy.
+//!
+//! # Contract Freeze
+//! - No implementation logic beyond enum variants, accessors, and constructors
+//! - All recovery orchestration logic must happen in the application layer
+//! - All persistence must happen behind repository interfaces
+//! - The FailureScenario ↔ RecoveryRecipe mapping is the core domain invariant
+
+pub mod error;
+pub mod escalation;
+pub mod event;
+pub mod recipe;
+pub mod result;
+pub mod scenario;
+pub mod step;
+
+pub use error::RecoveryError;
+pub use escalation::EscalationPolicy;
+pub use event::RecoveryEvent;
+pub use recipe::RecoveryRecipe;
+pub use result::RecoveryResult;
+pub use scenario::FailureScenario;
+pub use step::RecoveryStep;

--- a/engine/src/recovery_recipes/domain/recipe.rs
+++ b/engine/src/recovery_recipes/domain/recipe.rs
@@ -1,0 +1,269 @@
+//! RecoveryRecipe — binds a scenario to its recovery steps and escalation policy.
+//!
+//! @canonical .pi/architecture/modules/recovery-recipes.md#recoveryrecipe
+//! Implements: Contract Freeze — RecoveryRecipe struct
+//! Issue: #438 (recovery-recipes epic)
+//!
+//! # Contract (Frozen)
+//! - A recipe is an immutable value object once constructed
+//! - `scenario` identifies which failure scenario this recipe handles
+//! - `steps` is an ordered sequence of recovery actions to attempt
+//! - `max_attempts` limits how many automatic recovery cycles to attempt
+//! - `escalation_policy` defines behavior when attempts are exhausted
+//! - Implements `Clone`, `Debug`, `PartialEq`, `Eq` for testability
+//! - Serialization support for configuration files and API responses
+
+use serde::{Deserialize, Serialize};
+
+use super::escalation::EscalationPolicy;
+use super::scenario::FailureScenario;
+use super::step::RecoveryStep;
+
+/// Binds a `FailureScenario` to its ordered recovery steps and escalation policy.
+///
+/// A `RecoveryRecipe` defines what to do when a known failure scenario occurs:
+/// which recovery steps to execute, in what order, how many times to retry,
+/// and what to do when automatic recovery is exhausted.
+///
+/// # Built-in Recipe Catalog
+///
+/// | Scenario | Steps | Max Attempts | Escalation |
+/// |----------|-------|-------------|------------|
+/// | CompileError | CleanBuild → ExpandContext | 1 | AlertHuman |
+/// | TestFailure | ExpandContext | 1 | AlertHuman |
+/// | ToolConnectionError | RetryConnection(30s) → RestartService | 2 | AlertHuman |
+/// | ProviderFailure | RetryConnection(10s) → RetryConnection(60s) | 2 | AlertHuman |
+/// | PartialInitialization | RestartWorker | 1 | AlertHuman |
+/// | AuthorizationError | AcceptTrust | 1 | AlertHuman |
+/// | StaleBranch | RebaseBranch | 1 | LogAndContinue |
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecoveryRecipe {
+    /// The failure scenario this recipe handles.
+    pub scenario: FailureScenario,
+
+    /// Ordered sequence of recovery steps to attempt.
+    /// Steps are executed in order until one succeeds or all are exhausted.
+    pub steps: Vec<RecoveryStep>,
+
+    /// Maximum automatic recovery attempts for this scenario.
+    /// Must be >= 1. Enforced by the recovery engine: `max_attempts = 1`
+    /// means "try once, then escalate".
+    pub max_attempts: u32,
+
+    /// What to do when automatic recovery attempts are exhausted.
+    pub escalation_policy: EscalationPolicy,
+}
+
+impl RecoveryRecipe {
+    /// Create a new `RecoveryRecipe` with validation.
+    ///
+    /// Returns `Err(RecoveryError::InvalidConfiguration)` if:
+    /// - `steps` is empty
+    /// - `max_attempts` is 0
+    pub fn new(
+        scenario: FailureScenario,
+        steps: Vec<RecoveryStep>,
+        max_attempts: u32,
+        escalation_policy: EscalationPolicy,
+    ) -> Result<Self, super::error::RecoveryError> {
+        if steps.is_empty() {
+            return Err(super::error::RecoveryError::InvalidConfiguration {
+                detail: format!(
+                    "Recipe for {:?} must have at least one recovery step",
+                    scenario
+                ),
+            });
+        }
+        if max_attempts == 0 {
+            return Err(super::error::RecoveryError::InvalidConfiguration {
+                detail: format!(
+                    "Recipe for {:?} must have max_attempts >= 1",
+                    scenario
+                ),
+            });
+        }
+        Ok(Self {
+            scenario,
+            steps,
+            max_attempts,
+            escalation_policy,
+        })
+    }
+
+    /// Returns `true` if this recipe has remaining steps after `taken` steps.
+    pub fn has_remaining_steps(&self, taken: usize) -> bool {
+        taken < self.steps.len()
+    }
+
+    /// Returns the number of steps in this recipe.
+    pub fn step_count(&self) -> usize {
+        self.steps.len()
+    }
+
+    /// Build the default recipe catalog.
+    ///
+    /// Returns the canonical set of built-in recipes as defined in the
+    /// architecture module. Implementations may override individual recipes
+    /// via the `RecoveryRecipeRepository`.
+    pub fn default_catalog() -> Vec<Self> {
+        use super::escalation::EscalationPolicy::*;
+        use super::scenario::FailureScenario::*;
+        use super::step::RecoveryStep::*;
+
+        vec![
+            // CompileError: try clean build, then expand context
+            Self {
+                scenario: CompileError,
+                steps: vec![CleanBuild, ExpandContext],
+                max_attempts: 1,
+                escalation_policy: AlertHuman,
+            },
+            // TestFailure: expand context and retry
+            Self {
+                scenario: TestFailure,
+                steps: vec![ExpandContext],
+                max_attempts: 1,
+                escalation_policy: AlertHuman,
+            },
+            // ToolConnectionError: retry with timeout, then restart service
+            Self {
+                scenario: ToolConnectionError,
+                steps: vec![
+                    RetryConnection { timeout_ms: 30000 },
+                    RestartService {
+                        name: "external".to_string(),
+                    },
+                ],
+                max_attempts: 2,
+                escalation_policy: AlertHuman,
+            },
+            // ProviderFailure: retry with escalating timeout
+            Self {
+                scenario: ProviderFailure,
+                steps: vec![
+                    RetryConnection { timeout_ms: 10000 },
+                    RetryConnection { timeout_ms: 60000 },
+                ],
+                max_attempts: 2,
+                escalation_policy: AlertHuman,
+            },
+            // PartialInitialization: restart the worker
+            Self {
+                scenario: PartialInitialization,
+                steps: vec![RestartWorker],
+                max_attempts: 1,
+                escalation_policy: AlertHuman,
+            },
+            // AuthorizationError: auto-accept trust
+            Self {
+                scenario: AuthorizationError,
+                steps: vec![AcceptTrust],
+                max_attempts: 1,
+                escalation_policy: AlertHuman,
+            },
+            // StaleBranch: rebase onto main
+            Self {
+                scenario: StaleBranch,
+                steps: vec![RebaseBranch],
+                max_attempts: 1,
+                escalation_policy: LogAndContinue,
+            },
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_recipe() {
+        let recipe = RecoveryRecipe::new(
+            FailureScenario::CompileError,
+            vec![RecoveryStep::CleanBuild],
+            1,
+            EscalationPolicy::AlertHuman,
+        );
+        assert!(recipe.is_ok());
+        let recipe = recipe.unwrap();
+        assert_eq!(recipe.scenario, FailureScenario::CompileError);
+        assert_eq!(recipe.steps.len(), 1);
+        assert_eq!(recipe.max_attempts, 1);
+        assert_eq!(recipe.escalation_policy, EscalationPolicy::AlertHuman);
+    }
+
+    #[test]
+    fn test_empty_steps_rejected() {
+        let recipe = RecoveryRecipe::new(
+            FailureScenario::CompileError,
+            vec![],
+            1,
+            EscalationPolicy::AlertHuman,
+        );
+        assert!(recipe.is_err());
+    }
+
+    #[test]
+    fn test_zero_max_attempts_rejected() {
+        let recipe = RecoveryRecipe::new(
+            FailureScenario::CompileError,
+            vec![RecoveryStep::CleanBuild],
+            0,
+            EscalationPolicy::AlertHuman,
+        );
+        assert!(recipe.is_err());
+    }
+
+    #[test]
+    fn test_has_remaining_steps() {
+        let recipe = RecoveryRecipe::new(
+            FailureScenario::CompileError,
+            vec![RecoveryStep::CleanBuild, RecoveryStep::ExpandContext],
+            1,
+            EscalationPolicy::AlertHuman,
+        )
+        .unwrap();
+        assert!(recipe.has_remaining_steps(0));
+        assert!(recipe.has_remaining_steps(1));
+        assert!(!recipe.has_remaining_steps(2));
+    }
+
+    #[test]
+    fn test_default_catalog_contains_all_scenarios() {
+        let catalog = RecoveryRecipe::default_catalog();
+        let scenarios: Vec<FailureScenario> = catalog.iter().map(|r| r.scenario).collect();
+
+        assert!(scenarios.contains(&FailureScenario::CompileError));
+        assert!(scenarios.contains(&FailureScenario::TestFailure));
+        assert!(scenarios.contains(&FailureScenario::ToolConnectionError));
+        assert!(scenarios.contains(&FailureScenario::ProviderFailure));
+        assert!(scenarios.contains(&FailureScenario::PartialInitialization));
+        assert!(scenarios.contains(&FailureScenario::AuthorizationError));
+        assert!(scenarios.contains(&FailureScenario::StaleBranch));
+        assert_eq!(catalog.len(), 7);
+    }
+
+    #[test]
+    fn test_default_catalog_steps_not_empty() {
+        for recipe in RecoveryRecipe::default_catalog() {
+            assert!(
+                !recipe.steps.is_empty(),
+                "Recipe for {:?} has no steps",
+                recipe.scenario
+            );
+        }
+    }
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        let recipe = RecoveryRecipe {
+            scenario: FailureScenario::CompileError,
+            steps: vec![RecoveryStep::CleanBuild, RecoveryStep::ExpandContext],
+            max_attempts: 1,
+            escalation_policy: EscalationPolicy::AlertHuman,
+        };
+        let json = serde_json::to_string(&recipe).unwrap();
+        let deserialized: RecoveryRecipe = serde_json::from_str(&json).unwrap();
+        assert_eq!(recipe, deserialized);
+    }
+}

--- a/engine/src/recovery_recipes/domain/result.rs
+++ b/engine/src/recovery_recipes/domain/result.rs
@@ -1,0 +1,183 @@
+//! RecoveryResult — outcome of a recovery recipe execution.
+//!
+//! @canonical .pi/architecture/modules/recovery-recipes.md#recoveryresult
+//! Implements: Contract Freeze — RecoveryResult enum
+//! Issue: #438 (recovery-recipes epic)
+//!
+//! # Contract (Frozen)
+//! - Three mutually exclusive outcomes
+//! - `Recovered` — all steps completed, node can re-execute
+//! - `PartialRecovery` — some steps succeeded, node might still recover
+//! - `EscalationRequired` — automatic recovery exhausted, escalation needed
+//! - Implements `Clone`, `Debug`, `PartialEq`, `Eq` for testability
+//! - Serialization support for eventing and API responses
+
+use serde::{Deserialize, Serialize};
+
+use super::step::RecoveryStep;
+
+/// Outcome of executing a `RecoveryRecipe` for a given `FailureScenario`.
+///
+/// The result determines how the execution engine proceeds:
+/// - `Recovered`: re-execute the failed node
+/// - `PartialRecovery`: re-execute with partial state (some steps succeeded)
+/// - `EscalationRequired`: apply escalation policy (alert, skip, or abort)
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecoveryResult {
+    /// All recovery steps completed successfully.
+    /// The execution engine should re-execute the failed node.
+    Recovered {
+        /// Number of recovery steps that were executed.
+        steps_taken: u32,
+    },
+
+    /// Some steps succeeded, some could not run or failed.
+    /// The execution engine may re-execute with partial recovery state.
+    PartialRecovery {
+        /// Steps that completed successfully.
+        recovered: Vec<RecoveryStep>,
+        /// Steps that could not be executed or failed.
+        remaining: Vec<RecoveryStep>,
+    },
+
+    /// Automatic recovery attempts exhausted — escalation is required.
+    /// The execution engine should apply the recipe's `EscalationPolicy`.
+    EscalationRequired {
+        /// Human-readable reason for the escalation.
+        reason: String,
+    },
+}
+
+impl RecoveryResult {
+    /// Returns `true` if this result indicates successful recovery.
+    pub fn is_recovered(&self) -> bool {
+        matches!(self, RecoveryResult::Recovered { .. })
+    }
+
+    /// Returns `true` if this result indicates partial recovery.
+    pub fn is_partial(&self) -> bool {
+        matches!(self, RecoveryResult::PartialRecovery { .. })
+    }
+
+    /// Returns `true` if escalation is required.
+    pub fn is_escalation_required(&self) -> bool {
+        matches!(self, RecoveryResult::EscalationRequired { .. })
+    }
+
+    /// Returns the number of steps that were successfully executed.
+    pub fn steps_executed(&self) -> u32 {
+        match self {
+            RecoveryResult::Recovered { steps_taken } => *steps_taken,
+            RecoveryResult::PartialRecovery { recovered, .. } => recovered.len() as u32,
+            RecoveryResult::EscalationRequired { .. } => 0,
+        }
+    }
+
+    /// Returns a human-readable summary of this result.
+    pub fn summary(&self) -> String {
+        match self {
+            RecoveryResult::Recovered { steps_taken } => {
+                format!("Recovered after {} step(s)", steps_taken)
+            }
+            RecoveryResult::PartialRecovery { recovered, remaining } => {
+                format!(
+                    "Partial recovery: {} succeeded, {} remaining",
+                    recovered.len(),
+                    remaining.len()
+                )
+            }
+            RecoveryResult::EscalationRequired { reason } => {
+                format!("Escalation required: {}", reason)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_recovered() {
+        let result = RecoveryResult::Recovered { steps_taken: 2 };
+        assert!(result.is_recovered());
+        assert!(!result.is_partial());
+        assert!(!result.is_escalation_required());
+    }
+
+    #[test]
+    fn test_is_partial() {
+        let result = RecoveryResult::PartialRecovery {
+            recovered: vec![RecoveryStep::CleanBuild],
+            remaining: vec![RecoveryStep::ExpandContext],
+        };
+        assert!(!result.is_recovered());
+        assert!(result.is_partial());
+        assert!(!result.is_escalation_required());
+    }
+
+    #[test]
+    fn test_is_escalation_required() {
+        let result = RecoveryResult::EscalationRequired {
+            reason: "max attempts reached".to_string(),
+        };
+        assert!(!result.is_recovered());
+        assert!(!result.is_partial());
+        assert!(result.is_escalation_required());
+    }
+
+    #[test]
+    fn test_steps_executed() {
+        assert_eq!(
+            RecoveryResult::Recovered { steps_taken: 3 }.steps_executed(),
+            3
+        );
+        assert_eq!(
+            RecoveryResult::PartialRecovery {
+                recovered: vec![RecoveryStep::CleanBuild],
+                remaining: vec![RecoveryStep::ExpandContext],
+            }
+            .steps_executed(),
+            1
+        );
+        assert_eq!(
+            RecoveryResult::EscalationRequired {
+                reason: "test".to_string()
+            }
+            .steps_executed(),
+            0
+        );
+    }
+
+    #[test]
+    fn test_summary() {
+        let result = RecoveryResult::Recovered { steps_taken: 1 };
+        assert_eq!(result.summary(), "Recovered after 1 step(s)");
+
+        let result = RecoveryResult::EscalationRequired {
+            reason: "max".to_string(),
+        };
+        assert!(result.summary().contains("Escalation required"));
+    }
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        let variants = vec![
+            RecoveryResult::Recovered { steps_taken: 2 },
+            RecoveryResult::PartialRecovery {
+                recovered: vec![RecoveryStep::CleanBuild],
+                remaining: vec![RecoveryStep::ExpandContext],
+            },
+            RecoveryResult::EscalationRequired {
+                reason: "max attempts".to_string(),
+            },
+        ];
+
+        for variant in variants {
+            let json = serde_json::to_string(&variant).unwrap();
+            let deserialized: RecoveryResult = serde_json::from_str(&json).unwrap();
+            assert_eq!(format!("{:?}", variant), format!("{:?}", deserialized));
+        }
+    }
+}

--- a/engine/src/recovery_recipes/domain/scenario.rs
+++ b/engine/src/recovery_recipes/domain/scenario.rs
@@ -1,0 +1,183 @@
+//! FailureScenario — typed enumeration of known recoverable failure scenarios.
+//!
+//! @canonical .pi/architecture/modules/recovery-recipes.md#failurescenario
+//! Implements: Contract Freeze — FailureScenario enum
+//! Issue: #438 (recovery-recipes epic)
+//!
+//! # Contract (Frozen)
+//! - Each variant corresponds to a known recoverable failure
+//! - Implements `Clone`, `Debug`, `PartialEq`, `Eq`, `Hash` for testability
+//! - Serialization support for eventing and API responses
+//! - `from_failure_type()` maps from `FailureType` (failure_classification) to
+//!   `FailureScenario` — returns `None` for unrecognized scenarios
+//! - `as_str()` returns snake_case name for serialization
+
+use serde::{Deserialize, Serialize};
+
+/// Typed enumeration of all known recoverable failure scenarios.
+///
+/// Each variant corresponds to a failure mode that has a configured
+/// `RecoveryRecipe`. Unknown failure types have no recipe and are
+/// escalated immediately.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureScenario {
+    /// Build failure (cargo build, npm build, etc.).
+    CompileError,
+    /// Test failure (non-compile test suite failure).
+    TestFailure,
+    /// Tool connection failure (LSP, MCP, external service).
+    ToolConnectionError,
+    /// LLM provider API failure (rate limit, timeout, 5xx).
+    ProviderFailure,
+    /// Partial initialization (some components started, some didn't).
+    PartialInitialization,
+    /// Authorization failure (trust prompt, API key, permission).
+    AuthorizationError,
+    /// Branch is stale relative to main.
+    StaleBranch,
+}
+
+impl FailureScenario {
+    /// Returns the canonical snake_case name of this scenario.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            FailureScenario::CompileError => "compile_error",
+            FailureScenario::TestFailure => "test_failure",
+            FailureScenario::ToolConnectionError => "tool_connection_error",
+            FailureScenario::ProviderFailure => "provider_failure",
+            FailureScenario::PartialInitialization => "partial_initialization",
+            FailureScenario::AuthorizationError => "authorization_error",
+            FailureScenario::StaleBranch => "stale_branch",
+        }
+    }
+
+    /// Returns a human-readable description of this scenario.
+    pub fn description(&self) -> &'static str {
+        match self {
+            FailureScenario::CompileError => "Build/compile failure (cargo build, npm build, etc.)",
+            FailureScenario::TestFailure => "Test suite failure (non-compile)",
+            FailureScenario::ToolConnectionError => {
+                "Tool connection failure (LSP, MCP, external service)"
+            }
+            FailureScenario::ProviderFailure => {
+                "LLM provider API failure (rate limit, timeout, 5xx)"
+            }
+            FailureScenario::PartialInitialization => {
+                "Partial initialization (some components started, some didn't)"
+            }
+            FailureScenario::AuthorizationError => {
+                "Authorization failure (trust prompt, API key, permission)"
+            }
+            FailureScenario::StaleBranch => "Branch is stale relative to main",
+        }
+    }
+
+    /// Map from `FailureType` (failure_classification module) to `FailureScenario`.
+    ///
+    /// Returns `None` when the failure type does not correspond to a known
+    /// recoverable scenario. The caller should escalate immediately in that case.
+    ///
+    /// # Current Mapping
+    ///
+    /// | FailureType | FailureScenario |
+    /// |-------------|-----------------|
+    /// | BuildFailure | CompileError |
+    /// | TestFailure | TestFailure |
+    /// | _ | None (escalate) |
+    ///
+    /// Additional mappings will be added when the failure_classification module
+    /// introduces new `FailureType` variants (e.g., ToolConnectionError,
+    /// LlmApiError, PartialInitialization, AuthorizationError, StaleBranch).
+    pub fn from_failure_type(
+        ft: &crate::failure_classification::domain::FailureType,
+    ) -> Option<Self> {
+        use crate::failure_classification::domain::FailureType;
+        match ft {
+            FailureType::BuildFailure => Some(Self::CompileError),
+            FailureType::TestFailure => Some(Self::TestFailure),
+            // Future FailureType variants to map when added:
+            // FailureType::ToolConnectionError => Some(Self::ToolConnectionError),
+            // FailureType::LlmApiError => Some(Self::ProviderFailure),
+            // FailureType::PartialInitialization => Some(Self::PartialInitialization),
+            // FailureType::AuthorizationError => Some(Self::AuthorizationError),
+            // FailureType::StaleBranch => Some(Self::StaleBranch),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_as_str() {
+        assert_eq!(FailureScenario::CompileError.as_str(), "compile_error");
+        assert_eq!(FailureScenario::TestFailure.as_str(), "test_failure");
+        assert_eq!(
+            FailureScenario::ToolConnectionError.as_str(),
+            "tool_connection_error"
+        );
+        assert_eq!(FailureScenario::ProviderFailure.as_str(), "provider_failure");
+        assert_eq!(
+            FailureScenario::PartialInitialization.as_str(),
+            "partial_initialization"
+        );
+        assert_eq!(
+            FailureScenario::AuthorizationError.as_str(),
+            "authorization_error"
+        );
+        assert_eq!(FailureScenario::StaleBranch.as_str(), "stale_branch");
+    }
+
+    #[test]
+    fn test_description() {
+        assert!(!FailureScenario::CompileError.description().is_empty());
+        assert!(!FailureScenario::TestFailure.description().is_empty());
+    }
+
+    #[test]
+    fn test_from_failure_type_build_failure() {
+        let result =
+            FailureScenario::from_failure_type(&crate::failure_classification::domain::FailureType::BuildFailure);
+        assert_eq!(result, Some(FailureScenario::CompileError));
+    }
+
+    #[test]
+    fn test_from_failure_type_test_failure() {
+        let result =
+            FailureScenario::from_failure_type(&crate::failure_classification::domain::FailureType::TestFailure);
+        assert_eq!(result, Some(FailureScenario::TestFailure));
+    }
+
+    #[test]
+    fn test_from_failure_type_unknown_returns_none() {
+        let result =
+            FailureScenario::from_failure_type(&crate::failure_classification::domain::FailureType::Transient);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        for variant in &[
+            FailureScenario::CompileError,
+            FailureScenario::TestFailure,
+            FailureScenario::ToolConnectionError,
+            FailureScenario::ProviderFailure,
+            FailureScenario::PartialInitialization,
+            FailureScenario::AuthorizationError,
+            FailureScenario::StaleBranch,
+        ] {
+            let json = serde_json::to_string(variant).unwrap();
+            let deserialized: FailureScenario = serde_json::from_str(&json).unwrap();
+            assert_eq!(*variant, deserialized);
+        }
+    }
+
+    #[test]
+    fn test_serde_rename() {
+        let json = serde_json::to_string(&FailureScenario::CompileError).unwrap();
+        assert_eq!(json, "\"compile_error\"");
+    }
+}

--- a/engine/src/recovery_recipes/domain/step.rs
+++ b/engine/src/recovery_recipes/domain/step.rs
@@ -1,0 +1,227 @@
+//! RecoveryStep — individual executable recovery actions.
+//!
+//! @canonical .pi/architecture/modules/recovery-recipes.md#recoverystep
+//! Implements: Contract Freeze — RecoveryStep enum
+//! Issue: #438 (recovery-recipes epic)
+//!
+//! # Contract (Frozen)
+//! - Each variant is a single atomic recovery action
+//! - Parameterized variants (RetryConnection, RestartService, EscalateToHuman)
+//!   carry typed fields for configuration
+//! - Implements `Clone`, `Debug`, `PartialEq`, `Eq` for testability
+//! - Serialization support for eventing and API responses
+//! - Display implementation for logging
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Individual executable recovery actions.
+///
+/// Each variant represents a single atomic recovery action that can be
+/// composed into a `RecoveryRecipe`. Steps are executed sequentially
+/// until one succeeds or all are exhausted.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecoveryStep {
+    /// Run a clean build (e.g., cargo clean && cargo build).
+    CleanBuild,
+
+    /// Retry the failed operation with expanded context (more file reads,
+    /// broader search scope, increased context window).
+    ExpandContext,
+
+    /// Retry a tool connection with a configurable timeout in milliseconds.
+    RetryConnection {
+        /// Timeout in milliseconds for the retry attempt.
+        #[serde(rename = "timeout_ms")]
+        timeout_ms: u64,
+    },
+
+    /// Restart an external service or daemon by name.
+    RestartService {
+        /// Name of the service to restart.
+        name: String,
+    },
+
+    /// Rebase the current branch onto main.
+    RebaseBranch,
+
+    /// Auto-accept a trust prompt for known repositories/tools.
+    AcceptTrust,
+
+    /// Restart the worker or executor process.
+    RestartWorker,
+
+    /// Escalate to a human operator with a reason.
+    EscalateToHuman {
+        /// Reason for escalation, as a human-readable string.
+        reason: String,
+    },
+}
+
+impl RecoveryStep {
+    /// Returns the canonical snake_case name of this step.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RecoveryStep::CleanBuild => "clean_build",
+            RecoveryStep::ExpandContext => "expand_context",
+            RecoveryStep::RetryConnection { .. } => "retry_connection",
+            RecoveryStep::RestartService { .. } => "restart_service",
+            RecoveryStep::RebaseBranch => "rebase_branch",
+            RecoveryStep::AcceptTrust => "accept_trust",
+            RecoveryStep::RestartWorker => "restart_worker",
+            RecoveryStep::EscalateToHuman { .. } => "escalate_to_human",
+        }
+    }
+
+    /// Returns a human-readable description of this step.
+    pub fn description(&self) -> &'static str {
+        match self {
+            RecoveryStep::CleanBuild => "Run a clean build from scratch",
+            RecoveryStep::ExpandContext => "Retry with expanded context",
+            RecoveryStep::RetryConnection { .. } => "Retry the connection with a timeout",
+            RecoveryStep::RestartService { .. } => "Restart an external service",
+            RecoveryStep::RebaseBranch => "Rebase the branch onto main",
+            RecoveryStep::AcceptTrust => "Auto-accept trust prompt",
+            RecoveryStep::RestartWorker => "Restart the worker process",
+            RecoveryStep::EscalateToHuman { .. } => "Escalate to a human operator",
+        }
+    }
+
+    /// Returns `true` if this step is considered safe to auto-execute
+    /// (no destructive side effects beyond the intended recovery).
+    pub fn is_safe(&self) -> bool {
+        match self {
+            RecoveryStep::CleanBuild
+            | RecoveryStep::ExpandContext
+            | RecoveryStep::RetryConnection { .. }
+            | RecoveryStep::RebaseBranch
+            | RecoveryStep::AcceptTrust
+            | RecoveryStep::RestartWorker => true,
+            // RestartService and EscalateToHuman require human judgment
+            RecoveryStep::RestartService { .. } | RecoveryStep::EscalateToHuman { .. } => false,
+        }
+    }
+}
+
+impl fmt::Display for RecoveryStep {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RecoveryStep::CleanBuild => write!(f, "CleanBuild"),
+            RecoveryStep::ExpandContext => write!(f, "ExpandContext"),
+            RecoveryStep::RetryConnection { timeout_ms } => {
+                write!(f, "RetryConnection({}ms)", timeout_ms)
+            }
+            RecoveryStep::RestartService { name } => write!(f, "RestartService({})", name),
+            RecoveryStep::RebaseBranch => write!(f, "RebaseBranch"),
+            RecoveryStep::AcceptTrust => write!(f, "AcceptTrust"),
+            RecoveryStep::RestartWorker => write!(f, "RestartWorker"),
+            RecoveryStep::EscalateToHuman { reason } => write!(f, "EscalateToHuman({})", reason),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_as_str() {
+        assert_eq!(RecoveryStep::CleanBuild.as_str(), "clean_build");
+        assert_eq!(RecoveryStep::ExpandContext.as_str(), "expand_context");
+        assert_eq!(
+            RecoveryStep::RetryConnection { timeout_ms: 30000 }.as_str(),
+            "retry_connection"
+        );
+        assert_eq!(
+            RecoveryStep::RestartService {
+                name: "lsp".to_string()
+            }
+            .as_str(),
+            "restart_service"
+        );
+        assert_eq!(RecoveryStep::RebaseBranch.as_str(), "rebase_branch");
+        assert_eq!(RecoveryStep::AcceptTrust.as_str(), "accept_trust");
+        assert_eq!(RecoveryStep::RestartWorker.as_str(), "restart_worker");
+        assert_eq!(
+            RecoveryStep::EscalateToHuman {
+                reason: "test".to_string()
+            }
+            .as_str(),
+            "escalate_to_human"
+        );
+    }
+
+    #[test]
+    fn test_display_clean_build() {
+        assert_eq!(RecoveryStep::CleanBuild.to_string(), "CleanBuild");
+    }
+
+    #[test]
+    fn test_display_retry_connection() {
+        let step = RecoveryStep::RetryConnection { timeout_ms: 30000 };
+        assert_eq!(step.to_string(), "RetryConnection(30000ms)");
+    }
+
+    #[test]
+    fn test_display_restart_service() {
+        let step = RecoveryStep::RestartService {
+            name: "lsp".to_string(),
+        };
+        assert_eq!(step.to_string(), "RestartService(lsp)");
+    }
+
+    #[test]
+    fn test_display_escalate() {
+        let step = RecoveryStep::EscalateToHuman {
+            reason: "max attempts".to_string(),
+        };
+        assert_eq!(step.to_string(), "EscalateToHuman(max attempts)");
+    }
+
+    #[test]
+    fn test_is_safe_clean_build() {
+        assert!(RecoveryStep::CleanBuild.is_safe());
+    }
+
+    #[test]
+    fn test_is_safe_restart_service() {
+        assert!(!RecoveryStep::RestartService {
+            name: "test".to_string()
+        }
+        .is_safe());
+    }
+
+    #[test]
+    fn test_is_safe_escalate() {
+        assert!(!RecoveryStep::EscalateToHuman {
+            reason: "test".to_string()
+        }
+        .is_safe());
+    }
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        let steps = vec![
+            RecoveryStep::CleanBuild,
+            RecoveryStep::ExpandContext,
+            RecoveryStep::RetryConnection { timeout_ms: 30000 },
+            RecoveryStep::RestartService {
+                name: "lsp".to_string(),
+            },
+            RecoveryStep::RebaseBranch,
+            RecoveryStep::AcceptTrust,
+            RecoveryStep::RestartWorker,
+            RecoveryStep::EscalateToHuman {
+                reason: "test".to_string(),
+            },
+        ];
+
+        for step in steps {
+            let json = serde_json::to_string(&step).unwrap();
+            let deserialized: RecoveryStep = serde_json::from_str(&json).unwrap();
+            assert_eq!(format!("{:?}", step), format!("{:?}", deserialized));
+        }
+    }
+}

--- a/engine/src/recovery_recipes/infrastructure/mod.rs
+++ b/engine/src/recovery_recipes/infrastructure/mod.rs
@@ -1,0 +1,13 @@
+//! Infrastructure layer interfaces for the Recovery Recipes bounded context.
+//!
+//! @canonical .pi/architecture/modules/recovery-recipes.md
+//! Implements: Contract Freeze — repository interfaces
+//! Issue: #438 (recovery-recipes epic)
+//!
+//! This module defines repository interfaces that abstract data access
+//! behind traits. Implementations are provided by the concrete
+//! infrastructure module.
+
+pub mod repository;
+
+pub use repository::RecoveryRecipeRepository;

--- a/engine/src/recovery_recipes/infrastructure/repository.rs
+++ b/engine/src/recovery_recipes/infrastructure/repository.rs
@@ -1,0 +1,67 @@
+//! Repository interfaces for the Recovery Recipes bounded context.
+//!
+//! @canonical .pi/architecture/modules/recovery-recipes.md#repo
+//! Implements: Contract Freeze — RecoveryRecipeRepository trait
+//! Issue: #438 (recovery-recipes epic)
+//!
+//! Repositories abstract data access behind interfaces, allowing
+//! implementations to use filesystem, environment, or mock storage
+//! without coupling domain logic to infrastructure.
+//!
+//! # Contract (Frozen)
+//! - All repository methods are async
+//! - All methods return domain error types
+//! - No framework-specific annotations on trait definitions
+//! - Implementations are hidden behind these interfaces
+
+use async_trait::async_trait;
+
+use crate::recovery_recipes::domain::{FailureScenario, RecoveryError, RecoveryRecipe};
+
+/// Repository for storing and retrieving recovery recipes.
+///
+/// Implementations can store recipes in memory, on disk, or in a database.
+/// The repository is the single source of truth for recipe configuration,
+/// including custom overrides that take precedence over built-in defaults.
+///
+/// # Security
+/// - Recipe steps are predefined — no arbitrary command injection possible
+/// - `max_attempts` is validated to be >= 1
+/// - Steps must be non-empty
+#[async_trait]
+pub trait RecoveryRecipeRepository: Send + Sync {
+    /// Retrieve the recipe for a given failure scenario.
+    ///
+    /// Checks custom recipes first, then falls back to the default catalog.
+    /// Returns `None` if no recipe is configured for the scenario.
+    async fn recipe_for(
+        &self,
+        scenario: FailureScenario,
+    ) -> Result<Option<RecoveryRecipe>, RecoveryError>;
+
+    /// Store a custom recipe override.
+    ///
+    /// Custom recipes take precedence over the default catalog.
+    /// Returns the previous recipe for the same scenario, if any.
+    async fn store_recipe(
+        &self,
+        recipe: RecoveryRecipe,
+    ) -> Result<Option<RecoveryRecipe>, RecoveryError>;
+
+    /// Retrieve all stored custom recipes.
+    ///
+    /// Returns a map of scenario → recipe for registered overrides only
+    /// (does not include built-in defaults).
+    async fn all_recipes(&self) -> Result<Vec<RecoveryRecipe>, RecoveryError>;
+
+    /// Remove a custom recipe override for the given scenario.
+    ///
+    /// Returns `true` if a recipe existed and was removed, `false` otherwise.
+    async fn remove_recipe(
+        &self,
+        scenario: FailureScenario,
+    ) -> Result<bool, RecoveryError>;
+
+    /// Clear all custom recipe overrides, resetting to the default catalog.
+    async fn clear_recipes(&self) -> Result<(), RecoveryError>;
+}

--- a/engine/src/recovery_recipes/interfaces/http.rs
+++ b/engine/src/recovery_recipes/interfaces/http.rs
@@ -1,0 +1,260 @@
+//! HTTP API contracts for Recovery Recipes endpoints.
+//!
+//! @canonical .pi/architecture/modules/recovery-recipes.md
+//! Implements: Contract Freeze — HTTP endpoint contracts and error formats
+//! Issue: #438 (recovery-recipes epic)
+//!
+//! Defines endpoint paths, methods, request/response schemas, and error
+//! response formats. These contracts are framework-agnostic — they describe
+//! the API surface that any HTTP server implementation must satisfy.
+//!
+//! # Contract (Frozen)
+//! - All endpoints documented with method, path, request, and response types
+//! - Error responses follow a unified format
+//! - No framework-specific annotations (axum/actix/warp annotations added by implementation)
+
+use serde::{Deserialize, Serialize};
+
+use crate::recovery_recipes::application::dto::{
+    AttemptRecoveryInput, AttemptRecoveryOutput, CanAttemptInput, CanAttemptOutput,
+    RecipeForInput, RecipeForOutput,
+};
+
+use crate::recovery_recipes::domain::{FailureScenario, RecoveryRecipe, RecoveryResult, RecoveryStep};
+
+// ---------------------------------------------------------------------------
+// API Base Path
+// ---------------------------------------------------------------------------
+
+/// All recovery recipes endpoints are served under this base path.
+pub const API_BASE_PATH: &str = "/api/v1/recovery";
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/recovery/attempt
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/recovery/attempt
+///
+/// Attempt recovery for a given failure scenario using its configured recipe.
+///
+/// **Request:** `AttemptRecoveryRequest`
+/// **Response:** `200 OK` with `AttemptRecoveryResponse`
+pub const ATTEMPT_PATH: &str = "/api/v1/recovery/attempt";
+pub const ATTEMPT_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/recovery/attempt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttemptRecoveryRequest {
+    /// The failure scenario to recover from.
+    pub scenario: FailureScenario,
+    /// The recipe to use for recovery steps.
+    pub recipe: RecoveryRecipe,
+    /// Current attempt number (1-based).
+    pub attempt_number: u32,
+    /// Optional original error message.
+    pub original_error: Option<String>,
+    /// Optional execution ID for audit logging.
+    pub execution_id: Option<String>,
+}
+
+impl From<AttemptRecoveryRequest> for AttemptRecoveryInput {
+    fn from(req: AttemptRecoveryRequest) -> Self {
+        Self {
+            scenario: req.scenario,
+            recipe: req.recipe,
+            attempt_number: req.attempt_number,
+            original_error: req.original_error,
+            execution_id: req.execution_id,
+        }
+    }
+}
+
+/// Response body for POST /api/v1/recovery/attempt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttemptRecoveryResponse {
+    pub success: bool,
+    pub result: RecoveryResult,
+    pub last_step: Option<RecoveryStep>,
+    pub is_final_attempt: bool,
+    pub summary: String,
+}
+
+impl From<AttemptRecoveryOutput> for AttemptRecoveryResponse {
+    fn from(output: AttemptRecoveryOutput) -> Self {
+        Self {
+            success: output.result.is_recovered() || output.result.is_partial(),
+            result: output.result,
+            last_step: output.last_step,
+            is_final_attempt: output.is_final_attempt,
+            summary: output.summary,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/recovery/recipe
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/recovery/recipe
+///
+/// Look up the recovery recipe for a given failure scenario.
+///
+/// **Request:** `RecipeForRequest`
+/// **Response:** `200 OK` with `RecipeForResponse`
+pub const RECIPE_PATH: &str = "/api/v1/recovery/recipe";
+pub const RECIPE_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/recovery/recipe.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecipeForRequest {
+    /// The failure scenario to find a recipe for.
+    pub scenario: FailureScenario,
+}
+
+impl From<RecipeForRequest> for RecipeForInput {
+    fn from(req: RecipeForRequest) -> Self {
+        Self {
+            scenario: req.scenario,
+            custom_recipes: None,
+        }
+    }
+}
+
+/// Response body for POST /api/v1/recovery/recipe.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecipeForResponse {
+    pub success: bool,
+    pub recipe: Option<RecoveryRecipe>,
+    pub source: String,
+}
+
+impl From<RecipeForOutput> for RecipeForResponse {
+    fn from(output: RecipeForOutput) -> Self {
+        Self {
+            success: output.recipe.is_some(),
+            recipe: output.recipe,
+            source: format!("{:?}", output.source),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/recovery/can-attempt
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/recovery/can-attempt
+///
+/// Check whether recovery can be attempted for a failure scenario.
+///
+/// **Request:** `CanAttemptRequest`
+/// **Response:** `200 OK` with `CanAttemptResponse`
+pub const CAN_ATTEMPT_PATH: &str = "/api/v1/recovery/can-attempt";
+pub const CAN_ATTEMPT_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/recovery/can-attempt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CanAttemptRequest {
+    /// The failure scenario to check.
+    pub scenario: FailureScenario,
+    /// The recipe that would be used.
+    pub recipe: RecoveryRecipe,
+}
+
+impl From<CanAttemptRequest> for CanAttemptInput {
+    fn from(req: CanAttemptRequest) -> Self {
+        Self {
+            scenario: req.scenario,
+            recipe: req.recipe,
+        }
+    }
+}
+
+/// Response body for POST /api/v1/recovery/can-attempt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CanAttemptResponse {
+    pub can_attempt: bool,
+    pub reason: String,
+    pub remaining_attempts: u32,
+}
+
+impl From<CanAttemptOutput> for CanAttemptResponse {
+    fn from(output: CanAttemptOutput) -> Self {
+        Self {
+            can_attempt: output.can_attempt,
+            reason: output.reason,
+            remaining_attempts: output.remaining_attempts,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: GET /api/v1/recovery/recipes
+// ---------------------------------------------------------------------------
+
+/// GET /api/v1/recovery/recipes
+///
+/// Retrieve the default recovery recipe catalog.
+///
+/// **Request:** None
+/// **Response:** `200 OK` with `CatalogResponse`
+pub const CATALOG_PATH: &str = "/api/v1/recovery/recipes";
+pub const CATALOG_METHOD: &str = "GET";
+
+/// Response body for GET /api/v1/recovery/recipes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogResponse {
+    pub recipes: Vec<RecoveryRecipe>,
+}
+
+// ---------------------------------------------------------------------------
+// Unified Error Response Format
+// ---------------------------------------------------------------------------
+
+/// Standard error response for all Recovery Recipes API endpoints.
+///
+/// All 4xx/5xx responses use this format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiErrorResponse {
+    /// HTTP status code.
+    pub status: u16,
+    /// Machine-readable error code.
+    pub code: String,
+    /// Human-readable error message.
+    pub message: String,
+    /// Detailed error context (optional, may include field-level errors).
+    pub details: Option<serde_json::Value>,
+    /// Request ID for tracing (if available).
+    pub request_id: Option<String>,
+}
+
+/// Standardized error codes for Recovery Recipes API.
+pub mod error_codes {
+    /// No recipe configured for the given scenario.
+    pub const NO_RECIPE: &str = "NO_RECIPE";
+    /// Maximum recovery attempts reached.
+    pub const MAX_ATTEMPTS_REACHED: &str = "MAX_ATTEMPTS_REACHED";
+    /// A recovery step failed during execution.
+    pub const STEP_FAILED: &str = "STEP_FAILED";
+    /// Recovery was aborted by a cancellation signal.
+    pub const ABORTED: &str = "ABORTED";
+    /// Invalid recipe configuration.
+    pub const INVALID_CONFIGURATION: &str = "INVALID_CONFIGURATION";
+    /// A required dependency is unavailable.
+    pub const DEPENDENCY_UNAVAILABLE: &str = "DEPENDENCY_UNAVAILABLE";
+    /// Invalid input provided (empty steps, zero max_attempts, etc.).
+    pub const INVALID_INPUT: &str = "INVALID_INPUT";
+    /// Internal server error.
+    pub const INTERNAL_ERROR: &str = "INTERNAL_ERROR";
+}
+
+/// HTTP status code mappings for Recovery Recipes errors.
+pub mod status_codes {
+    pub const NO_RECIPE: u16 = 404;
+    pub const MAX_ATTEMPTS_REACHED: u16 = 429;
+    pub const STEP_FAILED: u16 = 500;
+    pub const ABORTED: u16 = 499;
+    pub const INVALID_CONFIGURATION: u16 = 422;
+    pub const DEPENDENCY_UNAVAILABLE: u16 = 503;
+    pub const INVALID_INPUT: u16 = 400;
+    pub const INTERNAL_ERROR: u16 = 500;
+}

--- a/engine/src/recovery_recipes/interfaces/mod.rs
+++ b/engine/src/recovery_recipes/interfaces/mod.rs
@@ -1,0 +1,10 @@
+//! Interface adapters for the Recovery Recipes bounded context.
+//!
+//! @canonical .pi/architecture/modules/recovery-recipes.md
+//! Implements: Contract Freeze — HTTP API endpoint contracts
+//! Issue: #438 (recovery-recipes epic)
+//!
+//! This module defines API contracts (HTTP, CLI, etc.) that external
+//! actors use to interact with the recovery recipes system.
+
+pub mod http;

--- a/engine/src/recovery_recipes/mod.rs
+++ b/engine/src/recovery_recipes/mod.rs
@@ -1,0 +1,46 @@
+//! Recovery Recipes bounded context.
+//!
+//! @canonical .pi/architecture/modules/recovery-recipes.md
+//! Implements: Contract Freeze — recovery-recipes module
+//! Issue: #438 (recovery-recipes epic)
+//!
+//! This module encodes known failure scenarios and their automatic recovery
+//! procedures. The core rule is: **one automatic recovery attempt per scenario
+//! before human escalation.** Each failure scenario has a `RecoveryRecipe` —
+//! a sequence of recovery steps with a maximum attempt count and an escalation
+//! policy for when attempts are exhausted.
+//!
+//! # Architecture
+//!
+//! ```text
+//! recovery_recipes/
+//! ├── domain/               # Domain entities (FailureScenario, RecoveryStep, RecoveryRecipe,
+//! │   │                     #   EscalationPolicy, RecoveryResult, RecoveryEvent, RecoveryError)
+//! │   ├── error.rs          # RecoveryError enum
+//! │   ├── escalation.rs     # EscalationPolicy enum
+//! │   ├── event.rs          # RecoveryEvent payload schemas
+//! │   ├── recipe.rs         # RecoveryRecipe struct + default catalog
+//! │   ├── result.rs         # RecoveryResult enum
+//! │   ├── scenario.rs       # FailureScenario enum + FailureType mapping
+//! │   └── step.rs           # RecoveryStep enum
+//! ├── application/          # Service traits, DTOs, factory interfaces
+//! │   ├── context.rs        # RecoveryContext (per-session attempt tracker)
+//! │   ├── dto.rs            # Input/Output DTOs with validation
+//! │   └── service.rs        # RecoveryService trait
+//! ├── infrastructure/       # Repository interfaces
+//! │   └── repository.rs     # RecoveryRecipeRepository trait
+//! └── interfaces/           # API contracts
+//!     └── http.rs           # REST endpoint contracts
+//! ```
+//!
+//! # Contract Freeze Notice
+//!
+//! ALL files in this module are frozen contracts.
+//! - No implementation changes without explicit contract change approval
+//! - Implementation PRs MUST reference these interfaces
+//! - DTO schemas serve as the canonical data contract
+
+pub mod application;
+pub mod domain;
+pub mod infrastructure;
+pub mod interfaces;


### PR DESCRIPTION
Defines and freezes all public interfaces, contracts, and schemas for the recovery-recipes epic before implementation begins.

## Components Frozen
- FailureScenario — 7 recoverable failure scenarios with FailureType mapping
- RecoveryStep — 8 executable recovery actions with validation
- RecoveryRecipe — validated recipe struct with default catalog of 7 recipes
- EscalationPolicy — AlertHuman, LogAndContinue, Abort
- RecoveryResult — Recovered, PartialRecovery, EscalationRequired
- RecoveryContext — per-session attempt tracker and event log
- RecoveryEvent — 5 event payload schemas for audit trail

## Files Created
```
src/recovery_recipes/
├── mod.rs
├── domain/ (7 files: scenario, step, recipe, escalation, result, event, error)
├── application/ (3 files: service, context, dto)
├── infrastructure/ (1 file: repository)
└── interfaces/ (1 file: http.rs)
```

## Validation
- ✅ cargo build — clean
- ✅ cargo test — 50 tests pass
- ✅ CoreOrchestratorError updated with Recovery(#[from] RecoveryError)

Issue: Closes #438 (tracking) / Part of #438