### PR TITLE
feat: contract freeze for quality-gates module (#449, #450)

### DIFF
--- a/engine/.pi/issues/issue-greencontract.md
+++ b/engine/.pi/issues/issue-greencontract.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-QUALITY-GATES-2"
+  epic: "TBD"
+  component: "GreenContract"
+  module: "quality-gates"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement GreenContract for the quality-gates module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for greencontract
+    application:
+      - New service/handler for greencontract
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/quality-gates.md#greencontract"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Declares required quality level and evaluates observed level
+
+  file_changes:
+    - "create: src/quality-gates/greencontract/"
+    - "create: tests/unit/quality-gates/greencontract/"
+    - "create: tests/integration/quality-gates/greencontract/"
+---
+
+# ISSUE-QUALITY-GATES-2: GreenContract
+
+## Intent
+
+Declares required quality level and evaluates observed level
+
+## Architecture Context
+
+- **Module:** quality-gates
+- **Component:** GreenContract
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement GreenContract for the quality-gates module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for greencontract
+
+### Application
+- New service/handler for greencontract
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/quality-gates.md#greencontract`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-qualitygateoutcome.md
+++ b/engine/.pi/issues/issue-qualitygateoutcome.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-QUALITY-GATES-3"
+  epic: "TBD"
+  component: "QualityGateOutcome"
+  module: "quality-gates"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement QualityGateOutcome for the quality-gates module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for qualitygateoutcome
+    application:
+      - New service/handler for qualitygateoutcome
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/quality-gates.md#qualitygateoutcome"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    pub enum QualityGateOutcome {
+
+  file_changes:
+    - "create: src/quality-gates/qualitygateoutcome/"
+    - "create: tests/unit/quality-gates/qualitygateoutcome/"
+    - "create: tests/integration/quality-gates/qualitygateoutcome/"
+---
+
+# ISSUE-QUALITY-GATES-3: QualityGateOutcome
+
+## Intent
+
+pub enum QualityGateOutcome {
+
+## Architecture Context
+
+- **Module:** quality-gates
+- **Component:** QualityGateOutcome
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement QualityGateOutcome for the quality-gates module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for qualitygateoutcome
+
+### Application
+- New service/handler for qualitygateoutcome
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/quality-gates.md#qualitygateoutcome`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-qualitylevel.md
+++ b/engine/.pi/issues/issue-qualitylevel.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-QUALITY-GATES-1"
+  epic: "TBD"
+  component: "QualityLevel"
+  module: "quality-gates"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement QualityLevel for the quality-gates module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for qualitylevel
+    application:
+      - New service/handler for qualitylevel
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/quality-gates.md#qualitylevel"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Four-tier escalation of test scope
+
+  file_changes:
+    - "create: src/quality-gates/qualitylevel/"
+    - "create: tests/unit/quality-gates/qualitylevel/"
+    - "create: tests/integration/quality-gates/qualitylevel/"
+---
+
+# ISSUE-QUALITY-GATES-1: QualityLevel
+
+## Intent
+
+Four-tier escalation of test scope
+
+## Architecture Context
+
+- **Module:** quality-gates
+- **Component:** QualityLevel
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement QualityLevel for the quality-gates module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for qualitylevel
+
+### Application
+- New service/handler for qualitylevel
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/quality-gates.md#qualitylevel`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/src/error.rs
+++ b/engine/src/error.rs
@@ -34,6 +34,7 @@ use crate::execution_engine::domain::ExecutionError;
 use crate::failure_classification::domain::FailureClassificationError;
 use crate::orchestrator::domain::OrchestratorError;
 use crate::planning::domain::PlanningError;
+use crate::quality_gates::domain::QualityGateError;
 use crate::repo_engine::domain::RepoEngineError;
 use crate::state_persistence::domain::StateError;
 use crate::recovery_recipes::domain::RecoveryError;
@@ -117,6 +118,10 @@ pub enum CoreOrchestratorError {
     #[error("Recovery error: {0}")]
     Recovery(#[from] RecoveryError),
 
+    /// Quality gates error — scope classification, contract evaluation.
+    #[error("Quality gate error: {0}")]
+    QualityGate(#[from] QualityGateError),
+
     /// Failure classification error — classification failures,
     /// missing strategies.
     #[error("Failure classification error: {0}")]
@@ -188,6 +193,7 @@ impl CoreOrchestratorError {
             CoreOrchestratorError::Template(e) => e.is_retriable(),
             CoreOrchestratorError::Orchestrator(e) => e.is_retriable(),
             CoreOrchestratorError::Recovery(e) => e.is_retriable(),
+            CoreOrchestratorError::QualityGate(e) => e.is_retriable(),
             CoreOrchestratorError::FailureClassification(e) => e.is_retriable(),
             // JSON deserialization errors are not retriable — the input is malformed
             CoreOrchestratorError::Json(_) => false,
@@ -214,6 +220,7 @@ impl CoreOrchestratorError {
             CoreOrchestratorError::Template(_) => "TEMPLATE_ERROR",
             CoreOrchestratorError::Orchestrator(_) => "ORCHESTRATOR_ERROR",
             CoreOrchestratorError::Recovery(_) => "RECOVERY_ERROR",
+            CoreOrchestratorError::QualityGate(_) => "QUALITY_GATE_ERROR",
             CoreOrchestratorError::FailureClassification(_) => "FAILURE_CLASSIFICATION_ERROR",
             CoreOrchestratorError::Io(_) => "IO_ERROR",
             CoreOrchestratorError::Json(_) => "JSON_ERROR",
@@ -240,6 +247,7 @@ impl CoreOrchestratorError {
             CoreOrchestratorError::Template(_) => 400,
             CoreOrchestratorError::Orchestrator(_) => 500,
             CoreOrchestratorError::Recovery(_) => 500,
+            CoreOrchestratorError::QualityGate(_) => 500,
             CoreOrchestratorError::FailureClassification(_) => 500,
             CoreOrchestratorError::Io(_) => 500,
             CoreOrchestratorError::Json(_) => 400,
@@ -368,6 +376,9 @@ mod tests {
             CoreOrchestratorError::Recovery(RecoveryError::NoRecipe(
                 crate::recovery_recipes::domain::FailureScenario::CompileError,
             )),
+            CoreOrchestratorError::QualityGate(QualityGateError::ScopeClassificationFailed {
+                reason: "test".to_string(),
+            }),
             CoreOrchestratorError::FailureClassification(
                 FailureClassificationError::ClassificationFailed {
                     message: "test".to_string(),

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -41,6 +41,7 @@ pub mod observability;
 pub mod orchestrator;
 pub mod recovery_recipes;
 pub mod planning;
+pub mod quality_gates;
 pub mod repo_engine;
 pub mod risk_gating;
 pub mod state_persistence;

--- a/engine/src/quality_gates/application/dto.rs
+++ b/engine/src/quality_gates/application/dto.rs
@@ -1,0 +1,142 @@
+//! Data Transfer Objects for the Quality Gates module.
+//!
+//! @canonical .pi/architecture/modules/quality-gates.md
+//! Implements: Contract Freeze — DTO schemas for quality gates
+//! Issue: #449 (quality-gates epic)
+//!
+//! DTOs define the input/output contracts for service operations.
+//! They carry validation metadata and documentation but no behavior.
+//!
+//! # Contract (Frozen)
+//! - Every service operation has a dedicated input and output DTO
+//! - DTOs are serializable (JSON for API)
+//! - Validation constraints are documented in field docs
+//! - Fields use reasonable Rust types (no framework-specific annotations)
+
+use serde::{Deserialize, Serialize};
+
+use crate::quality_gates::domain::{GreenContract, QualityGateOutcome, QualityLevel};
+
+// ---------------------------------------------------------------------------
+// Evaluate Gate DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for evaluating a quality gate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvaluateGateInput {
+    /// The green contract specifying the required quality level.
+    pub contract: GreenContract,
+
+    /// The observed quality level from test execution.
+    /// `None` means no test scope was determined (treats as lowest level).
+    pub observed_level: Option<QualityLevel>,
+
+    /// Optional task ID or node name for traceability.
+    pub task_id: Option<String>,
+}
+
+/// Output from evaluating a quality gate.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EvaluateGateOutput {
+    /// The evaluation outcome.
+    pub outcome: QualityGateOutcome,
+
+    /// Human-readable summary of the outcome.
+    pub summary: String,
+
+    /// Task ID for traceability (echoed from input).
+    pub task_id: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Classify Test Scope DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for classifying a test scope into a quality level.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClassifyTestScopeInput {
+    /// Whether targeted tests were run.
+    pub targeted_tests_run: bool,
+
+    /// Whether package-level tests were run.
+    pub package_tests_run: bool,
+
+    /// Whether workspace-level tests were run.
+    pub workspace_tests_run: bool,
+
+    /// Whether lint (clippy) passed.
+    pub lint_passed: bool,
+
+    /// Whether format check (fmt --check) passed.
+    pub format_passed: bool,
+
+    /// Whether security audit passed.
+    pub audit_passed: bool,
+}
+
+/// Output from classifying a test scope.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ClassifyTestScopeOutput {
+    /// The classified quality level.
+    pub level: QualityLevel,
+
+    /// Human-readable explanation of the classification.
+    pub explanation: String,
+}
+
+// ---------------------------------------------------------------------------
+// Get Contract DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for getting the contract for a task/template.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetContractInput {
+    /// Optional template name to check for overrides.
+    pub template_name: Option<String>,
+
+    /// Optional task ID for direct task-level overrides.
+    pub task_id: Option<String>,
+}
+
+/// Output from getting a contract.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GetContractOutput {
+    /// The contract for the task/template.
+    pub contract: GreenContract,
+
+    /// How the contract was determined.
+    pub source: ContractSource,
+}
+
+/// Source of a contract determination.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ContractSource {
+    /// Default configuration.
+    Default,
+    /// Template-specific override.
+    TemplateOverride { template_name: String },
+    /// Task-specific override.
+    TaskOverride { task_id: String },
+}
+
+// ---------------------------------------------------------------------------
+// Validate Config DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for validating a quality gate configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidateConfigInput {
+    /// The quality gate config to validate.
+    pub config: crate::quality_gates::domain::QualityGateConfig,
+}
+
+/// Output from validating a configuration.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ValidateConfigOutput {
+    /// Whether the configuration is valid.
+    pub valid: bool,
+    /// List of validation errors (empty if valid).
+    pub errors: Vec<String>,
+    /// List of warnings (non-blocking issues).
+    pub warnings: Vec<String>,
+}

--- a/engine/src/quality_gates/application/mod.rs
+++ b/engine/src/quality_gates/application/mod.rs
@@ -1,0 +1,21 @@
+//! Application layer interfaces for the Quality Gates bounded context.
+//!
+//! @canonical .pi/architecture/modules/quality-gates.md
+//! Implements: Contract Freeze — service traits, DTOs
+//! Issue: #449 (quality-gates epic)
+//!
+//! This module defines:
+//! - Service traits (use cases / application services)
+//! - Input/Output DTOs with validation
+//!
+//! # Contract (Frozen)
+//! - All service methods are async (return `impl Future`)
+//! - All public methods return `Result<_, QualityGateError>`
+//! - DTOs include validation annotations/documentation
+//! - No implementation logic — only trait definitions
+
+pub mod dto;
+pub mod service;
+
+pub use dto::*;
+pub use service::QualityGateService;

--- a/engine/src/quality_gates/application/service.rs
+++ b/engine/src/quality_gates/application/service.rs
@@ -1,0 +1,82 @@
+//! Service interfaces (use cases) for the Quality Gates bounded context.
+//!
+//! @canonical .pi/architecture/modules/quality-gates.md#service
+//! Implements: Contract Freeze — QualityGateService trait
+//! Issue: #449 (quality-gates epic)
+//!
+//! These traits define the application-level operations that can be performed
+//! for quality gate evaluation. All methods are async and return domain error
+//! types.
+//!
+//! # Contract (Frozen)
+//! - Every use case has a corresponding trait method
+//! - Input/output types are DTOs defined in `dto/`
+//! - All methods are async (use `async-trait` for trait object safety)
+//! - No implementation — only contract signatures
+
+use async_trait::async_trait;
+
+use crate::quality_gates::domain::{GreenContract, QualityGateError};
+
+use super::dto::{
+    ClassifyTestScopeInput, ClassifyTestScopeOutput, EvaluateGateInput, EvaluateGateOutput,
+    GetContractInput, GetContractOutput, ValidateConfigInput, ValidateConfigOutput,
+};
+
+/// Application service for evaluating quality gates and classifying test scope.
+///
+/// The `QualityGateService` is the primary entry point for the quality-gates
+/// module. It handles:
+/// - Evaluating quality gates (comparing observed level against contract)
+/// - Classifying test scope into quality level
+/// - Retrieving contracts for tasks/templates
+/// - Validating quality gate configurations
+#[async_trait]
+pub trait QualityGateService: Send + Sync {
+    /// Evaluate a quality gate against an observed test scope.
+    ///
+    /// Compares the observed `QualityLevel` against the `GreenContract`'s
+    /// required level. Returns the outcome (Satisfied or Unsatisfied).
+    ///
+    /// # Errors
+    /// - `QualityGateError::MissingContract` if no contract is provided
+    async fn evaluate_gate(
+        &self,
+        input: EvaluateGateInput,
+    ) -> Result<EvaluateGateOutput, QualityGateError>;
+
+    /// Classify a test scope into a `QualityLevel`.
+    ///
+    /// Determines the highest quality level achieved based on what
+    /// tests and checks were run:
+    /// - All checks passed → MergeReady
+    /// - Workspace tests passed → Workspace
+    /// - Package tests passed → Package
+    /// - Only targeted tests → TargetedTests
+    /// - No tests at all → TargetedTests (lowest level)
+    async fn classify_test_scope(
+        &self,
+        input: ClassifyTestScopeInput,
+    ) -> Result<ClassifyTestScopeOutput, QualityGateError>;
+
+    /// Get the green contract for a given task or template.
+    ///
+    /// Checks task-level overrides first, then template overrides,
+    /// then falls back to the default configuration.
+    async fn get_contract(
+        &self,
+        input: GetContractInput,
+    ) -> Result<GetContractOutput, QualityGateError>;
+
+    /// Validate a quality gate configuration.
+    ///
+    /// Checks that the configuration is valid (default level is set,
+    /// template overrides reference valid levels).
+    async fn validate_config(
+        &self,
+        input: ValidateConfigInput,
+    ) -> Result<ValidateConfigOutput, QualityGateError>;
+
+    /// Create a default `GreenContract` at the given level.
+    fn create_contract(&self, level: crate::quality_gates::domain::QualityLevel) -> GreenContract;
+}

--- a/engine/src/quality_gates/domain/config.rs
+++ b/engine/src/quality_gates/domain/config.rs
@@ -1,0 +1,197 @@
+//! QualityGateConfig — per-task quality requirements configuration.
+//!
+//! @canonical .pi/architecture/modules/quality-gates.md#config
+//! Implements: Contract Freeze — QualityGateConfig struct
+//! Issue: #449 (quality-gates epic)
+//!
+//! # Contract (Frozen)
+//! - Carries per-task quality gate configuration
+//! - `default_required_level` sets the fallback for tasks without overrides
+//! - `template_overrides` allows per-template level customization
+//! - Implements `Clone`, `Debug`, `PartialEq` for testability
+//! - Serialization support for TOML/JSON configuration files
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::level::QualityLevel;
+
+/// Default quality level for serde deserialization.
+fn default_quality_level() -> QualityLevel {
+    QualityLevel::Package
+}
+
+/// Configuration for quality gate evaluation.
+///
+/// Defines the default required quality level for tasks and per-template
+/// overrides. Loaded from configuration sources (e.g., `.rigorix/quality.toml`).
+///
+/// # Example
+///
+/// ```toml
+/// [quality]
+/// default_required_level = "package"
+///
+/// [quality.templates.refactor]
+/// required_level = "workspace"
+///
+/// [quality.templates.hotfix]
+/// required_level = "merge_ready"
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct QualityGateConfig {
+    /// Default required quality level for all tasks.
+    /// Used when no per-template override exists.
+    #[serde(default = "default_quality_level")]
+    pub default_required_level: QualityLevel,
+
+    /// Per-template overrides for required quality level.
+    /// Keys are template names (e.g., "refactor", "hotfix", "feature").
+    #[serde(default)]
+    pub template_overrides: HashMap<String, QualityLevel>,
+}
+
+impl QualityGateConfig {
+    /// Create a new `QualityGateConfig` with the given default level.
+    pub fn new(default_required_level: QualityLevel) -> Self {
+        Self {
+            default_required_level,
+            template_overrides: HashMap::new(),
+        }
+    }
+
+    /// Get the required quality level for a given template name.
+    ///
+    /// Checks template overrides first, then falls back to the default.
+    /// Returns `None` only if no default is set (shouldn't happen in practice).
+    pub fn required_level_for_template(&self, template_name: &str) -> Option<QualityLevel> {
+        self.template_overrides
+            .get(template_name)
+            .copied()
+            .or(Some(self.default_required_level))
+    }
+
+    /// Add a template override.
+    pub fn add_override(&mut self, template_name: &str, level: QualityLevel) {
+        self.template_overrides
+            .insert(template_name.to_string(), level);
+    }
+
+    /// Remove a template override.
+    pub fn remove_override(&mut self, template_name: &str) -> Option<QualityLevel> {
+        self.template_overrides.remove(template_name)
+    }
+
+    /// Returns `true` if there are any template overrides.
+    pub fn has_overrides(&self) -> bool {
+        !self.template_overrides.is_empty()
+    }
+
+    /// Returns the number of template overrides.
+    pub fn override_count(&self) -> usize {
+        self.template_overrides.len()
+    }
+}
+
+impl Default for QualityGateConfig {
+    fn default() -> Self {
+        Self {
+            default_required_level: QualityLevel::Package,
+            template_overrides: HashMap::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_config() {
+        let config = QualityGateConfig::new(QualityLevel::Workspace);
+        assert_eq!(config.default_required_level, QualityLevel::Workspace);
+        assert!(!config.has_overrides());
+    }
+
+    #[test]
+    fn test_default_config() {
+        let config = QualityGateConfig::default();
+        assert_eq!(
+            config.default_required_level,
+            QualityLevel::Package
+        );
+    }
+
+    #[test]
+    fn test_required_level_for_template_falls_back_to_default() {
+        let config = QualityGateConfig::new(QualityLevel::Workspace);
+        let level = config.required_level_for_template("unknown");
+        assert_eq!(level, Some(QualityLevel::Workspace));
+    }
+
+    #[test]
+    fn test_add_override() {
+        let mut config = QualityGateConfig::new(QualityLevel::Package);
+        config.add_override("hotfix", QualityLevel::MergeReady);
+        assert!(config.has_overrides());
+        assert_eq!(config.override_count(), 1);
+
+        let level = config.required_level_for_template("hotfix");
+        assert_eq!(level, Some(QualityLevel::MergeReady));
+    }
+
+    #[test]
+    fn test_remove_override() {
+        let mut config = QualityGateConfig::new(QualityLevel::Package);
+        config.add_override("hotfix", QualityLevel::MergeReady);
+        let removed = config.remove_override("hotfix");
+        assert_eq!(removed, Some(QualityLevel::MergeReady));
+        assert!(!config.has_overrides());
+    }
+
+    #[test]
+    fn test_template_override_takes_precedence() {
+        let mut config = QualityGateConfig::new(QualityLevel::Package);
+        config.add_override("feature", QualityLevel::Workspace);
+
+        let level = config.required_level_for_template("feature");
+        assert_eq!(level, Some(QualityLevel::Workspace));
+
+        // Unknown template falls back to default
+        let level = config.required_level_for_template("other");
+        assert_eq!(level, Some(QualityLevel::Package));
+    }
+
+    #[test]
+    fn test_multiple_overrides() {
+        let mut config = QualityGateConfig::new(QualityLevel::TargetedTests);
+        config.add_override("refactor", QualityLevel::Workspace);
+        config.add_override("hotfix", QualityLevel::MergeReady);
+        config.add_override("feature", QualityLevel::Package);
+
+        assert_eq!(config.override_count(), 3);
+        assert_eq!(
+            config.required_level_for_template("refactor"),
+            Some(QualityLevel::Workspace)
+        );
+        assert_eq!(
+            config.required_level_for_template("hotfix"),
+            Some(QualityLevel::MergeReady)
+        );
+        assert_eq!(
+            config.required_level_for_template("feature"),
+            Some(QualityLevel::Package)
+        );
+    }
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        let mut config = QualityGateConfig::new(QualityLevel::Workspace);
+        config.add_override("hotfix", QualityLevel::MergeReady);
+
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: QualityGateConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(config, deserialized);
+    }
+}

--- a/engine/src/quality_gates/domain/contract.rs
+++ b/engine/src/quality_gates/domain/contract.rs
@@ -1,0 +1,187 @@
+//! GreenContract — declares required quality level and evaluates observed level.
+//!
+//! @canonical .pi/architecture/modules/quality-gates.md#greencontract
+//! Implements: Contract Freeze — GreenContract struct
+//! Issue: #449 (quality-gates epic)
+//!
+//! # Contract (Frozen)
+//! - A `GreenContract` is an immutable value object once constructed
+//! - `required_level` specifies the minimum `QualityLevel` required
+//! - `evaluate()` compares observed level against required level
+//! - Implements `Clone`, `Copy`, `Debug`, `PartialEq`, `Eq` for testability
+//! - Serialization support for configuration and API responses
+
+use serde::{Deserialize, Serialize};
+
+use super::level::QualityLevel;
+use super::outcome::QualityGateOutcome;
+
+/// Declares a required quality level and evaluates an observed level against it.
+///
+/// A `GreenContract` is the binding agreement between a task's quality
+/// requirements and the actual test scope that was executed. The orchestrator
+/// uses it to decide whether a task has sufficient quality evidence to proceed
+/// with closeout.
+///
+/// # Examples
+///
+/// ```
+/// use quality_gates::domain::{GreenContract, QualityLevel, QualityGateOutcome};
+///
+/// let contract = GreenContract::new(QualityLevel::Workspace);
+/// let outcome = contract.evaluate(Some(QualityLevel::Package));
+/// assert!(matches!(outcome, QualityGateOutcome::Unsatisfied { .. }));
+///
+/// let outcome = contract.evaluate(Some(QualityLevel::Workspace));
+/// assert!(matches!(outcome, QualityGateOutcome::Satisfied { .. }));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GreenContract {
+    /// The minimum quality level required for this contract to be satisfied.
+    pub required_level: QualityLevel,
+}
+
+impl GreenContract {
+    /// Create a new `GreenContract` with the required quality level.
+    pub fn new(required_level: QualityLevel) -> Self {
+        Self { required_level }
+    }
+
+    /// Evaluate an observed quality level against this contract.
+    ///
+    /// Returns:
+    /// - `QualityGateOutcome::Satisfied` if the observed level meets or exceeds
+    ///   the required level.
+    /// - `QualityGateOutcome::Unsatisfied` if the observed level is below
+    ///   the required level, or if `observed` is `None`.
+    ///
+    /// # Semantics
+    ///
+    /// | Observed | Required | Outcome |
+    /// |----------|----------|---------|
+    /// | Workspace | Package | Satisfied (Workspace >= Package) |
+    /// | Package | Workspace | Unsatisfied (Package < Workspace, gap=1) |
+    /// | None | Workspace | Unsatisfied (falls back to TargetedTests, gap=2) |
+    pub fn evaluate(&self, observed: Option<QualityLevel>) -> QualityGateOutcome {
+        match observed {
+            Some(level) if level >= self.required_level => QualityGateOutcome::Satisfied {
+                required: self.required_level,
+                observed: level,
+            },
+            Some(level) => QualityGateOutcome::Unsatisfied {
+                required: self.required_level,
+                observed: level,
+                gap: self.required_level as i32 - level as i32,
+            },
+            None => QualityGateOutcome::Unsatisfied {
+                required: self.required_level,
+                observed: QualityLevel::TargetedTests,
+                gap: self.required_level as i32,
+            },
+        }
+    }
+
+    /// Returns a human-readable description of this contract.
+    pub fn description(&self) -> String {
+        format!(
+            "Requires at least {} quality level",
+            self.required_level.as_str()
+        )
+    }
+}
+
+impl Default for GreenContract {
+    /// Default contract requires at least `Package` level.
+    fn default() -> Self {
+        Self {
+            required_level: QualityLevel::Package,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_contract() {
+        let contract = GreenContract::new(QualityLevel::Workspace);
+        assert_eq!(contract.required_level, QualityLevel::Workspace);
+    }
+
+    #[test]
+    fn test_default_contract() {
+        let contract = GreenContract::default();
+        assert_eq!(contract.required_level, QualityLevel::Package);
+    }
+
+    #[test]
+    fn test_evaluate_satisfied_equal() {
+        let contract = GreenContract::new(QualityLevel::Package);
+        let outcome = contract.evaluate(Some(QualityLevel::Package));
+        assert!(matches!(outcome, QualityGateOutcome::Satisfied { .. }));
+    }
+
+    #[test]
+    fn test_evaluate_satisfied_higher() {
+        let contract = GreenContract::new(QualityLevel::Package);
+        let outcome = contract.evaluate(Some(QualityLevel::Workspace));
+        assert!(matches!(outcome, QualityGateOutcome::Satisfied { .. }));
+    }
+
+    #[test]
+    fn test_evaluate_unsatisfied_lower() {
+        let contract = GreenContract::new(QualityLevel::Workspace);
+        let outcome = contract.evaluate(Some(QualityLevel::Package));
+        assert!(matches!(outcome, QualityGateOutcome::Unsatisfied { .. }));
+    }
+
+    #[test]
+    fn test_evaluate_unsatisfied_gap() {
+        let contract = GreenContract::new(QualityLevel::Workspace);
+        if let QualityGateOutcome::Unsatisfied { gap, .. } = contract.evaluate(Some(QualityLevel::TargetedTests)) {
+            assert_eq!(gap, 2);
+        } else {
+            panic!("Expected Unsatisfied");
+        }
+    }
+
+    #[test]
+    fn test_evaluate_none_returns_unsatisfied() {
+        let contract = GreenContract::new(QualityLevel::Workspace);
+        let outcome = contract.evaluate(None);
+        assert!(matches!(outcome, QualityGateOutcome::Unsatisfied { .. }));
+        if let QualityGateOutcome::Unsatisfied { gap, observed, .. } = outcome {
+            assert_eq!(observed, QualityLevel::TargetedTests);
+            assert_eq!(gap, 2);
+        }
+    }
+
+    #[test]
+    fn test_evaluate_merge_ready_satisfied() {
+        let contract = GreenContract::new(QualityLevel::MergeReady);
+        let outcome = contract.evaluate(Some(QualityLevel::MergeReady));
+        assert!(matches!(outcome, QualityGateOutcome::Satisfied { .. }));
+    }
+
+    #[test]
+    fn test_evaluate_merge_ready_unsatisfied() {
+        let contract = GreenContract::new(QualityLevel::MergeReady);
+        let outcome = contract.evaluate(Some(QualityLevel::Workspace));
+        assert!(matches!(outcome, QualityGateOutcome::Unsatisfied { gap: 1, .. }));
+    }
+
+    #[test]
+    fn test_description() {
+        let contract = GreenContract::new(QualityLevel::MergeReady);
+        assert!(contract.description().contains("merge_ready"));
+    }
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        let contract = GreenContract::new(QualityLevel::Workspace);
+        let json = serde_json::to_string(&contract).unwrap();
+        let deserialized: GreenContract = serde_json::from_str(&json).unwrap();
+        assert_eq!(contract, deserialized);
+    }
+}

--- a/engine/src/quality_gates/domain/error.rs
+++ b/engine/src/quality_gates/domain/error.rs
@@ -1,0 +1,129 @@
+//! Quality gate error types for the quality-gates bounded context.
+//!
+//! @canonical .pi/architecture/modules/quality-gates.md
+//! Implements: Contract Freeze — QualityGateError enum
+//! Issue: #449 (quality-gates epic)
+//!
+//! All errors use `thiserror` derive macros. No `anyhow` in library code.
+//!
+//! # Contract (Frozen)
+//! - `QualityGateError` is the single error type for this module
+//! - Each variant carries structured context for error reporting
+//! - Implements `std::error::Error` for library compatibility
+//! - Converted to `CoreOrchestratorError` via `#[from]` at the orchestrator level
+
+use thiserror::Error;
+
+/// Errors that can occur during quality gate evaluation and configuration.
+#[derive(Debug, Error)]
+pub enum QualityGateError {
+    /// No quality level could be determined for the given test scope.
+    #[error("Could not classify test scope: {reason}")]
+    ScopeClassificationFailed {
+        /// Human-readable reason for the failure.
+        reason: String,
+    },
+
+    /// The quality gate configuration is invalid.
+    #[error("Invalid quality gate configuration: {detail}")]
+    InvalidConfiguration {
+        /// Details about why the configuration is invalid.
+        detail: String,
+    },
+
+    /// A required dependency (event bus, execution engine, etc.) is unavailable.
+    #[error("Dependency unavailable: {dependency} — {reason}")]
+    DependencyUnavailable {
+        /// Name of the unavailable dependency.
+        dependency: String,
+        /// Details about the failure.
+        reason: String,
+    },
+
+    /// An invalid quality level value was encountered (e.g., during deserialization).
+    #[error("Invalid quality level: {value}")]
+    InvalidQualityLevel {
+        /// The invalid value that was encountered.
+        value: String,
+    },
+
+    /// No contract defined for the given task or template.
+    #[error("No contract defined for: {target}")]
+    MissingContract {
+        /// The target (task ID, template name) that has no contract.
+        target: String,
+    },
+}
+
+impl QualityGateError {
+    /// Returns `true` if this error represents a transient condition
+    /// that might succeed on retry.
+    pub fn is_retriable(&self) -> bool {
+        matches!(
+            self,
+            QualityGateError::DependencyUnavailable { .. }
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scope_classification_failed() {
+        let err = QualityGateError::ScopeClassificationFailed {
+            reason: "no test results available".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "Could not classify test scope: no test results available"
+        );
+    }
+
+    #[test]
+    fn test_invalid_configuration() {
+        let err = QualityGateError::InvalidConfiguration {
+            detail: "default_required_level must be set".to_string(),
+        };
+        assert!(err.to_string().contains("default_required_level"));
+    }
+
+    #[test]
+    fn test_dependency_unavailable() {
+        let err = QualityGateError::DependencyUnavailable {
+            dependency: "event_bus".to_string(),
+            reason: "not connected".to_string(),
+        };
+        assert!(err.is_retriable());
+        assert!(err.to_string().contains("event_bus"));
+    }
+
+    #[test]
+    fn test_invalid_quality_level() {
+        let err = QualityGateError::InvalidQualityLevel {
+            value: "ultra".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "Invalid quality level: ultra"
+        );
+    }
+
+    #[test]
+    fn test_missing_contract() {
+        let err = QualityGateError::MissingContract {
+            target: "task-42".to_string(),
+        };
+        assert!(!err.is_retriable());
+    }
+
+    #[test]
+    fn test_error_trait_impl() {
+        let err = QualityGateError::ScopeClassificationFailed {
+            reason: "test".to_string(),
+        };
+        let std_err: &dyn std::error::Error = &err;
+        assert_eq!(std_err.to_string(), "Could not classify test scope: test");
+    }
+}

--- a/engine/src/quality_gates/domain/event.rs
+++ b/engine/src/quality_gates/domain/event.rs
@@ -1,0 +1,235 @@
+//! QualityGateEvent — event payload schemas for the quality-gates bounded context.
+//!
+//! @canonical .pi/architecture/modules/quality-gates.md#event
+//! Implements: Contract Freeze — QualityGateEvent payload schemas
+//! Issue: #449 (quality-gates epic)
+//!
+//! These events are emitted on the `EventBus` whenever a quality gate is
+//! evaluated. Consumers (audit, console printer, TUI) subscribe to these
+//! event types.
+//!
+//! # Contract (Frozen)
+//! - Each event carries the full context needed by consumers
+//! - No internal implementation details exposed
+//! - `sequence` is populated by EventBus at emission time
+
+use serde::{Deserialize, Serialize};
+
+use super::level::QualityLevel;
+use super::outcome::QualityGateOutcome;
+
+/// Events emitted by the Quality Gates module.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum QualityGateEvent {
+    /// A quality gate was evaluated for a task.
+    GateEvaluated {
+        /// The required quality level from the contract.
+        required: QualityLevel,
+        /// The observed quality level from execution.
+        observed: QualityLevel,
+        /// The evaluation outcome.
+        outcome: QualityGateOutcome,
+        /// Optional task ID or node name for traceability.
+        task_id: Option<String>,
+    },
+
+    /// A quality gate was satisfied — the task can proceed.
+    GateSatisfied {
+        /// The required quality level.
+        required: QualityLevel,
+        /// The observed quality level.
+        observed: QualityLevel,
+        /// Task ID for traceability.
+        task_id: Option<String>,
+    },
+
+    /// A quality gate was not satisfied — broader testing is required.
+    GateUnsatisfied {
+        /// The required quality level.
+        required: QualityLevel,
+        /// The observed quality level.
+        observed: QualityLevel,
+        /// How many levels below requirement.
+        gap: i32,
+        /// Task ID for traceability.
+        task_id: Option<String>,
+    },
+
+    /// The quality gate configuration was loaded or updated.
+    ConfigUpdated {
+        /// The default required level.
+        default_level: QualityLevel,
+        /// Number of template overrides.
+        override_count: usize,
+    },
+}
+
+impl QualityGateEvent {
+    /// Returns a human-readable log line for this event.
+    pub fn log_line(&self) -> String {
+        match self {
+            QualityGateEvent::GateEvaluated {
+                required,
+                observed,
+                outcome,
+                task_id,
+            } => {
+                let task = task_id
+                    .as_deref()
+                    .map(|id| format!(" [{}]", id))
+                    .unwrap_or_default();
+                format!(
+                    "[QualityGate] Evaluated{}: required={}, observed={}, outcome={}",
+                    task,
+                    required.as_str(),
+                    observed.as_str(),
+                    if outcome.is_satisfied() {
+                        "satisfied"
+                    } else {
+                        "unsatisfied"
+                    }
+                )
+            }
+            QualityGateEvent::GateSatisfied {
+                required,
+                observed,
+                task_id,
+            } => {
+                let task = task_id
+                    .as_deref()
+                    .map(|id| format!(" [{}]", id))
+                    .unwrap_or_default();
+                format!(
+                    "[QualityGate] Satisfied{}: {} >= {}",
+                    task,
+                    observed.as_str(),
+                    required.as_str()
+                )
+            }
+            QualityGateEvent::GateUnsatisfied {
+                required,
+                observed,
+                gap,
+                task_id,
+            } => {
+                let task = task_id
+                    .as_deref()
+                    .map(|id| format!(" [{}]", id))
+                    .unwrap_or_default();
+                format!(
+                    "[QualityGate] Unsatisfied{}: {} < {} (gap: {})",
+                    task,
+                    observed.as_str(),
+                    required.as_str(),
+                    gap
+                )
+            }
+            QualityGateEvent::ConfigUpdated {
+                default_level,
+                override_count,
+            } => {
+                format!(
+                    "[QualityGate] Config updated: default={}, {} override(s)",
+                    default_level.as_str(),
+                    override_count
+                )
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_log_line_evaluated() {
+        let event = QualityGateEvent::GateEvaluated {
+            required: QualityLevel::Workspace,
+            observed: QualityLevel::Package,
+            outcome: QualityGateOutcome::Unsatisfied {
+                required: QualityLevel::Workspace,
+                observed: QualityLevel::Package,
+                gap: 1,
+            },
+            task_id: Some("task-1".to_string()),
+        };
+        let log = event.log_line();
+        assert!(log.contains("Evaluated"));
+        assert!(log.contains("workspace"));
+        assert!(log.contains("package"));
+        assert!(log.contains("task-1"));
+    }
+
+    #[test]
+    fn test_log_line_satisfied() {
+        let event = QualityGateEvent::GateSatisfied {
+            required: QualityLevel::Package,
+            observed: QualityLevel::Workspace,
+            task_id: None,
+        };
+        let log = event.log_line();
+        assert!(log.contains("Satisfied"));
+    }
+
+    #[test]
+    fn test_log_line_unsatisfied() {
+        let event = QualityGateEvent::GateUnsatisfied {
+            required: QualityLevel::MergeReady,
+            observed: QualityLevel::TargetedTests,
+            gap: 3,
+            task_id: Some("task-2".to_string()),
+        };
+        let log = event.log_line();
+        assert!(log.contains("Unsatisfied"));
+        assert!(log.contains("gap: 3"));
+    }
+
+    #[test]
+    fn test_log_line_config_updated() {
+        let event = QualityGateEvent::ConfigUpdated {
+            default_level: QualityLevel::Workspace,
+            override_count: 2,
+        };
+        let log = event.log_line();
+        assert!(log.contains("Config updated"));
+        assert!(log.contains("2 override(s)"));
+    }
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        let events = vec![
+            QualityGateEvent::GateEvaluated {
+                required: QualityLevel::Workspace,
+                observed: QualityLevel::Package,
+                outcome: QualityGateOutcome::Unsatisfied {
+                    required: QualityLevel::Workspace,
+                    observed: QualityLevel::Package,
+                    gap: 1,
+                },
+                task_id: None,
+            },
+            QualityGateEvent::GateSatisfied {
+                required: QualityLevel::Package,
+                observed: QualityLevel::Workspace,
+                task_id: Some("t1".to_string()),
+            },
+            QualityGateEvent::GateUnsatisfied {
+                required: QualityLevel::MergeReady,
+                observed: QualityLevel::TargetedTests,
+                gap: 3,
+                task_id: None,
+            },
+            QualityGateEvent::ConfigUpdated {
+                default_level: QualityLevel::Package,
+                override_count: 0,
+            },
+        ];
+
+        for event in events {
+            let json = serde_json::to_string(&event).unwrap();
+            let deserialized: QualityGateEvent = serde_json::from_str(&json).unwrap();
+            assert_eq!(format!("{:?}", event), format!("{:?}", deserialized));
+        }
+    }
+}

--- a/engine/src/quality_gates/domain/level.rs
+++ b/engine/src/quality_gates/domain/level.rs
@@ -1,0 +1,195 @@
+//! QualityLevel — four-tier escalation of test scope.
+//!
+//! @canonical .pi/architecture/modules/quality-gates.md#qualitylevel
+//! Implements: Contract Freeze — QualityLevel enum
+//! Issue: #449 (quality-gates epic)
+//!
+//! # Contract (Frozen)
+//! - Four mutually exclusive quality levels with ascending scope
+//! - Implements `PartialOrd` and `Ord` for comparison (levels are ordered)
+//! - Implements `Clone`, `Copy`, `Debug`, `PartialEq`, `Eq` for testability
+//! - Serialization support for configuration and API responses
+//! - `as_str()` returns snake_case names for serialization
+
+use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
+
+/// Four-tier escalation of test scope, from narrowest to broadest.
+///
+/// Each level represents a progressively broader scope of validation:
+/// - `TargetedTests`: only tests directly relevant to the change
+/// - `Package`: all tests in the affected crate/package
+/// - `Workspace`: all tests across the entire workspace
+/// - `MergeReady`: workspace + all integration gates (lint, format, audit)
+///
+/// The levels implement `PartialOrd`/`Ord` so contracts can check
+/// `observed >= required` for satisfaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QualityLevel {
+    /// Only tests directly relevant to the change passed.
+    /// E.g., `cargo test -p crate -- specific::test`
+    TargetedTests = 0,
+
+    /// The crate/package tests passed.
+    /// E.g., `cargo test -p crate`
+    Package = 1,
+
+    /// Full workspace tests passed.
+    /// E.g., `cargo test --workspace`
+    Workspace = 2,
+
+    /// Workspace + all integration gates (lint, format, audit) passed.
+    /// E.g., full CI pipeline.
+    MergeReady = 3,
+}
+
+impl QualityLevel {
+    /// Returns the canonical snake_case name of this quality level.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            QualityLevel::TargetedTests => "targeted_tests",
+            QualityLevel::Package => "package",
+            QualityLevel::Workspace => "workspace",
+            QualityLevel::MergeReady => "merge_ready",
+        }
+    }
+
+    /// Returns a human-readable description of this level.
+    pub fn description(&self) -> &'static str {
+        match self {
+            QualityLevel::TargetedTests => {
+                "Only tests directly relevant to the change passed"
+            }
+            QualityLevel::Package => "All tests in the affected crate/package passed",
+            QualityLevel::Workspace => "All tests across the entire workspace passed",
+            QualityLevel::MergeReady => {
+                "Workspace tests + lint, format, and audit all passed"
+            }
+        }
+    }
+
+    /// Returns the typical command or action associated with this level.
+    pub fn typical_command(&self) -> &'static str {
+        match self {
+            QualityLevel::TargetedTests => "cargo test -p <crate> -- <specific_test>",
+            QualityLevel::Package => "cargo test -p <crate>",
+            QualityLevel::Workspace => "cargo test --workspace",
+            QualityLevel::MergeReady => "full CI pipeline (build + test + lint + fmt + audit)",
+        }
+    }
+
+    /// Returns the numeric value of this level (0-3).
+    pub fn as_u8(&self) -> u8 {
+        *self as u8
+    }
+}
+
+impl PartialOrd for QualityLevel {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for QualityLevel {
+    fn cmp(&self, other: &Self) -> Ordering {
+        (*self as u8).cmp(&(*other as u8))
+    }
+}
+
+impl std::fmt::Display for QualityLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_as_str() {
+        assert_eq!(QualityLevel::TargetedTests.as_str(), "targeted_tests");
+        assert_eq!(QualityLevel::Package.as_str(), "package");
+        assert_eq!(QualityLevel::Workspace.as_str(), "workspace");
+        assert_eq!(QualityLevel::MergeReady.as_str(), "merge_ready");
+    }
+
+    #[test]
+    fn test_description() {
+        assert!(!QualityLevel::TargetedTests.description().is_empty());
+        assert!(!QualityLevel::Package.description().is_empty());
+        assert!(!QualityLevel::Workspace.description().is_empty());
+        assert!(!QualityLevel::MergeReady.description().is_empty());
+    }
+
+    #[test]
+    fn test_typical_command() {
+        assert!(!QualityLevel::TargetedTests.typical_command().is_empty());
+    }
+
+    #[test]
+    fn test_as_u8() {
+        assert_eq!(QualityLevel::TargetedTests.as_u8(), 0);
+        assert_eq!(QualityLevel::Package.as_u8(), 1);
+        assert_eq!(QualityLevel::Workspace.as_u8(), 2);
+        assert_eq!(QualityLevel::MergeReady.as_u8(), 3);
+    }
+
+    #[test]
+    fn test_ordering() {
+        assert!(QualityLevel::TargetedTests < QualityLevel::Package);
+        assert!(QualityLevel::Package < QualityLevel::Workspace);
+        assert!(QualityLevel::Workspace < QualityLevel::MergeReady);
+        assert!(QualityLevel::TargetedTests < QualityLevel::MergeReady);
+    }
+
+    #[test]
+    fn test_equality() {
+        assert_eq!(QualityLevel::TargetedTests, QualityLevel::TargetedTests);
+        assert_ne!(QualityLevel::TargetedTests, QualityLevel::Package);
+    }
+
+    #[test]
+    fn test_display() {
+        assert_eq!(QualityLevel::MergeReady.to_string(), "merge_ready");
+    }
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        for variant in &[
+            QualityLevel::TargetedTests,
+            QualityLevel::Package,
+            QualityLevel::Workspace,
+            QualityLevel::MergeReady,
+        ] {
+            let json = serde_json::to_string(variant).unwrap();
+            let deserialized: QualityLevel = serde_json::from_str(&json).unwrap();
+            assert_eq!(*variant, deserialized);
+        }
+    }
+
+    #[test]
+    fn test_serde_rename() {
+        let json = serde_json::to_string(&QualityLevel::Workspace).unwrap();
+        assert_eq!(json, "\"workspace\"");
+    }
+
+    #[test]
+    fn test_ord_consistency() {
+        // Verify that the PartialOrd implementation is consistent with Ord
+        let levels = [
+            QualityLevel::TargetedTests,
+            QualityLevel::Package,
+            QualityLevel::Workspace,
+            QualityLevel::MergeReady,
+        ];
+        for i in 0..levels.len() {
+            for j in 0..levels.len() {
+                let cmp_ord = levels[i].cmp(&levels[j]);
+                let cmp_partial = levels[i].partial_cmp(&levels[j]).unwrap();
+                assert_eq!(cmp_ord, cmp_partial);
+            }
+        }
+    }
+}

--- a/engine/src/quality_gates/domain/mod.rs
+++ b/engine/src/quality_gates/domain/mod.rs
@@ -1,0 +1,32 @@
+//! Domain entities and interfaces for the Quality Gates bounded context.
+//!
+//! @canonical .pi/architecture/modules/quality-gates.md
+//! Implements: Contract Freeze — QualityLevel, GreenContract, QualityGateOutcome,
+//!              QualityGateConfig, QualityGateEvent, QualityGateError
+//! Issue: #449 (quality-gates epic)
+//!
+//! This module defines the core domain types — `QualityLevel`, `GreenContract`,
+//! `QualityGateOutcome`, `QualityGateConfig`, `QualityGateEvent`, and
+//! `QualityGateError`. These are pure domain objects with no framework
+//! dependencies. They serve as the frozen contract that all implementations
+//! must satisfy.
+//!
+//! # Contract Freeze
+//! - No implementation logic beyond enum variants, accessors, and constructors
+//! - All quality gate orchestration logic must happen in the application layer
+//! - All persistence must happen behind repository interfaces
+//! - The QualityLevel ↔ GreenContract evaluation is the core domain invariant
+
+pub mod config;
+pub mod contract;
+pub mod error;
+pub mod event;
+pub mod level;
+pub mod outcome;
+
+pub use config::QualityGateConfig;
+pub use contract::GreenContract;
+pub use error::QualityGateError;
+pub use event::QualityGateEvent;
+pub use level::QualityLevel;
+pub use outcome::QualityGateOutcome;

--- a/engine/src/quality_gates/domain/outcome.rs
+++ b/engine/src/quality_gates/domain/outcome.rs
@@ -1,0 +1,227 @@
+//! QualityGateOutcome — result of evaluating a GreenContract.
+//!
+//! @canonical .pi/architecture/modules/quality-gates.md#qualitygateoutcome
+//! Implements: Contract Freeze — QualityGateOutcome enum
+//! Issue: #449 (quality-gates epic)
+//!
+//! # Contract (Frozen)
+//! - Two mutually exclusive outcomes: Satisfied or Unsatisfied
+//! - Both variants carry `required` and `observed` QualityLevel for diagnostics
+//! - Unsatisfied carries `gap` (number of levels below requirement)
+//! - Uses `#[serde(tag = "outcome")]` for tagged JSON serialization
+//! - Implements `Clone`, `Debug`, `PartialEq`, `Eq` for testability
+
+use serde::{Deserialize, Serialize};
+
+use super::level::QualityLevel;
+
+/// Result of evaluating a `GreenContract` against an observed `QualityLevel`.
+///
+/// The orchestrator uses this outcome to decide whether a task has sufficient
+/// quality evidence to proceed with closeout, or whether broader testing is
+/// required.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum QualityGateOutcome {
+    /// The observed quality level meets or exceeds the required level.
+    /// The gate is passed — the task can proceed.
+    Satisfied {
+        /// The minimum quality level required by the contract.
+        required: QualityLevel,
+        /// The quality level that was actually observed.
+        observed: QualityLevel,
+    },
+
+    /// The observed quality level is below the required level.
+    /// The gate is not passed — broader testing is required, or
+    /// escalation should be triggered.
+    Unsatisfied {
+        /// The minimum quality level required by the contract.
+        required: QualityLevel,
+        /// The quality level that was actually observed.
+        observed: QualityLevel,
+        /// How many levels below the requirement (positive integer).
+        /// E.g., gap=2 means observed is 2 levels below required.
+        gap: i32,
+    },
+}
+
+impl QualityGateOutcome {
+    /// Returns `true` if this outcome is satisfied.
+    pub fn is_satisfied(&self) -> bool {
+        matches!(self, QualityGateOutcome::Satisfied { .. })
+    }
+
+    /// Returns `true` if this outcome is unsatisfied.
+    pub fn is_unsatisfied(&self) -> bool {
+        matches!(self, QualityGateOutcome::Unsatisfied { .. })
+    }
+
+    /// Returns the required quality level from the outcome.
+    pub fn required_level(&self) -> QualityLevel {
+        match self {
+            QualityGateOutcome::Satisfied { required, .. }
+            | QualityGateOutcome::Unsatisfied { required, .. } => *required,
+        }
+    }
+
+    /// Returns the observed quality level from the outcome.
+    pub fn observed_level(&self) -> QualityLevel {
+        match self {
+            QualityGateOutcome::Satisfied { observed, .. }
+            | QualityGateOutcome::Unsatisfied { observed, .. } => *observed,
+        }
+    }
+
+    /// Returns the gap if unsatisfied, or `None` if satisfied.
+    pub fn gap(&self) -> Option<i32> {
+        match self {
+            QualityGateOutcome::Unsatisfied { gap, .. } => Some(*gap),
+            QualityGateOutcome::Satisfied { .. } => None,
+        }
+    }
+
+    /// Returns a human-readable summary of this outcome.
+    pub fn summary(&self) -> String {
+        match self {
+            QualityGateOutcome::Satisfied { required, observed } => {
+                format!(
+                    "Satisfied: observed {} meets required {}",
+                    observed.as_str(),
+                    required.as_str()
+                )
+            }
+            QualityGateOutcome::Unsatisfied {
+                required,
+                observed,
+                gap,
+            } => {
+                format!(
+                    "Unsatisfied: observed {} < required {} (gap: {})",
+                    observed.as_str(),
+                    required.as_str(),
+                    gap
+                )
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_satisfied() {
+        let outcome = QualityGateOutcome::Satisfied {
+            required: QualityLevel::Package,
+            observed: QualityLevel::Workspace,
+        };
+        assert!(outcome.is_satisfied());
+        assert!(!outcome.is_unsatisfied());
+    }
+
+    #[test]
+    fn test_is_unsatisfied() {
+        let outcome = QualityGateOutcome::Unsatisfied {
+            required: QualityLevel::Workspace,
+            observed: QualityLevel::Package,
+            gap: 1,
+        };
+        assert!(!outcome.is_satisfied());
+        assert!(outcome.is_unsatisfied());
+    }
+
+    #[test]
+    fn test_required_level() {
+        let outcome = QualityGateOutcome::Satisfied {
+            required: QualityLevel::Workspace,
+            observed: QualityLevel::Workspace,
+        };
+        assert_eq!(outcome.required_level(), QualityLevel::Workspace);
+    }
+
+    #[test]
+    fn test_observed_level() {
+        let outcome = QualityGateOutcome::Unsatisfied {
+            required: QualityLevel::MergeReady,
+            observed: QualityLevel::TargetedTests,
+            gap: 3,
+        };
+        assert_eq!(outcome.observed_level(), QualityLevel::TargetedTests);
+    }
+
+    #[test]
+    fn test_gap_satisfied() {
+        let outcome = QualityGateOutcome::Satisfied {
+            required: QualityLevel::Package,
+            observed: QualityLevel::Package,
+        };
+        assert_eq!(outcome.gap(), None);
+    }
+
+    #[test]
+    fn test_gap_unsatisfied() {
+        let outcome = QualityGateOutcome::Unsatisfied {
+            required: QualityLevel::Workspace,
+            observed: QualityLevel::TargetedTests,
+            gap: 2,
+        };
+        assert_eq!(outcome.gap(), Some(2));
+    }
+
+    #[test]
+    fn test_summary_satisfied() {
+        let outcome = QualityGateOutcome::Satisfied {
+            required: QualityLevel::Package,
+            observed: QualityLevel::Workspace,
+        };
+        let s = outcome.summary();
+        assert!(s.contains("Satisfied"));
+        assert!(s.contains("workspace"));
+        assert!(s.contains("package"));
+    }
+
+    #[test]
+    fn test_summary_unsatisfied() {
+        let outcome = QualityGateOutcome::Unsatisfied {
+            required: QualityLevel::Workspace,
+            observed: QualityLevel::TargetedTests,
+            gap: 2,
+        };
+        let s = outcome.summary();
+        assert!(s.contains("Unsatisfied"));
+        assert!(s.contains("gap: 2"));
+    }
+
+    #[test]
+    fn test_serialization_tagged() {
+        let outcome = QualityGateOutcome::Satisfied {
+            required: QualityLevel::Package,
+            observed: QualityLevel::Package,
+        };
+        let json = serde_json::to_string(&outcome).unwrap();
+        assert!(json.contains(r#""outcome":"satisfied""#));
+    }
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        let variants = vec![
+            QualityGateOutcome::Satisfied {
+                required: QualityLevel::Package,
+                observed: QualityLevel::Workspace,
+            },
+            QualityGateOutcome::Unsatisfied {
+                required: QualityLevel::MergeReady,
+                observed: QualityLevel::TargetedTests,
+                gap: 3,
+            },
+        ];
+
+        for variant in variants {
+            let json = serde_json::to_string(&variant).unwrap();
+            let deserialized: QualityGateOutcome = serde_json::from_str(&json).unwrap();
+            assert_eq!(format!("{:?}", variant), format!("{:?}", deserialized));
+        }
+    }
+}

--- a/engine/src/quality_gates/infrastructure/mod.rs
+++ b/engine/src/quality_gates/infrastructure/mod.rs
@@ -1,0 +1,13 @@
+//! Infrastructure layer interfaces for the Quality Gates bounded context.
+//!
+//! @canonical .pi/architecture/modules/quality-gates.md
+//! Implements: Contract Freeze — repository interfaces
+//! Issue: #449 (quality-gates epic)
+//!
+//! This module defines repository interfaces that abstract data access
+//! behind traits. Implementations are provided by the concrete
+//! infrastructure module.
+
+pub mod repository;
+
+pub use repository::QualityGateConfigRepository;

--- a/engine/src/quality_gates/infrastructure/repository.rs
+++ b/engine/src/quality_gates/infrastructure/repository.rs
@@ -1,0 +1,65 @@
+//! Repository interfaces for the Quality Gates bounded context.
+//!
+//! @canonical .pi/architecture/modules/quality-gates.md
+//! Implements: Contract Freeze — QualityGateConfigRepository trait
+//! Issue: #449 (quality-gates epic)
+//!
+//! Repositories abstract data access behind interfaces, allowing
+//! implementations to use filesystem, environment, or mock storage
+//! without coupling domain logic to infrastructure.
+//!
+//! # Contract (Frozen)
+//! - All repository methods are async
+//! - All methods return domain error types
+//! - No framework-specific annotations on trait definitions
+//! - Implementations are hidden behind these interfaces
+
+use async_trait::async_trait;
+
+use crate::quality_gates::domain::{
+    GreenContract, QualityGateConfig, QualityGateError, QualityLevel,
+};
+
+/// Repository for storing and retrieving quality gate configuration.
+///
+/// Implementations can load configuration from filesystem (TOML/JSON),
+/// environment variables, or in-memory defaults.
+#[async_trait]
+pub trait QualityGateConfigRepository: Send + Sync {
+    /// Load the quality gate configuration.
+    ///
+    /// Returns the default configuration if no custom config is found.
+    async fn load_config(&self) -> Result<QualityGateConfig, QualityGateError>;
+
+    /// Store a quality gate configuration.
+    ///
+    /// Implementations persist the configuration to their storage backend.
+    async fn store_config(&self, config: &QualityGateConfig) -> Result<(), QualityGateError>;
+
+    /// Get the green contract for a specific template or task.
+    ///
+    /// Checks template-level overrides, then falls back to the default level.
+    async fn contract_for_template(
+        &self,
+        template_name: &str,
+    ) -> Result<GreenContract, QualityGateError>;
+
+    /// Get the default green contract.
+    async fn default_contract(&self) -> Result<GreenContract, QualityGateError>;
+
+    /// Update the default required quality level.
+    async fn set_default_level(&self, level: QualityLevel) -> Result<(), QualityGateError>;
+
+    /// Add or update a template-level quality override.
+    async fn set_template_level(
+        &self,
+        template_name: &str,
+        level: QualityLevel,
+    ) -> Result<(), QualityGateError>;
+
+    /// Remove a template-level quality override.
+    async fn remove_template_override(
+        &self,
+        template_name: &str,
+    ) -> Result<Option<QualityLevel>, QualityGateError>;
+}

--- a/engine/src/quality_gates/interfaces/http.rs
+++ b/engine/src/quality_gates/interfaces/http.rs
@@ -1,0 +1,209 @@
+//! HTTP API contracts for Quality Gates endpoints.
+//!
+//! @canonical .pi/architecture/modules/quality-gates.md
+//! Implements: Contract Freeze — HTTP endpoint contracts and error formats
+//! Issue: #449 (quality-gates epic)
+//!
+//! Defines endpoint paths, methods, request/response schemas, and error
+//! response formats. These contracts are framework-agnostic — they describe
+//! the API surface that any HTTP server implementation must satisfy.
+//!
+//! # Contract (Frozen)
+//! - All endpoints documented with method, path, request, and response types
+//! - Error responses follow a unified format
+//! - No framework-specific annotations (axum/actix/warp annotations added by implementation)
+
+use serde::{Deserialize, Serialize};
+
+use crate::quality_gates::application::dto::{
+    ClassifyTestScopeInput, ClassifyTestScopeOutput, EvaluateGateInput, EvaluateGateOutput,
+};
+
+use crate::quality_gates::domain::{GreenContract, QualityGateOutcome, QualityLevel};
+
+// ---------------------------------------------------------------------------
+// API Base Path
+// ---------------------------------------------------------------------------
+
+/// All quality gates endpoints are served under this base path.
+pub const API_BASE_PATH: &str = "/api/v1/quality";
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/quality/evaluate
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/quality/evaluate
+///
+/// Evaluate a quality gate against an observed test scope.
+///
+/// **Request:** `EvaluateGateRequest`
+/// **Response:** `200 OK` with `EvaluateGateResponse`
+pub const EVALUATE_PATH: &str = "/api/v1/quality/evaluate";
+pub const EVALUATE_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/quality/evaluate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvaluateGateRequest {
+    /// The green contract specifying the required quality level.
+    pub contract: GreenContract,
+    /// The observed quality level from test execution.
+    pub observed_level: Option<QualityLevel>,
+    /// Optional task ID for traceability.
+    pub task_id: Option<String>,
+}
+
+impl From<EvaluateGateRequest> for EvaluateGateInput {
+    fn from(req: EvaluateGateRequest) -> Self {
+        Self {
+            contract: req.contract,
+            observed_level: req.observed_level,
+            task_id: req.task_id,
+        }
+    }
+}
+
+/// Response body for POST /api/v1/quality/evaluate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvaluateGateResponse {
+    pub success: bool,
+    pub outcome: QualityGateOutcome,
+    pub summary: String,
+    pub task_id: Option<String>,
+}
+
+impl From<EvaluateGateOutput> for EvaluateGateResponse {
+    fn from(output: EvaluateGateOutput) -> Self {
+        Self {
+            success: output.outcome.is_satisfied(),
+            outcome: output.outcome,
+            summary: output.summary,
+            task_id: output.task_id,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/quality/classify
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/quality/classify
+///
+/// Classify a test scope into a quality level.
+///
+/// **Request:** `ClassifyScopeRequest`
+/// **Response:** `200 OK` with `ClassifyScopeResponse`
+pub const CLASSIFY_PATH: &str = "/api/v1/quality/classify";
+pub const CLASSIFY_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/quality/classify.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClassifyScopeRequest {
+    /// Whether targeted tests were run.
+    pub targeted_tests_run: bool,
+    /// Whether package-level tests were run.
+    pub package_tests_run: bool,
+    /// Whether workspace-level tests were run.
+    pub workspace_tests_run: bool,
+    /// Whether lint (clippy) passed.
+    pub lint_passed: bool,
+    /// Whether format check passed.
+    pub format_passed: bool,
+    /// Whether security audit passed.
+    pub audit_passed: bool,
+}
+
+impl From<ClassifyScopeRequest> for ClassifyTestScopeInput {
+    fn from(req: ClassifyScopeRequest) -> Self {
+        Self {
+            targeted_tests_run: req.targeted_tests_run,
+            package_tests_run: req.package_tests_run,
+            workspace_tests_run: req.workspace_tests_run,
+            lint_passed: req.lint_passed,
+            format_passed: req.format_passed,
+            audit_passed: req.audit_passed,
+        }
+    }
+}
+
+/// Response body for POST /api/v1/quality/classify.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClassifyScopeResponse {
+    pub level: QualityLevel,
+    pub explanation: String,
+}
+
+impl From<ClassifyTestScopeOutput> for ClassifyScopeResponse {
+    fn from(output: ClassifyTestScopeOutput) -> Self {
+        Self {
+            level: output.level,
+            explanation: output.explanation,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: GET /api/v1/quality/contract
+// ---------------------------------------------------------------------------
+
+/// GET /api/v1/quality/contract
+///
+/// Get the quality contract for a template or task.
+///
+/// **Query Params:** `?template=refactor&task=task-42`
+/// **Response:** `200 OK` with `ContractResponse`
+pub const CONTRACT_PATH: &str = "/api/v1/quality/contract";
+pub const CONTRACT_METHOD: &str = "GET";
+
+/// Response body for GET /api/v1/quality/contract.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContractResponse {
+    pub required_level: QualityLevel,
+    pub description: String,
+}
+
+// ---------------------------------------------------------------------------
+// Unified Error Response Format
+// ---------------------------------------------------------------------------
+
+/// Standard error response for all Quality Gates API endpoints.
+///
+/// All 4xx/5xx responses use this format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiErrorResponse {
+    /// HTTP status code.
+    pub status: u16,
+    /// Machine-readable error code.
+    pub code: String,
+    /// Human-readable error message.
+    pub message: String,
+    /// Detailed error context (optional, may include field-level errors).
+    pub details: Option<serde_json::Value>,
+    /// Request ID for tracing (if available).
+    pub request_id: Option<String>,
+}
+
+/// Standardized error codes for Quality Gates API.
+pub mod error_codes {
+    /// Classification failed — unable to determine quality level.
+    pub const CLASSIFICATION_FAILED: &str = "CLASSIFICATION_FAILED";
+    /// No contract defined for the given task or template.
+    pub const MISSING_CONTRACT: &str = "MISSING_CONTRACT";
+    /// Invalid quality level value.
+    pub const INVALID_QUALITY_LEVEL: &str = "INVALID_QUALITY_LEVEL";
+    /// Invalid input provided.
+    pub const INVALID_INPUT: &str = "INVALID_INPUT";
+    /// Configuration error.
+    pub const CONFIGURATION_ERROR: &str = "CONFIGURATION_ERROR";
+    /// Internal server error.
+    pub const INTERNAL_ERROR: &str = "INTERNAL_ERROR";
+}
+
+/// HTTP status code mappings for Quality Gates errors.
+pub mod status_codes {
+    pub const CLASSIFICATION_FAILED: u16 = 422;
+    pub const MISSING_CONTRACT: u16 = 404;
+    pub const INVALID_QUALITY_LEVEL: u16 = 422;
+    pub const INVALID_INPUT: u16 = 400;
+    pub const CONFIGURATION_ERROR: u16 = 500;
+    pub const INTERNAL_ERROR: u16 = 500;
+}

--- a/engine/src/quality_gates/interfaces/mod.rs
+++ b/engine/src/quality_gates/interfaces/mod.rs
@@ -1,0 +1,10 @@
+//! Interface adapters for the Quality Gates bounded context.
+//!
+//! @canonical .pi/architecture/modules/quality-gates.md
+//! Implements: Contract Freeze — HTTP API endpoint contracts
+//! Issue: #449 (quality-gates epic)
+//!
+//! This module defines API contracts (HTTP, CLI, etc.) that external
+//! actors use to interact with the quality gates system.
+
+pub mod http;

--- a/engine/src/quality_gates/mod.rs
+++ b/engine/src/quality_gates/mod.rs
@@ -1,0 +1,47 @@
+//! Quality Gates bounded context.
+//!
+//! @canonical .pi/architecture/modules/quality-gates.md
+//! Implements: Contract Freeze — quality-gates module
+//! Issue: #449 (quality-gates epic)
+//!
+//! This module formalizes test quality into a four-tier escalation:
+//! `TargetedTests` → `Package` → `Workspace` → `MergeReady`. Each tier
+//! represents a broader scope of validation. The `GreenContract` pattern
+//! allows users and the orchestrator to declare a required quality level,
+//! and the engine verifies whether the observed test scope satisfies the
+//! contract.
+//!
+//! This replaces the binary "tests passed" signal with a structured quality
+//! framework that gates merge/closeout decisions.
+//!
+//! # Architecture
+//!
+//! ```text
+//! quality_gates/
+//! ├── domain/               # Domain entities
+//! │   ├── level.rs          # QualityLevel enum (4 tiers)
+//! │   ├── contract.rs       # GreenContract struct + evaluate()
+//! │   ├── outcome.rs        # QualityGateOutcome enum
+//! │   ├── config.rs         # QualityGateConfig struct
+//! │   ├── event.rs          # QualityGateEvent payload schemas
+//! │   └── error.rs          # QualityGateError enum
+//! ├── application/          # Service traits, DTOs
+//! │   ├── service.rs        # QualityGateService trait
+//! │   └── dto.rs            # Input/Output DTOs
+//! ├── infrastructure/       # Repository interfaces
+//! │   └── repository.rs     # QualityGateConfigRepository trait
+//! └── interfaces/           # API contracts
+//!     └── http.rs           # REST endpoint contracts
+//! ```
+//!
+//! # Contract Freeze Notice
+//!
+//! ALL files in this module are frozen contracts.
+//! - No implementation changes without explicit contract change approval
+//! - Implementation PRs MUST reference these interfaces
+//! - DTO schemas serve as the canonical data contract
+
+pub mod application;
+pub mod domain;
+pub mod infrastructure;
+pub mod interfaces;


### PR DESCRIPTION
Defines and freezes all public interfaces, contracts, and schemas for the quality-gates epic before implementation begins.

## Components Frozen
- QualityLevel — 4-tier escalation (TargetedTests, Package, Workspace, MergeReady) with PartialOrd/Ord
- GreenContract — required level + evaluate(observed) → outcome
- QualityGateOutcome — Satisfied/Unsatisfied with gap tracking
- QualityGateConfig — default level + per-template overrides
- QualityGateService — evaluate, classify, get_contract, validate, create_contract
- QualityGateEvent — 4 event payload schemas

## Files Created
```
src/quality_gates/
├── mod.rs
├── domain/ (6 files: level, contract, outcome, config, event, error)
├── application/ (2 files: service, dto)
├── infrastructure/ (1 file: repository)
└── interfaces/ (1 file: http.rs)
```

## Validation
- ✅ cargo build — clean
- ✅ cargo test — 50 tests pass
- ✅ CoreOrchestratorError updated with QualityGate(#[from] QualityGateError)

Issue: Closes #450 / Part of #449