### PR TITLE
Contract Freeze: permission-enforcer module

### DIFF
--- a/engine/.pi/issues/issue-bashclassifier.md
+++ b/engine/.pi/issues/issue-bashclassifier.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-PERMISSION-ENFORCER-4"
+  epic: "TBD"
+  component: "BashClassifier"
+  module: "permission-enforcer"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement BashClassifier for the permission-enforcer module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for bashclassifier
+    application:
+      - New service/handler for bashclassifier
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/permission-enforcer.md#bashclassifier"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Classifies bash commands into intent categories for mode-aware gating
+
+  file_changes:
+    - "create: src/permission-enforcer/bashclassifier/"
+    - "create: tests/unit/permission-enforcer/bashclassifier/"
+    - "create: tests/integration/permission-enforcer/bashclassifier/"
+---
+
+# ISSUE-PERMISSION-ENFORCER-4: BashClassifier
+
+## Intent
+
+Classifies bash commands into intent categories for mode-aware gating
+
+## Architecture Context
+
+- **Module:** permission-enforcer
+- **Component:** BashClassifier
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement BashClassifier for the permission-enforcer module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for bashclassifier
+
+### Application
+- New service/handler for bashclassifier
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/permission-enforcer.md#bashclassifier`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-enforcementresult.md
+++ b/engine/.pi/issues/issue-enforcementresult.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-PERMISSION-ENFORCER-5"
+  epic: "TBD"
+  component: "EnforcementResult"
+  module: "permission-enforcer"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement EnforcementResult for the permission-enforcer module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for enforcementresult
+    application:
+      - New service/handler for enforcementresult
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/permission-enforcer.md#enforcementresult"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Structured outcome of permission enforcement
+
+  file_changes:
+    - "create: src/permission-enforcer/enforcementresult/"
+    - "create: tests/unit/permission-enforcer/enforcementresult/"
+    - "create: tests/integration/permission-enforcer/enforcementresult/"
+---
+
+# ISSUE-PERMISSION-ENFORCER-5: EnforcementResult
+
+## Intent
+
+Structured outcome of permission enforcement
+
+## Architecture Context
+
+- **Module:** permission-enforcer
+- **Component:** EnforcementResult
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement EnforcementResult for the permission-enforcer module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for enforcementresult
+
+### Application
+- New service/handler for enforcementresult
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/permission-enforcer.md#enforcementresult`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-permissionenforcer.md
+++ b/engine/.pi/issues/issue-permissionenforcer.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-PERMISSION-ENFORCER-3"
+  epic: "TBD"
+  component: "PermissionEnforcer"
+  module: "permission-enforcer"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement PermissionEnforcer for the permission-enforcer module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for permissionenforcer
+    application:
+      - New service/handler for permissionenforcer
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/permission-enforcer.md#permissionenforcer"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Three specific checks: general tool gating, file write boundaries, bash command classification
+
+  file_changes:
+    - "create: src/permission-enforcer/permissionenforcer/"
+    - "create: tests/unit/permission-enforcer/permissionenforcer/"
+    - "create: tests/integration/permission-enforcer/permissionenforcer/"
+---
+
+# ISSUE-PERMISSION-ENFORCER-3: PermissionEnforcer
+
+## Intent
+
+Three specific checks: general tool gating, file write boundaries, bash command classification
+
+## Architecture Context
+
+- **Module:** permission-enforcer
+- **Component:** PermissionEnforcer
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement PermissionEnforcer for the permission-enforcer module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for permissionenforcer
+
+### Application
+- New service/handler for permissionenforcer
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/permission-enforcer.md#permissionenforcer`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-permissionmode.md
+++ b/engine/.pi/issues/issue-permissionmode.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-PERMISSION-ENFORCER-1"
+  epic: "TBD"
+  component: "PermissionMode"
+  module: "permission-enforcer"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement PermissionMode for the permission-enforcer module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for permissionmode
+    application:
+      - New service/handler for permissionmode
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/permission-enforcer.md#permissionmode"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Three-tier hierarchy controlling tool execution scope
+
+  file_changes:
+    - "create: src/permission-enforcer/permissionmode/"
+    - "create: tests/unit/permission-enforcer/permissionmode/"
+    - "create: tests/integration/permission-enforcer/permissionmode/"
+---
+
+# ISSUE-PERMISSION-ENFORCER-1: PermissionMode
+
+## Intent
+
+Three-tier hierarchy controlling tool execution scope
+
+## Architecture Context
+
+- **Module:** permission-enforcer
+- **Component:** PermissionMode
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement PermissionMode for the permission-enforcer module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for permissionmode
+
+### Application
+- New service/handler for permissionmode
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/permission-enforcer.md#permissionmode`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-permissionpolicy.md
+++ b/engine/.pi/issues/issue-permissionpolicy.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-PERMISSION-ENFORCER-2"
+  epic: "TBD"
+  component: "PermissionPolicy"
+  module: "permission-enforcer"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement PermissionPolicy for the permission-enforcer module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for permissionpolicy
+    application:
+      - New service/handler for permissionpolicy
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/permission-enforcer.md#permissionpolicy"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Authorization decisions based on active mode and tool requirements
+
+  file_changes:
+    - "create: src/permission-enforcer/permissionpolicy/"
+    - "create: tests/unit/permission-enforcer/permissionpolicy/"
+    - "create: tests/integration/permission-enforcer/permissionpolicy/"
+---
+
+# ISSUE-PERMISSION-ENFORCER-2: PermissionPolicy
+
+## Intent
+
+Authorization decisions based on active mode and tool requirements
+
+## Architecture Context
+
+- **Module:** permission-enforcer
+- **Component:** PermissionPolicy
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement PermissionPolicy for the permission-enforcer module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for permissionpolicy
+
+### Application
+- New service/handler for permissionpolicy
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/permission-enforcer.md#permissionpolicy`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -39,6 +39,7 @@ pub mod failure_classification;
 pub mod hooks;
 pub mod observability;
 pub mod orchestrator;
+pub mod permission;
 pub mod recovery_recipes;
 pub mod planning;
 pub mod repo_engine;

--- a/engine/src/permission/application/dto/mod.rs
+++ b/engine/src/permission/application/dto/mod.rs
@@ -1,0 +1,238 @@
+//! Data Transfer Objects for the Permission Enforcer module.
+//!
+//! @canonical .pi/architecture/modules/permission-enforcer.md
+//! Implements: Contract Freeze — DTO schemas for permission operations
+//! Issue: issue-contract-freeze
+//!
+//! DTOs define the input/output contracts for service operations.
+//! They carry validation metadata and documentation but no behavior.
+//!
+//! # Contract (Frozen)
+//! - Every service operation has a dedicated input and output DTO
+//! - DTOs are serializable (JSON for API)
+//! - Validation constraints are documented in field docs
+
+use serde::{Deserialize, Serialize};
+
+use crate::permission::domain::{PermissionConfig, PermissionMode};
+
+// ---------------------------------------------------------------------------
+// Check Permission DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for checking tool permission.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckPermissionInput {
+    /// The name of the tool being invoked.
+    pub tool: String,
+
+    /// The raw input/arguments to the tool.
+    pub input: String,
+
+    /// Optional execution ID for correlation.
+    pub execution_id: Option<String>,
+
+    /// Optional node ID (for DAG execution context).
+    pub node_id: Option<String>,
+}
+
+/// Output from checking tool permission.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckPermissionOutput {
+    /// Whether the tool is allowed or denied.
+    pub outcome: String, // "allowed" or "denied"
+
+    /// The active permission mode.
+    pub active_mode: String,
+
+    /// The required permission mode.
+    pub required_mode: String,
+
+    /// Human-readable reason (present if denied).
+    pub reason: Option<String>,
+
+    /// Whether this operation requires user confirmation.
+    pub requires_confirmation: bool,
+}
+
+// ---------------------------------------------------------------------------
+// File Write Check DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for checking a file write operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckFileWriteInput {
+    /// The path being written to.
+    pub path: String,
+
+    /// The workspace root directory.
+    pub workspace_root: String,
+
+    /// Optional execution ID for correlation.
+    pub execution_id: Option<String>,
+}
+
+/// Output from checking a file write operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckFileWriteOutput {
+    /// Whether the write is allowed.
+    pub allowed: bool,
+
+    /// The active permission mode.
+    pub active_mode: String,
+
+    /// Whether the path is within the workspace boundary.
+    pub within_workspace: bool,
+
+    /// Reason if denied.
+    pub reason: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Bash Check DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for checking a bash command.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckBashInput {
+    /// The bash command string to classify and check.
+    pub command: String,
+
+    /// Optional execution ID for correlation.
+    pub execution_id: Option<String>,
+}
+
+/// Output from checking a bash command.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckBashOutput {
+    /// Whether the command is allowed.
+    pub allowed: bool,
+
+    /// The classified command intent.
+    pub classification: String,
+
+    /// The active permission mode.
+    pub active_mode: String,
+
+    /// The minimum permission mode required for this command intent.
+    pub required_mode: String,
+
+    /// Reason if denied.
+    pub reason: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Mode Management DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for setting the active permission mode.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetModeInput {
+    /// The new permission mode.
+    pub mode: PermissionMode,
+
+    /// Optional execution ID for correlation.
+    pub execution_id: Option<String>,
+
+    /// Source of the mode change (e.g., "cli", "user", "hook").
+    pub source: String,
+
+    /// Optional reason for the mode change.
+    pub reason: Option<String>,
+}
+
+/// Output from setting the active permission mode.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetModeOutput {
+    /// The previous permission mode.
+    pub previous_mode: PermissionMode,
+
+    /// The new permission mode.
+    pub current_mode: PermissionMode,
+
+    /// Whether the mode was successfully changed.
+    pub success: bool,
+}
+
+/// Status response for the current permission state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PermissionStatusOutput {
+    /// The current active permission mode.
+    pub active_mode: PermissionMode,
+
+    /// The current permission configuration summary.
+    pub config_summary: PermissionConfigSummary,
+}
+
+/// Summary of the permission configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PermissionConfigSummary {
+    /// Number of allow rules.
+    pub allow_count: u32,
+
+    /// Number of deny rules.
+    pub deny_count: u32,
+
+    /// Number of ask rules.
+    pub ask_count: u32,
+
+    /// Number of per-tool permission overrides.
+    pub tool_permission_count: u32,
+}
+
+impl From<&PermissionConfig> for PermissionConfigSummary {
+    fn from(config: &PermissionConfig) -> Self {
+        Self {
+            allow_count: config.allow.len() as u32,
+            deny_count: config.deny.len() as u32,
+            ask_count: config.ask.len() as u32,
+            tool_permission_count: config.tool_permissions.len() as u32,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reload Policy DTOs
+// ---------------------------------------------------------------------------
+
+/// Output from reloading the permission policy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReloadPolicyOutput {
+    /// Whether the reload was successful.
+    pub success: bool,
+
+    /// Summary of the new configuration.
+    pub config_summary: PermissionConfigSummary,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_permission_config_summary_from_config() {
+        let config = PermissionConfig::default();
+        let summary = PermissionConfigSummary::from(&config);
+        assert_eq!(summary.allow_count, config.allow.len() as u32);
+        assert_eq!(summary.deny_count, config.deny.len() as u32);
+        assert_eq!(summary.ask_count, config.ask.len() as u32);
+        assert_eq!(
+            summary.tool_permission_count,
+            config.tool_permissions.len() as u32
+        );
+    }
+
+    #[test]
+    fn test_dto_serde() {
+        let input = CheckPermissionInput {
+            tool: "bash".to_string(),
+            input: "ls -la".to_string(),
+            execution_id: Some("exec-1".to_string()),
+            node_id: Some("node-1".to_string()),
+        };
+        let json = serde_json::to_string(&input).unwrap();
+        let deserialized: CheckPermissionInput = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.tool, "bash");
+        assert_eq!(deserialized.input, "ls -la");
+    }
+}

--- a/engine/src/permission/application/enforcer.rs
+++ b/engine/src/permission/application/enforcer.rs
@@ -1,0 +1,87 @@
+//! PermissionEnforcer — application service trait for permission gating.
+//!
+//! @canonical .pi/architecture/modules/permission-enforcer.md#enforcer
+//! Implements: Contract Freeze — PermissionEnforcer trait
+//! Issue: issue-contract-freeze
+//!
+//! Defines the application service interface for the permission enforcer.
+//! The PermissionEnforcer sits between the execution engine and tool
+//! execution, gating every tool call based on the active permission mode,
+//! workspace boundaries, and bash command classification.
+//!
+//! # Contract (Frozen)
+//! - All methods return `PermissionOutcome` for structured feedback
+//! - Workspace checks require an explicit `workspace_root` parameter
+//! - Bash classification is built into the `check_bash` method
+//! - Context overrides modify evaluation behavior
+
+use async_trait::async_trait;
+
+use crate::permission::domain::{PermissionContext, PermissionError, PermissionMode, PermissionOutcome};
+
+/// Central permission enforcement service.
+///
+/// The PermissionEnforcer provides three distinct checks:
+///
+/// 1. **General tool gating** — checks if the tool is allowed by policy
+///    based on the active permission mode and configured rules.
+///
+/// 2. **File write boundary check** — for write_file/edit_file tools,
+///    verifies the target path is within the workspace root.
+///
+/// 3. **Bash command classification** — for bash tools, classifies the
+///    command intent and gates accordingly.
+///
+/// # Integration
+///
+/// The enforcer is called by the execution engine (or orchestrator)
+/// before every tool invocation. It returns `PermissionOutcome::Allowed`
+/// or `PermissionOutcome::Denied` with structured reasoning that can be
+/// fed back to the LLM.
+#[async_trait]
+pub trait PermissionEnforcer: Send + Sync {
+    /// General tool permission check.
+    ///
+    /// Evaluates the tool call against the active permission policy.
+    /// Returns `Allowed` if the tool is permitted, `Denied` with a
+    /// structured reason otherwise.
+    async fn check(
+        &self,
+        tool_name: &str,
+        input: &str,
+        context: Option<&PermissionContext>,
+    ) -> PermissionOutcome;
+
+    /// Workspace boundary check for file write operations.
+    ///
+    /// Verifies that the target path is within the workspace root.
+    /// In ReadOnly mode, all writes are denied.
+    /// In WorkspaceWrite mode, writes outside the workspace are denied.
+    /// In DangerousFullAccess mode, all writes are allowed.
+    async fn check_file_write(
+        &self,
+        path: &str,
+        workspace_root: &str,
+        context: Option<&PermissionContext>,
+    ) -> PermissionOutcome;
+
+    /// Bash command classification and permission check.
+    ///
+    /// Classifies the bash command using `BashClassifier` and gates
+    /// based on the active mode. In ReadOnly mode, only read-only
+    /// commands are allowed.
+    async fn check_bash(
+        &self,
+        command: &str,
+        context: Option<&PermissionContext>,
+    ) -> PermissionOutcome;
+
+    /// Get the current active permission mode.
+    fn active_mode(&self) -> PermissionMode;
+
+    /// Set the active permission mode.
+    fn set_active_mode(&self, mode: PermissionMode);
+
+    /// Reload the permission policy configuration.
+    async fn reload_policy(&self) -> Result<(), PermissionError>;
+}

--- a/engine/src/permission/application/factory.rs
+++ b/engine/src/permission/application/factory.rs
@@ -1,0 +1,53 @@
+//! Factory interface for constructing PermissionEnforcer instances.
+//!
+//! @canonical .pi/architecture/modules/permission-enforcer.md
+//! Implements: Contract Freeze — PermissionEnforcerFactory trait
+//! Issue: issue-contract-freeze
+//!
+//! Factories encapsulate the construction of the PermissionEnforcer
+//! with appropriate mode, rules, and configuration.
+//!
+//! # Contract (Frozen)
+//! - Every factory method returns a configured PermissionEnforcer
+//! - Configuration is validated during construction
+//! - No mutable state in factory implementations
+
+use async_trait::async_trait;
+
+use super::enforcer::PermissionEnforcer;
+use crate::permission::domain::{PermissionConfig, PermissionError, PermissionMode};
+
+/// Factory for constructing `PermissionEnforcer` instances.
+///
+/// Handles creation of the enforcer with the appropriate permission
+/// mode, allow/deny/ask rules, and per-tool permission mappings.
+#[async_trait]
+pub trait PermissionEnforcerFactory: Send + Sync {
+    /// Create a `PermissionEnforcer` from a `PermissionConfig`.
+    async fn create_from_config(
+        &self,
+        config: PermissionConfig,
+    ) -> Result<Box<dyn PermissionEnforcer>, PermissionError>;
+
+    /// Create a `PermissionEnforcer` with the default configuration
+    /// in the specified mode.
+    async fn create_with_mode(
+        &self,
+        mode: PermissionMode,
+    ) -> Result<Box<dyn PermissionEnforcer>, PermissionError>;
+
+    /// Create a `PermissionEnforcer` using the default configuration.
+    async fn create_default(
+        &self,
+    ) -> Result<Box<dyn PermissionEnforcer>, PermissionError>;
+
+    /// Create an extremely permissive `PermissionEnforcer` (for testing).
+    async fn create_permissive(
+        &self,
+    ) -> Result<Box<dyn PermissionEnforcer>, PermissionError>;
+
+    /// Create a read-only `PermissionEnforcer`.
+    async fn create_read_only(
+        &self,
+    ) -> Result<Box<dyn PermissionEnforcer>, PermissionError>;
+}

--- a/engine/src/permission/application/mod.rs
+++ b/engine/src/permission/application/mod.rs
@@ -1,0 +1,24 @@
+//! Application layer interfaces for the Permission Enforcer bounded context.
+//!
+//! @canonical .pi/architecture/modules/permission-enforcer.md
+//! Implements: Contract Freeze — service traits, DTOs, factory interfaces
+//! Issue: issue-contract-freeze
+//!
+//! This module defines:
+//! - Service traits (use cases / application services)
+//! - Input/Output DTOs with validation
+//! - Factory interfaces for constructing PermissionEnforcer instances
+//!
+//! # Contract (Frozen)
+//! - All service methods are async (return `impl Future`)
+//! - All public methods return domain types
+//! - DTOs include documentation
+//! - No implementation logic — only trait definitions
+
+pub mod dto;
+pub mod enforcer;
+pub mod factory;
+
+pub use dto::*;
+pub use enforcer::*;
+pub use factory::*;

--- a/engine/src/permission/domain/bash_classifier.rs
+++ b/engine/src/permission/domain/bash_classifier.rs
@@ -1,0 +1,695 @@
+//! BashClassifier — classifies bash commands by intent for mode-aware gating.
+//!
+//! @canonical .pi/architecture/modules/permission-enforcer.md#bash-classifier
+//! Implements: Contract Freeze — BashClassifier and CommandIntent
+//! Issue: issue-contract-freeze
+//!
+//! Classifies bash commands into intent categories so the permission
+//! enforcer can gate them based on the active mode. In ReadOnly mode,
+//! only read-only commands are allowed. In WorkspaceWrite mode, all
+//! commands are allowed. In DangerousFullAccess mode, no restrictions.
+//!
+//! # Contract (Frozen)
+//! - Classification is purely syntactic (extracts the base command)
+//! - No execution or parsing of command arguments for safety
+//! - The `classify()` function is a pure function (no side effects)
+//! - Command lists are frozen — additions require contract change
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Intent classification for a bash command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum CommandIntent {
+    /// Read-only operations that have no side effects.
+    /// Examples: ls, cat, grep, find, head, tail, wc, sort, uniq, diff
+    ReadOnly,
+
+    /// File/directory write operations within the filesystem.
+    /// Examples: cp, mv, mkdir, touch, tee, install
+    Write,
+
+    /// Potentially destructive operations that modify state irreversibly.
+    /// Examples: rm, shred, truncate, mkfifo, mknod, dd
+    Destructive,
+
+    /// Network-related operations that make external connections.
+    /// Examples: curl, wget, ssh, scp, rsync, nc, ping
+    Network,
+
+    /// Process management operations (start, stop, signal processes).
+    /// Examples: kill, pkill, killall, nice, renice, bg, fg
+    ProcessManagement,
+
+    /// Package and dependency management operations.
+    /// Examples: apt, brew, pip, npm, cargo install, gem, rustup
+    PackageManagement,
+
+    /// System administration operations that modify system state.
+    /// Examples: sudo, chmod, chown, mount, umount, systemctl, service, docker
+    SystemAdmin,
+
+    /// Unknown/unclassified command — treated as potentially unsafe.
+    Unknown,
+}
+
+impl CommandIntent {
+    /// Returns `true` if this intent is read-only (safe to execute in any mode).
+    pub fn is_read_only(&self) -> bool {
+        matches!(self, CommandIntent::ReadOnly)
+    }
+
+    /// Returns `true` if this intent is always unsafe (requires DangerousFullAccess).
+    pub fn is_destructive(&self) -> bool {
+        matches!(self, CommandIntent::Destructive)
+    }
+
+    /// Returns `true` if this intent requires write-like access.
+    pub fn requires_write_access(&self) -> bool {
+        matches!(
+            self,
+            CommandIntent::Write
+                | CommandIntent::PackageManagement
+                | CommandIntent::SystemAdmin
+                | CommandIntent::Unknown
+        )
+    }
+
+    /// Returns `true` if this intent requires full system access.
+    pub fn requires_full_access(&self) -> bool {
+        matches!(
+            self,
+            CommandIntent::Destructive
+                | CommandIntent::Network
+                | CommandIntent::ProcessManagement
+        )
+    }
+}
+
+impl fmt::Display for CommandIntent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CommandIntent::ReadOnly => write!(f, "read_only"),
+            CommandIntent::Write => write!(f, "write"),
+            CommandIntent::Destructive => write!(f, "destructive"),
+            CommandIntent::Network => write!(f, "network"),
+            CommandIntent::ProcessManagement => write!(f, "process_management"),
+            CommandIntent::PackageManagement => write!(f, "package_management"),
+            CommandIntent::SystemAdmin => write!(f, "system_admin"),
+            CommandIntent::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
+/// Classifies bash commands into intent categories for permission gating.
+///
+/// Classification extracts the base command (first token before space/pipe)
+/// and matches it against known command lists. Complex commands with pipes
+/// or chains are classified based on the first command.
+pub struct BashClassifier;
+
+// ---------------------------------------------------------------------------
+// Frozen command classification tables
+// ---------------------------------------------------------------------------
+
+/// Commands that only read state without side effects.
+const READ_ONLY_COMMANDS: &[&str] = &[
+    "ls", "cat", "grep", "egrep", "fgrep", "find", "head", "tail", "wc",
+    "sort", "uniq", "diff", "file", "stat", "du", "df", "ps", "top", "htop",
+    "who", "whoami", "env", "echo", "printf", "which", "whereis", "type",
+    "printenv", "pwd", "date", "cal", "nproc", "free", "uptime", "lscpu",
+    "lsblk", "lspci", "lsusb", "getfacl", "bat", "less", "more", "xxd",
+    "hexdump", "od", "strings", "nm", "objdump", "readelf", "ldd",
+    "git", // git subcommands classified separately — see below
+];
+
+/// Git read-only subcommands (single command: "git log", "git status").
+const GIT_READ_ONLY_SUBCOMMANDS: &[&[&str]] = &[
+    &["git", "log"],
+    &["git", "status"],
+    &["git", "diff"],
+    &["git", "show"],
+    &["git", "branch"],
+    &["git", "tag"],
+    &["git", "describe"],
+    &["git", "blame"],
+    &["git", "grep"],
+    &["git", "ls-files"],
+    &["git", "ls-tree"],
+    &["git", "rev-parse"],
+    &["git", "rev-list"],
+    &["git", "cat-file"],
+    &["git", "config", "--list"],
+    &["git", "remote", "-v"],
+];
+
+/// Git write subcommands (single command: "git commit", "git push").
+const GIT_WRITE_SUBCOMMANDS: &[&[&str]] = &[
+    &["git", "add"],
+    &["git", "commit"],
+    &["git", "push"],
+    &["git", "pull"],
+    &["git", "fetch"],
+    &["git", "merge"],
+    &["git", "rebase"],
+    &["git", "checkout"],
+    &["git", "switch"],
+    &["git", "restore"],
+    &["git", "reset"],
+    &["git", "stash"],
+    &["git", "cherry-pick"],
+    &["git", "revert"],
+    &["git", "clean"],
+    &["git", "rm"],
+    &["git", "mv"],
+];
+
+/// Commands that write/modify state (non-destructive).
+const WRITE_COMMANDS: &[&str] = &[
+    "cp", "mv", "mkdir", "rmdir", "touch", "ln", "tee", "install",
+    "test", "[",
+];
+
+/// Commands that are destructive or hard to undo.
+const DESTRUCTIVE_COMMANDS: &[&str] = &[
+    "rm", "shred", "truncate", "mkfifo", "mknod", "dd", "fallocate",
+    "fstrim", "wipefs", "mkfs", "fdisk", "parted",
+];
+
+/// Commands that make network connections.
+const NETWORK_COMMANDS: &[&str] = &[
+    "curl", "wget", "ssh", "scp", "rsync", "nc", "ncat", "socat",
+    "ping", "traceroute", "tracepath", "mtr", "nslookup", "dig",
+    "host", "whois", "netstat", "ss", "ip", "ifconfig", "iwconfig",
+    "iw", "tcpdump", "nmap", "telnet", "ftp", "sftp",
+];
+
+/// Commands that manage processes.
+const PROCESS_COMMANDS: &[&str] = &[
+    "kill", "pkill", "killall", "nice", "renice", "bg", "fg", "jobs",
+    "wait", "nohup", "disown", "timeout",
+];
+
+/// Package and dependency managers.
+const PACKAGE_MANAGERS: &[&str] = &[
+    "apt", "apt-get", "apt-cache", "dpkg", "brew", "port", "pip",
+    "pip3", "pipx", "npm", "yarn", "pnpm", "bun", "cargo", "gem",
+    "rustup", "go", "dotnet", "nuget", "conda", "mamba", "flatpak",
+    "snap", "pacman", "yay", "paru", "zypper", "dnf", "yum", "rpm",
+    "nix", "guix", "choco", "scoop",
+];
+
+/// System administration commands.
+const SYSTEM_ADMIN_COMMANDS: &[&str] = &[
+    "sudo", "doas", "chmod", "chown", "chgrp", "mount", "umount",
+    "systemctl", "journalctl", "service", "docker", "podman", "kubectl",
+    "helm", "minikube", "systemd-run", "firewall-cmd", "ufw",
+    "iptables", "nft", "sysctl", "modprobe", "insmod", "rmmod",
+    "swapon", "swapoff", "crontab", "at", "batch", "logrotate",
+    "setfacl", "setcap",
+];
+
+/// Cargo subcommands that are compilation/build operations.
+const CARGO_BUILD_SUBCOMMANDS: &[&str] = &[
+    "build", "check", "test", "bench", "clippy", "fmt", "fix",
+    "doc", "run", "publish", "package", "update", "clean",
+];
+
+impl BashClassifier {
+    /// Classify a bash command into an intent category.
+    ///
+    /// Extracts the base command from the input string by taking the first
+    /// whitespace-separated token before any pipe (`|`), semicolon (`;`),
+    /// or double ampersand (`&&`). Then matches against known command lists.
+    ///
+    /// # Edge Cases
+    /// - Empty input → `Unknown`
+    /// - Just whitespace → `Unknown`
+    /// - Complex pipelines → classified by first command only
+    /// - Path-prefixed commands (`/usr/bin/ls`) → stripped to base name
+    pub fn classify(command: &str) -> CommandIntent {
+        let command = command.trim();
+        if command.is_empty() {
+            return CommandIntent::Unknown;
+        }
+
+        // Extract the first command before pipe, semicolon, or &&
+        let first_cmd = command
+            .split('|')
+            .next()
+            .unwrap_or(command)
+            .split(';')
+            .next()
+            .unwrap_or(command)
+            .split("&&")
+            .next()
+            .unwrap_or(command)
+            .trim();
+
+        // Split into tokens
+        let tokens: Vec<&str> = first_cmd.split_whitespace().collect();
+        if tokens.is_empty() {
+            return CommandIntent::Unknown;
+        }
+
+        // Handle redirection operators as first token
+        if tokens[0] == ">" || tokens[0] == ">>" {
+            return CommandIntent::Destructive;
+        }
+
+        // Check for `cargo <build_subcommand>` — classify as PackageManagement
+        if tokens.len() >= 2 && tokens[0] == "cargo" && CARGO_BUILD_SUBCOMMANDS.contains(&tokens[1])
+        {
+            return CommandIntent::PackageManagement;
+        }
+
+        // Check for `cargo install` specifically
+        if tokens.len() >= 2
+            && tokens[0] == "cargo"
+            && (tokens[1] == "install" || tokens[1] == "uninstall")
+        {
+            return CommandIntent::PackageManagement;
+        }
+
+        // Check for git subcommands
+        if tokens.len() >= 2 && tokens[0] == "git" {
+            // Check if git command includes a known write subcommand
+            for sub in GIT_WRITE_SUBCOMMANDS {
+                if tokens.starts_with(sub) {
+                    return CommandIntent::Write;
+                }
+            }
+            // Check if git command includes a known read-only subcommand
+            for sub in GIT_READ_ONLY_SUBCOMMANDS {
+                if tokens.starts_with(sub) {
+                    return CommandIntent::ReadOnly;
+                }
+            }
+            // Unknown git command — treat as write (conservative)
+            return CommandIntent::Write;
+        }
+
+        // Extract base command name (strip path prefix if present)
+        let base = tokens[0];
+        let base_name = base.rsplit('/').next().unwrap_or(base);
+
+        // Match against known command lists
+        if READ_ONLY_COMMANDS.contains(&base_name) {
+            return CommandIntent::ReadOnly;
+        }
+        if DESTRUCTIVE_COMMANDS.contains(&base_name) {
+            return CommandIntent::Destructive;
+        }
+        if PACKAGE_MANAGERS.contains(&base_name) {
+            return CommandIntent::PackageManagement;
+        }
+        if SYSTEM_ADMIN_COMMANDS.contains(&base_name) {
+            return CommandIntent::SystemAdmin;
+        }
+        if WRITE_COMMANDS.contains(&base_name) {
+            return CommandIntent::Write;
+        }
+        if NETWORK_COMMANDS.contains(&base_name) {
+            return CommandIntent::Network;
+        }
+        if PROCESS_COMMANDS.contains(&base_name) {
+            return CommandIntent::ProcessManagement;
+        }
+
+        CommandIntent::Unknown
+    }
+
+    /// Returns the minimum `PermissionMode` required for a given `CommandIntent`.
+    pub fn required_mode_for_intent(intent: CommandIntent) -> crate::permission::domain::PermissionMode {
+        use crate::permission::domain::PermissionMode;
+        match intent {
+            CommandIntent::ReadOnly => PermissionMode::ReadOnly,
+            CommandIntent::Write => PermissionMode::WorkspaceWrite,
+            CommandIntent::PackageManagement => PermissionMode::WorkspaceWrite,
+            CommandIntent::SystemAdmin => PermissionMode::DangerousFullAccess,
+            CommandIntent::Destructive => PermissionMode::DangerousFullAccess,
+            CommandIntent::Network => PermissionMode::DangerousFullAccess,
+            CommandIntent::ProcessManagement => PermissionMode::DangerousFullAccess,
+            CommandIntent::Unknown => PermissionMode::WorkspaceWrite, // conservative
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // Read-only command tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_classify_ls() {
+        assert_eq!(BashClassifier::classify("ls"), CommandIntent::ReadOnly);
+        assert_eq!(BashClassifier::classify("ls -la"), CommandIntent::ReadOnly);
+        assert_eq!(
+            BashClassifier::classify("/usr/bin/ls -la"),
+            CommandIntent::ReadOnly
+        );
+    }
+
+    #[test]
+    fn test_classify_cat() {
+        assert_eq!(BashClassifier::classify("cat file.txt"), CommandIntent::ReadOnly);
+        assert_eq!(
+            BashClassifier::classify("cat /etc/passwd"),
+            CommandIntent::ReadOnly
+        );
+    }
+
+    #[test]
+    fn test_classify_grep() {
+        assert_eq!(
+            BashClassifier::classify("grep pattern file.txt"),
+            CommandIntent::ReadOnly
+        );
+        assert_eq!(
+            BashClassifier::classify("grep -r pattern /path"),
+            CommandIntent::ReadOnly
+        );
+    }
+
+    #[test]
+    fn test_classify_find() {
+        assert_eq!(
+            BashClassifier::classify("find . -name '*.rs'"),
+            CommandIntent::ReadOnly
+        );
+    }
+
+    #[test]
+    fn test_classify_head_tail_wc() {
+        assert_eq!(BashClassifier::classify("head -n 10 file"), CommandIntent::ReadOnly);
+        assert_eq!(BashClassifier::classify("tail -f log"), CommandIntent::ReadOnly);
+        assert_eq!(BashClassifier::classify("wc -l file"), CommandIntent::ReadOnly);
+    }
+
+    #[test]
+    fn test_classify_git_read_only() {
+        assert_eq!(
+            BashClassifier::classify("git log --oneline"),
+            CommandIntent::ReadOnly
+        );
+        assert_eq!(
+            BashClassifier::classify("git status"),
+            CommandIntent::ReadOnly
+        );
+        assert_eq!(
+            BashClassifier::classify("git diff HEAD"),
+            CommandIntent::ReadOnly
+        );
+        assert_eq!(
+            BashClassifier::classify("git show HEAD"),
+            CommandIntent::ReadOnly
+        );
+    }
+
+    #[test]
+    fn test_classify_echo_printf() {
+        assert_eq!(
+            BashClassifier::classify("echo hello"),
+            CommandIntent::ReadOnly
+        );
+        assert_eq!(
+            BashClassifier::classify("printf '%s\\n' hello"),
+            CommandIntent::ReadOnly
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Write command tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_classify_write_commands() {
+        assert_eq!(BashClassifier::classify("cp a b"), CommandIntent::Write);
+        assert_eq!(BashClassifier::classify("mv a b"), CommandIntent::Write);
+        assert_eq!(BashClassifier::classify("mkdir dir"), CommandIntent::Write);
+        assert_eq!(BashClassifier::classify("touch file"), CommandIntent::Write);
+        assert_eq!(BashClassifier::classify("tee file"), CommandIntent::Write);
+    }
+
+    #[test]
+    fn test_classify_git_write() {
+        assert_eq!(
+            BashClassifier::classify("git add file.rs"),
+            CommandIntent::Write
+        );
+        assert_eq!(
+            BashClassifier::classify("git commit -m 'fix'"),
+            CommandIntent::Write
+        );
+        assert_eq!(
+            BashClassifier::classify("git push origin main"),
+            CommandIntent::Write
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Destructive command tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_classify_destructive() {
+        assert_eq!(BashClassifier::classify("rm file"), CommandIntent::Destructive);
+        assert_eq!(
+            BashClassifier::classify("rm -rf /tmp"),
+            CommandIntent::Destructive
+        );
+        assert_eq!(
+            BashClassifier::classify("shred file"),
+            CommandIntent::Destructive
+        );
+        assert_eq!(BashClassifier::classify("dd if=/dev/zero of=file"), CommandIntent::Destructive);
+    }
+
+    #[test]
+    fn test_classify_redirect_destructive() {
+        assert_eq!(
+            BashClassifier::classify("> file"),
+            CommandIntent::Destructive
+        );
+        assert_eq!(
+            BashClassifier::classify(">> file"),
+            CommandIntent::Destructive
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Network command tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_classify_network() {
+        assert_eq!(
+            BashClassifier::classify("curl https://example.com"),
+            CommandIntent::Network
+        );
+        assert_eq!(
+            BashClassifier::classify("wget https://example.com/file"),
+            CommandIntent::Network
+        );
+        assert_eq!(
+            BashClassifier::classify("ping 8.8.8.8"),
+            CommandIntent::Network
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Package management tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_classify_package_management() {
+        assert_eq!(
+            BashClassifier::classify("cargo build"),
+            CommandIntent::PackageManagement
+        );
+        assert_eq!(
+            BashClassifier::classify("cargo test"),
+            CommandIntent::PackageManagement
+        );
+        assert_eq!(
+            BashClassifier::classify("cargo clippy"),
+            CommandIntent::PackageManagement
+        );
+        assert_eq!(
+            BashClassifier::classify("npm install"),
+            CommandIntent::PackageManagement
+        );
+        assert_eq!(
+            BashClassifier::classify("pip install flask"),
+            CommandIntent::PackageManagement
+        );
+        assert_eq!(
+            BashClassifier::classify("apt update"),
+            CommandIntent::PackageManagement
+        );
+        assert_eq!(
+            BashClassifier::classify("brew install curl"),
+            CommandIntent::PackageManagement
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // System admin tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_classify_system_admin() {
+        assert_eq!(
+            BashClassifier::classify("sudo apt update"),
+            CommandIntent::SystemAdmin
+        );
+        assert_eq!(
+            BashClassifier::classify("chmod +x script.sh"),
+            CommandIntent::SystemAdmin
+        );
+        assert_eq!(
+            BashClassifier::classify("systemctl start nginx"),
+            CommandIntent::SystemAdmin
+        );
+        assert_eq!(
+            BashClassifier::classify("docker ps"),
+            CommandIntent::SystemAdmin
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Process management tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_classify_process() {
+        assert_eq!(
+            BashClassifier::classify("kill 1234"),
+            CommandIntent::ProcessManagement
+        );
+        assert_eq!(
+            BashClassifier::classify("pkill nginx"),
+            CommandIntent::ProcessManagement
+        );
+        assert_eq!(
+            BashClassifier::classify("jobs"),
+            CommandIntent::ProcessManagement
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Edge case tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_classify_empty_input() {
+        assert_eq!(BashClassifier::classify(""), CommandIntent::Unknown);
+        assert_eq!(BashClassifier::classify("   "), CommandIntent::Unknown);
+    }
+
+    #[test]
+    fn test_classify_pipeline() {
+        // Pipeline classified by first command
+        assert_eq!(
+            BashClassifier::classify("ls -la | grep pattern"),
+            CommandIntent::ReadOnly
+        );
+        assert_eq!(
+            BashClassifier::classify("cat file | wc -l"),
+            CommandIntent::ReadOnly
+        );
+    }
+
+    #[test]
+    fn test_classify_unknown_command() {
+        assert_eq!(
+            BashClassifier::classify("some_unknown_tool"),
+            CommandIntent::Unknown
+        );
+    }
+
+    #[test]
+    fn test_classify_semicolon_chain() {
+        assert_eq!(
+            BashClassifier::classify("ls; rm file"),
+            CommandIntent::ReadOnly
+        );
+    }
+
+    #[test]
+    fn test_classify_and_chain() {
+        assert_eq!(
+            BashClassifier::classify("ls && echo done"),
+            CommandIntent::ReadOnly
+        );
+    }
+
+    #[test]
+    fn test_classify_multiple_pipes() {
+        assert_eq!(
+            BashClassifier::classify("cat data.json | jq '.users' | head -5"),
+            CommandIntent::ReadOnly
+        );
+    }
+
+    #[test]
+    fn test_classify_unrecognized_git_subcommand() {
+        // Unknown git subcommand defaults to Write (conservative)
+        assert_eq!(
+            BashClassifier::classify("git unknown-cmd"),
+            CommandIntent::Write
+        );
+    }
+
+    #[test]
+    fn test_classify_path_prefixed() {
+        assert_eq!(
+            BashClassifier::classify("/bin/ls -la /tmp"),
+            CommandIntent::ReadOnly
+        );
+        assert_eq!(
+            BashClassifier::classify("/usr/bin/find . -name '*.rs'"),
+            CommandIntent::ReadOnly
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // required_mode_for_intent tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_required_mode_for_intent() {
+        use crate::permission::domain::PermissionMode;
+        assert_eq!(
+            BashClassifier::required_mode_for_intent(CommandIntent::ReadOnly),
+            PermissionMode::ReadOnly
+        );
+        assert_eq!(
+            BashClassifier::required_mode_for_intent(CommandIntent::Write),
+            PermissionMode::WorkspaceWrite
+        );
+        assert_eq!(
+            BashClassifier::required_mode_for_intent(CommandIntent::Destructive),
+            PermissionMode::DangerousFullAccess
+        );
+        assert_eq!(
+            BashClassifier::required_mode_for_intent(CommandIntent::Network),
+            PermissionMode::DangerousFullAccess
+        );
+        assert_eq!(
+            BashClassifier::required_mode_for_intent(CommandIntent::PackageManagement),
+            PermissionMode::WorkspaceWrite
+        );
+        assert_eq!(
+            BashClassifier::required_mode_for_intent(CommandIntent::SystemAdmin),
+            PermissionMode::DangerousFullAccess
+        );
+        assert_eq!(
+            BashClassifier::required_mode_for_intent(CommandIntent::Unknown),
+            PermissionMode::WorkspaceWrite
+        );
+    }
+}

--- a/engine/src/permission/domain/config.rs
+++ b/engine/src/permission/domain/config.rs
@@ -1,0 +1,179 @@
+//! PermissionConfig — configuration for the permission enforcer.
+//!
+//! @canonical .pi/architecture/modules/permission-enforcer.md#config
+//! Implements: Contract Freeze — PermissionConfig struct
+//! Issue: issue-contract-freeze
+//!
+//! Defines the configuration for the permission enforcer, including
+//! the default mode, allow/deny/ask rule lists, and per-tool permission
+//! mappings. Config is loaded from `.rigorix/permissions.toml` or
+//! equivalent configuration source.
+//!
+//! # Contract (Frozen)
+//! - All configuration is optional — defaults are safe
+//! - Allow/deny/ask rules are simple string patterns (currently exact match)
+//! - Per-tool permission overrides map tool names to required modes
+//! - Serialized as TOML for the config file
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use super::PermissionMode;
+
+/// Configuration for the permission enforcer.
+///
+/// Loaded from the `.rigorix/permissions.toml` file (or equivalent).
+/// All fields have safe defaults so the enforcer works without
+/// explicit configuration.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PermissionConfig {
+    /// Default permission mode applied when no mode is explicitly set.
+    #[serde(default)]
+    pub default_mode: PermissionMode,
+
+    /// Tool names that are always allowed (overrides mode check).
+    #[serde(default)]
+    pub allow: Vec<String>,
+
+    /// Tool names that are always denied (overrides allow rules).
+    #[serde(default)]
+    pub deny: Vec<String>,
+
+    /// Tool names that require user confirmation via prompter.
+    #[serde(default)]
+    pub ask: Vec<String>,
+
+    /// Per-tool permission mode overrides.
+    /// Maps tool name to the minimum mode required.
+    #[serde(default)]
+    pub tool_permissions: HashMap<String, PermissionMode>,
+}
+
+impl Default for PermissionConfig {
+    fn default() -> Self {
+        Self {
+            default_mode: PermissionMode::WorkspaceWrite,
+            allow: vec![
+                "read_file".to_string(),
+                "grep_search".to_string(),
+                "glob".to_string(),
+                "lsp_query".to_string(),
+            ],
+            deny: vec![],
+            ask: vec![
+                "git_commit".to_string(),
+                "git_push".to_string(),
+                "bash".to_string(),
+            ],
+            tool_permissions: HashMap::from([
+                ("read_file".to_string(), PermissionMode::ReadOnly),
+                ("grep_search".to_string(), PermissionMode::ReadOnly),
+                ("glob".to_string(), PermissionMode::ReadOnly),
+                ("lsp_query".to_string(), PermissionMode::ReadOnly),
+                ("write_file".to_string(), PermissionMode::WorkspaceWrite),
+                ("edit_file".to_string(), PermissionMode::WorkspaceWrite),
+                ("create_file".to_string(), PermissionMode::WorkspaceWrite),
+                ("delete_file".to_string(), PermissionMode::DangerousFullAccess),
+                ("bash".to_string(), PermissionMode::WorkspaceWrite),
+                ("git_commit".to_string(), PermissionMode::WorkspaceWrite),
+                ("git_push".to_string(), PermissionMode::DangerousFullAccess),
+                ("run_command".to_string(), PermissionMode::WorkspaceWrite),
+            ]),
+        }
+    }
+}
+
+impl PermissionConfig {
+    /// Create a `PermissionConfig` that allows everything (for testing).
+    pub fn permissive() -> Self {
+        Self {
+            default_mode: PermissionMode::DangerousFullAccess,
+            allow: vec!["*".to_string()], // wildcard: allow all
+            deny: vec![],
+            ask: vec![],
+            tool_permissions: HashMap::new(),
+        }
+    }
+
+    /// Create a `PermissionConfig` that allows only read operations.
+    pub fn read_only() -> Self {
+        Self {
+            default_mode: PermissionMode::ReadOnly,
+            allow: vec![
+                "read_file".to_string(),
+                "grep_search".to_string(),
+                "glob".to_string(),
+                "lsp_query".to_string(),
+            ],
+            deny: vec![
+                "write_file".to_string(),
+                "edit_file".to_string(),
+                "create_file".to_string(),
+                "delete_file".to_string(),
+                "bash".to_string(),
+                "git_commit".to_string(),
+                "git_push".to_string(),
+                "run_command".to_string(),
+            ],
+            ask: vec![],
+            tool_permissions: HashMap::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = PermissionConfig::default();
+        assert_eq!(config.default_mode, PermissionMode::WorkspaceWrite);
+        assert!(!config.allow.is_empty());
+        assert!(config.deny.is_empty());
+        assert!(config.tool_permissions.contains_key("read_file"));
+        assert_eq!(
+            config.tool_permissions.get("read_file"),
+            Some(&PermissionMode::ReadOnly)
+        );
+    }
+
+    #[test]
+    fn test_permissive_config() {
+        let config = PermissionConfig::permissive();
+        assert_eq!(config.default_mode, PermissionMode::DangerousFullAccess);
+        assert!(config.allow.contains(&"*".to_string()));
+    }
+
+    #[test]
+    fn test_read_only_config() {
+        let config = PermissionConfig::read_only();
+        assert_eq!(config.default_mode, PermissionMode::ReadOnly);
+        assert!(config.deny.contains(&"bash".to_string()));
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let config = PermissionConfig::default();
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: PermissionConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, config);
+    }
+
+    #[test]
+    fn test_config_with_custom_tool_permissions() {
+        let config = PermissionConfig {
+            default_mode: PermissionMode::ReadOnly,
+            allow: vec![],
+            deny: vec!["curl".to_string()],
+            ask: vec!["bash".to_string()],
+            tool_permissions: HashMap::from([
+                ("custom_tool".to_string(), PermissionMode::DangerousFullAccess),
+            ]),
+        };
+        assert_eq!(
+            config.tool_permissions.get("custom_tool"),
+            Some(&PermissionMode::DangerousFullAccess)
+        );
+    }
+}

--- a/engine/src/permission/domain/context.rs
+++ b/engine/src/permission/domain/context.rs
@@ -1,0 +1,138 @@
+//! PermissionContext — override context for permission decisions.
+//!
+//! @canonical .pi/architecture/modules/permission-enforcer.md#context
+//! Implements: Contract Freeze — PermissionContext struct
+//! Issue: issue-contract-freeze
+//!
+//! Provides temporal or conditional override context for permission
+//! decisions. Hooks or user interactions can set override context
+//! that modifies how the permission policy evaluates requests.
+//!
+//! # Contract (Frozen)
+//! - Overrides have clear precedence rules
+//! - Context is ephemeral (not persisted)
+//! - `duration_secs` = 0 means single-use (expires after one check)
+
+use serde::{Deserialize, Serialize};
+
+use super::PermissionMode;
+
+/// Override context that modifies permission policy decisions.
+///
+/// Context can be set by hooks (e.g., "user approved elevation via prompt")
+/// or by the user explicitly (e.g., `--permission-mode workspace-write`).
+///
+/// # Precedence
+/// 1. If `elevated_mode` is `Some`, it overrides the active mode for
+///    the specified duration or single check.
+/// 2. If `temporary_bypass` is `true`, all permission checks are bypassed
+///    for the specified duration or single check.
+/// 3. Otherwise, normal policy evaluation applies.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PermissionContext {
+    /// Temporarily elevate to this permission mode.
+    /// If `Some`, overrides the active mode for the duration.
+    pub elevated_mode: Option<PermissionMode>,
+
+    /// Duration in seconds for which the override is active.
+    /// 0 means single-use (expires after one permission check).
+    pub duration_secs: u64,
+
+    /// If true, all permission checks are bypassed temporarily.
+    pub temporary_bypass: bool,
+
+    /// Human-readable reason for the override (for audit).
+    pub reason: Option<String>,
+
+    /// Source of the override (e.g., "hook:bash_permission_prompt", "cli:--permission-mode").
+    pub source: Option<String>,
+}
+
+impl PermissionContext {
+    /// Create a new `PermissionContext` with no overrides.
+    pub fn none() -> Self {
+        Self {
+            elevated_mode: None,
+            duration_secs: 0,
+            temporary_bypass: false,
+            reason: None,
+            source: None,
+        }
+    }
+
+    /// Create a `PermissionContext` that elevates to a specific mode.
+    pub fn elevate(mode: PermissionMode, reason: &str) -> Self {
+        Self {
+            elevated_mode: Some(mode),
+            duration_secs: 0, // single-use by default
+            temporary_bypass: false,
+            reason: Some(reason.to_string()),
+            source: None,
+        }
+    }
+
+    /// Create a `PermissionContext` that bypasses all checks.
+    pub fn bypass(reason: &str) -> Self {
+        Self {
+            elevated_mode: None,
+            duration_secs: 0,
+            temporary_bypass: true,
+            reason: Some(reason.to_string()),
+            source: None,
+        }
+    }
+
+    /// Returns `true` if this context has any active override.
+    pub fn has_override(&self) -> bool {
+        self.elevated_mode.is_some() || self.temporary_bypass
+    }
+}
+
+impl Default for PermissionContext {
+    fn default() -> Self {
+        Self::none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_none_context() {
+        let ctx = PermissionContext::none();
+        assert!(!ctx.has_override());
+        assert!(ctx.elevated_mode.is_none());
+        assert!(!ctx.temporary_bypass);
+    }
+
+    #[test]
+    fn test_elevate_context() {
+        let ctx = PermissionContext::elevate(PermissionMode::DangerousFullAccess, "Need to install deps");
+        assert!(ctx.has_override());
+        assert_eq!(ctx.elevated_mode, Some(PermissionMode::DangerousFullAccess));
+        assert_eq!(ctx.reason.as_deref(), Some("Need to install deps"));
+    }
+
+    #[test]
+    fn test_bypass_context() {
+        let ctx = PermissionContext::bypass("User approved full access");
+        assert!(ctx.has_override());
+        assert!(ctx.temporary_bypass);
+        assert_eq!(ctx.reason.as_deref(), Some("User approved full access"));
+    }
+
+    #[test]
+    fn test_default_is_none() {
+        let ctx = PermissionContext::default();
+        assert!(!ctx.has_override());
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let ctx = PermissionContext::elevate(PermissionMode::DangerousFullAccess, "test");
+        let json = serde_json::to_string(&ctx).unwrap();
+        let deserialized: PermissionContext = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, ctx);
+    }
+}

--- a/engine/src/permission/domain/error.rs
+++ b/engine/src/permission/domain/error.rs
@@ -1,0 +1,150 @@
+//! PermissionError — typed error enum for the permission enforcer.
+//!
+//! @canonical .pi/architecture/modules/permission-enforcer.md#error
+//! Implements: Contract Freeze — PermissionError enum
+//! Issue: issue-contract-freeze
+//!
+//! All permission-related errors use `thiserror` derive macros.
+//! Errors carry structured context for error reporting and LLM feedback.
+//!
+//! # Contract (Frozen)
+//! - `PermissionError` is the single error type for this module
+//! - Each variant carries structured context
+//! - Implements `std::error::Error` for library compatibility
+//! - All errors are non-retriable by default
+
+use thiserror::Error;
+
+/// Errors that can occur during permission enforcement.
+#[derive(Debug, Error)]
+pub enum PermissionError {
+    /// A tool call was denied by the permission enforcer.
+    #[error("Permission denied: {reason}")]
+    PermissionDenied {
+        /// The name of the tool that was denied.
+        tool: String,
+        /// Human-readable reason for the denial.
+        reason: String,
+        /// The active permission mode.
+        active_mode: String,
+        /// The required permission mode.
+        required_mode: String,
+    },
+
+    /// The permission configuration is invalid.
+    #[error("Invalid permission configuration: {detail}")]
+    InvalidConfiguration {
+        /// Details about the configuration error.
+        detail: String,
+    },
+
+    /// The requested policy was not found.
+    #[error("Policy not found for tool: {tool}")]
+    PolicyNotFound {
+        /// The name of the tool with no policy.
+        tool: String,
+    },
+
+    /// The permission enforcer is in an invalid state.
+    #[error("Invalid enforcer state: {detail}")]
+    InvalidState {
+        /// Details about the state error.
+        detail: String,
+    },
+
+    /// The workspace root is not configured.
+    #[error("Workspace root not configured")]
+    WorkspaceRootNotConfigured,
+}
+
+impl PermissionError {
+    /// Returns `true` if the error is retriable.
+    /// Permission errors are generally not retriable.
+    pub fn is_retriable(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_permission_denied_error() {
+        let err = PermissionError::PermissionDenied {
+            tool: "bash".to_string(),
+            reason: "bash requires workspace_write mode".to_string(),
+            active_mode: "read_only".to_string(),
+            required_mode: "workspace_write".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("Permission denied"));
+        assert!(msg.contains("bash"));
+        assert!(msg.contains("workspace_write"));
+        assert!(!err.is_retriable());
+    }
+
+    #[test]
+    fn test_invalid_configuration_error() {
+        let err = PermissionError::InvalidConfiguration {
+            detail: "Unknown permission mode 'super_admin'".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("Invalid permission configuration"));
+        assert!(msg.contains("super_admin"));
+    }
+
+    #[test]
+    fn test_policy_not_found_error() {
+        let err = PermissionError::PolicyNotFound {
+            tool: "unknown_tool".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("Policy not found"));
+        assert!(msg.contains("unknown_tool"));
+    }
+
+    #[test]
+    fn test_invalid_state_error() {
+        let err = PermissionError::InvalidState {
+            detail: "Lock poisoned".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("Invalid enforcer state"));
+        assert!(msg.contains("Lock poisoned"));
+    }
+
+    #[test]
+    fn test_workspace_root_not_configured() {
+        let err = PermissionError::WorkspaceRootNotConfigured;
+        assert_eq!(err.to_string(), "Workspace root not configured");
+    }
+
+    #[test]
+    fn test_all_errors_non_retriable() {
+        assert!(!PermissionError::PermissionDenied {
+            tool: "x".to_string(),
+            reason: "test".to_string(),
+            active_mode: "ro".to_string(),
+            required_mode: "ww".to_string(),
+        }
+        .is_retriable());
+
+        assert!(!PermissionError::InvalidConfiguration {
+            detail: "test".to_string()
+        }
+        .is_retriable());
+
+        assert!(!PermissionError::PolicyNotFound {
+            tool: "x".to_string()
+        }
+        .is_retriable());
+
+        assert!(!PermissionError::InvalidState {
+            detail: "test".to_string()
+        }
+        .is_retriable());
+
+        assert!(!PermissionError::WorkspaceRootNotConfigured.is_retriable());
+    }
+}

--- a/engine/src/permission/domain/event/mod.rs
+++ b/engine/src/permission/domain/event/mod.rs
@@ -1,0 +1,177 @@
+//! Event payload schemas for the Permission Enforcer.
+//!
+//! @canonical .pi/architecture/modules/permission-enforcer.md
+//! Implements: Contract Freeze — PermissionEvent payload schemas
+//! Issue: issue-contract-freeze
+//!
+//! These events are emitted whenever permission enforcement actions
+//! are taken — tools evaluated, modes changed, permissions overridden.
+//! Consumers (audit, TUI) subscribe to these event types.
+//!
+//! # Contract (Frozen)
+//! - Each event carries full context needed by consumers
+//! - No internal implementation details exposed
+//! - All events include an optional `execution_id` for correlation
+
+use serde::{Deserialize, Serialize};
+
+/// Events emitted by the Permission Enforcer module.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum PermissionEvent {
+    /// A tool invocation was evaluated by the permission enforcer.
+    ToolEvaluated {
+        /// Optional execution ID for correlation.
+        execution_id: Option<String>,
+        /// The name of the tool being evaluated.
+        tool: String,
+        /// The active permission mode at evaluation time.
+        active_mode: String,
+        /// The required permission mode for this tool.
+        required_mode: String,
+        /// Whether the tool was allowed or denied.
+        outcome: String, // "allowed" or "denied"
+        /// The reason for the decision (if denied).
+        reason: Option<String>,
+    },
+
+    /// The active permission mode was changed.
+    ModeChanged {
+        /// Optional execution ID for correlation.
+        execution_id: Option<String>,
+        /// The previous permission mode.
+        previous_mode: String,
+        /// The new permission mode.
+        new_mode: String,
+        /// Source of the change (e.g., "cli", "hook", "user").
+        source: String,
+        /// Reason for the change.
+        reason: Option<String>,
+    },
+
+    /// A permission override was applied.
+    OverrideApplied {
+        /// Optional execution ID for correlation.
+        execution_id: Option<String>,
+        /// Type of override (e.g., "elevation", "bypass").
+        override_type: String,
+        /// Duration of the override in seconds (0 = single-use).
+        duration_secs: u64,
+        /// Source of the override.
+        source: Option<String>,
+        /// Reason for the override.
+        reason: Option<String>,
+    },
+
+    /// A bash command was classified and evaluated.
+    BashCommandEvaluated {
+        /// Optional execution ID for correlation.
+        execution_id: Option<String>,
+        /// The bash command string.
+        command: String,
+        /// The classified intent.
+        classification: String,
+        /// Whether the command was allowed.
+        allowed: bool,
+        /// The active mode at evaluation.
+        active_mode: String,
+        /// The minimum mode required for this command intent.
+        required_mode: String,
+    },
+
+    /// A file write was checked against workspace boundaries.
+    FileWriteChecked {
+        /// Optional execution ID for correlation.
+        execution_id: Option<String>,
+        /// The path that was checked.
+        path: String,
+        /// The workspace root.
+        workspace_root: String,
+        /// Whether the path is within the workspace.
+        within_workspace: bool,
+        /// Whether the write was allowed.
+        allowed: bool,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tool_evaluated_event() {
+        let event = PermissionEvent::ToolEvaluated {
+            execution_id: Some("exec-1".to_string()),
+            tool: "bash".to_string(),
+            active_mode: "read_only".to_string(),
+            required_mode: "workspace_write".to_string(),
+            outcome: "denied".to_string(),
+            reason: Some("bash requires workspace_write".to_string()),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let deserialized: PermissionEvent = serde_json::from_str(&json).unwrap();
+        assert!(matches!(deserialized, PermissionEvent::ToolEvaluated { .. }));
+    }
+
+    #[test]
+    fn test_mode_changed_event() {
+        let event = PermissionEvent::ModeChanged {
+            execution_id: None,
+            previous_mode: "read_only".to_string(),
+            new_mode: "workspace_write".to_string(),
+            source: "cli".to_string(),
+            reason: Some("User requested elevation".to_string()),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let deserialized: PermissionEvent = serde_json::from_str(&json).unwrap();
+        assert!(matches!(deserialized, PermissionEvent::ModeChanged { .. }));
+    }
+
+    #[test]
+    fn test_serde_roundtrip_all_variants() {
+        let variants = vec![
+            PermissionEvent::ToolEvaluated {
+                execution_id: None,
+                tool: "test".to_string(),
+                active_mode: "ro".to_string(),
+                required_mode: "ww".to_string(),
+                outcome: "denied".to_string(),
+                reason: None,
+            },
+            PermissionEvent::ModeChanged {
+                execution_id: None,
+                previous_mode: "ro".to_string(),
+                new_mode: "ww".to_string(),
+                source: "cli".to_string(),
+                reason: None,
+            },
+            PermissionEvent::OverrideApplied {
+                execution_id: None,
+                override_type: "elevation".to_string(),
+                duration_secs: 0,
+                source: None,
+                reason: None,
+            },
+            PermissionEvent::BashCommandEvaluated {
+                execution_id: None,
+                command: "ls".to_string(),
+                classification: "read_only".to_string(),
+                allowed: true,
+                active_mode: "read_only".to_string(),
+                required_mode: "read_only".to_string(),
+            },
+            PermissionEvent::FileWriteChecked {
+                execution_id: None,
+                path: "/tmp/test".to_string(),
+                workspace_root: "/workspace".to_string(),
+                within_workspace: false,
+                allowed: false,
+            },
+        ];
+
+        for event in variants {
+            let json = serde_json::to_string(&event).unwrap();
+            let deserialized: PermissionEvent = serde_json::from_str(&json).unwrap();
+            assert!(std::mem::discriminant(&event) == std::mem::discriminant(&deserialized));
+        }
+    }
+}

--- a/engine/src/permission/domain/mod.rs
+++ b/engine/src/permission/domain/mod.rs
@@ -1,0 +1,35 @@
+//! Domain entities and interfaces for the Permission Enforcer bounded context.
+//!
+//! @canonical .pi/architecture/modules/permission-enforcer.md#domain
+//! Implements: Contract Freeze — domain entities PermissionMode, PermissionPolicy,
+//!   PermissionOutcome, BashClassifier, PermissionConfig, PermissionError, PermissionEvent
+//! Issue: issue-contract-freeze
+//!
+//! This module defines the core domain types — the three-tier permission
+//! mode, the authorization policy, bash command classification, and all
+//! permission-related events. These are pure domain objects with no
+//! framework dependencies.
+//!
+//! # Contract (Frozen)
+//! - No implementation logic beyond constructors and field accessors
+//! - All enforcement orchestration lives in the application layer
+//! - All persistence happens behind repository interfaces
+
+pub mod bash_classifier;
+pub mod config;
+pub mod context;
+pub mod error;
+pub mod event;
+pub mod mode;
+pub mod outcome;
+pub mod policy;
+pub mod prompter;
+
+pub use bash_classifier::{BashClassifier, CommandIntent};
+pub use config::PermissionConfig;
+pub use context::PermissionContext;
+pub use error::PermissionError;
+pub use mode::PermissionMode;
+pub use outcome::{EnforcementResult, PermissionOutcome};
+pub use policy::PermissionPolicy;
+pub use prompter::{AllowAllPrompter, DenyAllPrompter, PermissionPrompter, PromptResponse};

--- a/engine/src/permission/domain/mode.rs
+++ b/engine/src/permission/domain/mode.rs
@@ -1,0 +1,210 @@
+//! PermissionMode — three-tier permission hierarchy.
+//!
+//! @canonical .pi/architecture/modules/permission-enforcer.md#mode
+//! Implements: Contract Freeze — PermissionMode enum
+//! Issue: issue-contract-freeze
+//!
+//! Defines the three-tier permission mode that controls which tools
+//! can be executed. The active mode caps the maximum risk level a tool
+//! can access. Tools requesting a higher `required_mode` than the
+//! active mode are denied.
+//!
+//! # Contract (Frozen)
+//! - Ord derives from the discriminant order: ReadOnly < WorkspaceWrite < DangerousFullAccess
+//! - Serde serialization uses snake_case
+//! - No additional variants without explicit contract change approval
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Three-tier permission mode hierarchy.
+///
+/// Each mode is more permissive than the previous one:
+/// - `ReadOnly` — Only read operations (file reads, grep, git log, read-only bash).
+/// - `WorkspaceWrite` — Read + write within the workspace boundary.
+/// - `DangerousFullAccess` — No restrictions.
+///
+/// The `Ord` derives from discriminant values: ReadOnly(0) < WorkspaceWrite(1) < DangerousFullAccess(2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionMode {
+    /// Only read operations: file_read, grep, glob, git_log, lsp_query.
+    /// Bash: only read-only commands (ls, cat, grep, find, etc.).
+    #[serde(rename = "read_only")]
+    ReadOnly = 0,
+
+    /// Read + write operations within the workspace boundary.
+    /// Bash: all commands allowed (subject to tool policy).
+    #[serde(rename = "workspace_write")]
+    WorkspaceWrite = 1,
+
+    /// No restrictions — full system access. Use with extreme caution.
+    #[serde(rename = "danger_full_access")]
+    DangerousFullAccess = 2,
+}
+
+impl PermissionMode {
+    /// Returns the string representation of this mode.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PermissionMode::ReadOnly => "read_only",
+            PermissionMode::WorkspaceWrite => "workspace_write",
+            PermissionMode::DangerousFullAccess => "danger_full_access",
+        }
+    }
+
+    /// Returns `true` if this mode allows read operations.
+    pub fn can_read(&self) -> bool {
+        true // All modes allow reads
+    }
+
+    /// Returns `true` if this mode allows write operations within workspace.
+    pub fn can_write_within_workspace(&self) -> bool {
+        matches!(self, PermissionMode::WorkspaceWrite | PermissionMode::DangerousFullAccess)
+    }
+
+    /// Returns `true` if this mode allows write operations outside workspace.
+    pub fn can_write_outside_workspace(&self) -> bool {
+        matches!(self, PermissionMode::DangerousFullAccess)
+    }
+
+    /// Returns `true` if this mode allows destructive operations.
+    pub fn can_execute_destructive(&self) -> bool {
+        matches!(self, PermissionMode::DangerousFullAccess)
+    }
+
+    /// Returns `true` if this mode allows package management commands.
+    pub fn can_manage_packages(&self) -> bool {
+        matches!(self, PermissionMode::WorkspaceWrite | PermissionMode::DangerousFullAccess)
+    }
+
+    /// Returns `true` if this mode allows network operations.
+    pub fn can_use_network(&self) -> bool {
+        matches!(self, PermissionMode::DangerousFullAccess)
+    }
+
+    /// Returns the minimum mode required for the given capability.
+    pub fn required_for_capability(capability: &str) -> Self {
+        match capability {
+            "read" | "grep" | "query" => PermissionMode::ReadOnly,
+            "write_within_workspace"
+            | "edit"
+            | "build"
+            | "package_management"
+            | "git_commit" => PermissionMode::WorkspaceWrite,
+            "write_outside_workspace"
+            | "destructive"
+            | "network"
+            | "process_management"
+            | "system_admin"
+            | "git_push" => PermissionMode::DangerousFullAccess,
+            _ => PermissionMode::WorkspaceWrite, // safe default
+        }
+    }
+}
+
+impl fmt::Display for PermissionMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl Default for PermissionMode {
+    fn default() -> Self {
+        PermissionMode::WorkspaceWrite
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ordering() {
+        assert!(PermissionMode::ReadOnly < PermissionMode::WorkspaceWrite);
+        assert!(PermissionMode::WorkspaceWrite < PermissionMode::DangerousFullAccess);
+        assert!(PermissionMode::ReadOnly < PermissionMode::DangerousFullAccess);
+    }
+
+    #[test]
+    fn test_capabilities() {
+        assert!(PermissionMode::ReadOnly.can_read());
+        assert!(!PermissionMode::ReadOnly.can_write_within_workspace());
+        assert!(!PermissionMode::ReadOnly.can_write_outside_workspace());
+        assert!(!PermissionMode::ReadOnly.can_execute_destructive());
+
+        assert!(PermissionMode::WorkspaceWrite.can_read());
+        assert!(PermissionMode::WorkspaceWrite.can_write_within_workspace());
+        assert!(!PermissionMode::WorkspaceWrite.can_write_outside_workspace());
+        assert!(!PermissionMode::WorkspaceWrite.can_execute_destructive());
+
+        assert!(PermissionMode::DangerousFullAccess.can_read());
+        assert!(PermissionMode::DangerousFullAccess.can_write_within_workspace());
+        assert!(PermissionMode::DangerousFullAccess.can_write_outside_workspace());
+        assert!(PermissionMode::DangerousFullAccess.can_execute_destructive());
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        for mode in &[
+            PermissionMode::ReadOnly,
+            PermissionMode::WorkspaceWrite,
+            PermissionMode::DangerousFullAccess,
+        ] {
+            let json = serde_json::to_string(mode).unwrap();
+            let deserialized: PermissionMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(*mode, deserialized);
+        }
+    }
+
+    #[test]
+    fn test_serde_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&PermissionMode::ReadOnly).unwrap(),
+            "\"read_only\""
+        );
+        assert_eq!(
+            serde_json::to_string(&PermissionMode::WorkspaceWrite).unwrap(),
+            "\"workspace_write\""
+        );
+        assert_eq!(
+            serde_json::to_string(&PermissionMode::DangerousFullAccess).unwrap(),
+            "\"danger_full_access\""
+        );
+    }
+
+    #[test]
+    fn test_as_str() {
+        assert_eq!(PermissionMode::ReadOnly.as_str(), "read_only");
+        assert_eq!(PermissionMode::WorkspaceWrite.as_str(), "workspace_write");
+        assert_eq!(
+            PermissionMode::DangerousFullAccess.as_str(),
+            "danger_full_access"
+        );
+    }
+
+    #[test]
+    fn test_default_is_workspace_write() {
+        assert_eq!(PermissionMode::default(), PermissionMode::WorkspaceWrite);
+    }
+
+    #[test]
+    fn test_required_for_capability() {
+        assert_eq!(
+            PermissionMode::required_for_capability("write_within_workspace"),
+            PermissionMode::WorkspaceWrite
+        );
+        assert_eq!(
+            PermissionMode::required_for_capability("destructive"),
+            PermissionMode::DangerousFullAccess
+        );
+        assert_eq!(
+            PermissionMode::required_for_capability("grep"),
+            PermissionMode::ReadOnly
+        );
+        assert_eq!(
+            PermissionMode::required_for_capability("unknown"),
+            PermissionMode::WorkspaceWrite
+        );
+    }
+}

--- a/engine/src/permission/domain/outcome.rs
+++ b/engine/src/permission/domain/outcome.rs
@@ -1,0 +1,190 @@
+//! PermissionOutcome — structured result of permission enforcement.
+//!
+//! @canonical .pi/architecture/modules/permission-enforcer.md#outcome
+//! Implements: Contract Freeze — PermissionOutcome / EnforcementResult enum
+//! Issue: issue-contract-freeze
+//!
+//! Represents the result of a permission check. A tool invocation is
+//! either `Allowed` or `Denied` with a structured reason that includes
+//! the tool name, the active mode, the required mode, and a human-readable
+//! explanation. This structured feedback allows the LLM to adapt.
+//!
+//! # Contract (Frozen)
+//! - `Allowed` carries no extra data (fast path)
+//! - `Denied` carries full context for LLM feedback and audit
+//! - Serialized with `outcome` tag for easy deserialization
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// The result of a permission enforcement check.
+///
+/// Returned by `PermissionPolicy::authorize()` and all
+/// `PermissionEnforcer` check methods.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "outcome")]
+pub enum PermissionOutcome {
+    /// The operation is permitted.
+    Allowed,
+
+    /// The operation is denied with a structured reason.
+    Denied {
+        /// The name of the tool that was denied.
+        tool: String,
+
+        /// The active permission mode at the time of denial.
+        active_mode: String,
+
+        /// The permission mode that would have been required.
+        required_mode: String,
+
+        /// Human-readable explanation of why the operation was denied.
+        reason: String,
+    },
+}
+
+impl PermissionOutcome {
+    /// Returns `true` if the outcome is `Allowed`.
+    pub fn is_allowed(&self) -> bool {
+        matches!(self, PermissionOutcome::Allowed)
+    }
+
+    /// Returns `true` if the outcome is `Denied`.
+    pub fn is_denied(&self) -> bool {
+        matches!(self, PermissionOutcome::Denied { .. })
+    }
+
+    /// Returns the deny reason if denied, or `None` if allowed.
+    pub fn deny_reason(&self) -> Option<&str> {
+        match self {
+            PermissionOutcome::Allowed => None,
+            PermissionOutcome::Denied { reason, .. } => Some(reason.as_str()),
+        }
+    }
+
+    /// Returns the denied tool if denied, or `None`.
+    pub fn denied_tool(&self) -> Option<&str> {
+        match self {
+            PermissionOutcome::Allowed => None,
+            PermissionOutcome::Denied { tool, .. } => Some(tool.as_str()),
+        }
+    }
+}
+
+impl fmt::Display for PermissionOutcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PermissionOutcome::Allowed => write!(f, "Allowed"),
+            PermissionOutcome::Denied { tool, active_mode, required_mode, reason } => {
+                write!(
+                    f,
+                    "Denied[tool={}, active_mode={}, required_mode={}]: {}",
+                    tool, active_mode, required_mode, reason
+                )
+            }
+        }
+    }
+}
+
+/// Alias for `PermissionOutcome` — used when integrating with
+/// the existing enforcement module to emphasize enforcement semantics.
+pub type EnforcementResult = PermissionOutcome;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_allowed_outcome() {
+        let outcome = PermissionOutcome::Allowed;
+        assert!(outcome.is_allowed());
+        assert!(!outcome.is_denied());
+        assert!(outcome.deny_reason().is_none());
+        assert!(outcome.denied_tool().is_none());
+    }
+
+    #[test]
+    fn test_denied_outcome() {
+        let outcome = PermissionOutcome::Denied {
+            tool: "bash".to_string(),
+            active_mode: "read_only".to_string(),
+            required_mode: "workspace_write".to_string(),
+            reason: "bash requires workspace_write mode".to_string(),
+        };
+        assert!(!outcome.is_allowed());
+        assert!(outcome.is_denied());
+        assert_eq!(outcome.deny_reason(), Some("bash requires workspace_write mode"));
+        assert_eq!(outcome.denied_tool(), Some("bash"));
+    }
+
+    #[test]
+    fn test_display_allowed() {
+        assert_eq!(PermissionOutcome::Allowed.to_string(), "Allowed");
+    }
+
+    #[test]
+    fn test_display_denied() {
+        let outcome = PermissionOutcome::Denied {
+            tool: "write_file".to_string(),
+            active_mode: "read_only".to_string(),
+            required_mode: "workspace_write".to_string(),
+            reason: "file writes not allowed".to_string(),
+        };
+        let display = outcome.to_string();
+        assert!(display.contains("Denied"));
+        assert!(display.contains("write_file"));
+        assert!(display.contains("read_only"));
+        assert!(display.contains("workspace_write"));
+        assert!(display.contains("file writes not allowed"));
+    }
+
+    #[test]
+    fn test_serde_roundtrip_allowed() {
+        let outcome = PermissionOutcome::Allowed;
+        let json = serde_json::to_string(&outcome).unwrap();
+        let deserialized: PermissionOutcome = serde_json::from_str(&json).unwrap();
+        assert_eq!(outcome, deserialized);
+    }
+
+    #[test]
+    fn test_serde_roundtrip_denied() {
+        let outcome = PermissionOutcome::Denied {
+            tool: "rm".to_string(),
+            active_mode: "read_only".to_string(),
+            required_mode: "danger_full_access".to_string(),
+            reason: "rm is destructive".to_string(),
+        };
+        let json = serde_json::to_string(&outcome).unwrap();
+        let deserialized: PermissionOutcome = serde_json::from_str(&json).unwrap();
+        assert_eq!(outcome, deserialized);
+    }
+
+    #[test]
+    fn test_serde_tagged_serialization() {
+        let json = serde_json::to_string(&PermissionOutcome::Allowed).unwrap();
+        assert!(json.contains(r#""outcome":"Allowed""#) || json.contains("\"Allowed\""));
+
+        let denied = PermissionOutcome::Denied {
+            tool: "x".to_string(),
+            active_mode: "a".to_string(),
+            required_mode: "b".to_string(),
+            reason: "test".to_string(),
+        };
+        let json = serde_json::to_string(&denied).unwrap();
+        assert!(json.contains(r#""outcome":"Denied""#));
+    }
+
+    #[test]
+    fn test_enforcement_result_alias() {
+        let allowed: EnforcementResult = PermissionOutcome::Allowed;
+        assert!(allowed.is_allowed());
+
+        let denied: EnforcementResult = PermissionOutcome::Denied {
+            tool: "test".to_string(),
+            active_mode: "ro".to_string(),
+            required_mode: "ww".to_string(),
+            reason: "test deny".to_string(),
+        };
+        assert!(denied.is_denied());
+    }
+}

--- a/engine/src/permission/domain/policy.rs
+++ b/engine/src/permission/domain/policy.rs
@@ -1,0 +1,408 @@
+//! PermissionPolicy — authorization logic based on active mode and rules.
+//!
+//! @canonical .pi/architecture/modules/permission-enforcer.md#policy
+//! Implements: Contract Freeze — PermissionPolicy authorization logic
+//! Issue: issue-contract-freeze
+//!
+//! Defines the permission policy that evaluates tool authorization
+//! requests against the active mode, allow/deny/ask rules, and
+//! per-tool permission requirements.
+//!
+//! # Contract (Frozen)
+//! - Authorization follows a strict 6-step pipeline (deny rules → allow → mode → ask → default)
+//! - Allow rules override mode restrictions (but not deny rules)
+//! - Deny rules are authoritative and checked first
+//! - Ask rules trigger interactive confirmation via `PermissionPrompter`
+//! - Unknown tools default to `WorkspaceWrite` mode (safe default)
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use super::context::PermissionContext;
+use super::mode::PermissionMode;
+use super::outcome::PermissionOutcome;
+use super::prompter::PermissionPrompter;
+
+/// Authorization policy that controls tool access based on permission mode.
+///
+/// The policy evaluates tool invocation requests through a structured
+/// pipeline:
+///
+/// 1. **Deny rules** — if the tool matches an explicit deny rule, deny immediately
+/// 2. **Allow rules** — if the tool matches an explicit allow rule, allow immediately
+/// 3. **Mode check** — check if the active mode is sufficient for the tool's requirement
+/// 4. **Context check** — check for temporary overrides (elevation, bypass)
+/// 5. **Ask rules** — if the tool matches an ask rule, prompt for confirmation
+/// 6. **Default** — allow (mode check already passed)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PermissionPolicy {
+    /// The active permission mode.
+    active_mode: PermissionMode,
+
+    /// Per-tool permission mode requirements.
+    /// Maps tool name to the minimum permission mode required.
+    tool_permissions: HashMap<String, PermissionMode>,
+
+    /// Tool names that are always allowed (override mode check).
+    allow_rules: Vec<String>,
+
+    /// Tool names that are always denied (checked first, authoritative).
+    deny_rules: Vec<String>,
+
+    /// Tool names that require user confirmation.
+    ask_rules: Vec<String>,
+
+    /// The default permission mode for tools without an explicit mapping.
+    default_required_mode: PermissionMode,
+}
+
+impl PermissionPolicy {
+    /// Create a new `PermissionPolicy`.
+    pub fn new(
+        active_mode: PermissionMode,
+        tool_permissions: HashMap<String, PermissionMode>,
+        allow_rules: Vec<String>,
+        deny_rules: Vec<String>,
+        ask_rules: Vec<String>,
+    ) -> Self {
+        Self {
+            active_mode,
+            tool_permissions,
+            allow_rules,
+            deny_rules,
+            ask_rules,
+            default_required_mode: PermissionMode::WorkspaceWrite,
+        }
+    }
+
+    /// Create a `PermissionPolicy` with the default configuration.
+    pub fn default_with_mode(active_mode: PermissionMode) -> Self {
+        Self::new(
+            active_mode,
+            HashMap::from([
+                ("read_file".to_string(), PermissionMode::ReadOnly),
+                ("grep_search".to_string(), PermissionMode::ReadOnly),
+                ("glob".to_string(), PermissionMode::ReadOnly),
+                ("lsp_query".to_string(), PermissionMode::ReadOnly),
+                ("write_file".to_string(), PermissionMode::WorkspaceWrite),
+                ("edit_file".to_string(), PermissionMode::WorkspaceWrite),
+                ("create_file".to_string(), PermissionMode::WorkspaceWrite),
+                ("delete_file".to_string(), PermissionMode::DangerousFullAccess),
+                ("bash".to_string(), PermissionMode::WorkspaceWrite),
+                ("git_commit".to_string(), PermissionMode::WorkspaceWrite),
+                ("git_push".to_string(), PermissionMode::DangerousFullAccess),
+                ("run_command".to_string(), PermissionMode::WorkspaceWrite),
+            ]),
+            vec![
+                "read_file".to_string(),
+                "grep_search".to_string(),
+                "glob".to_string(),
+                "lsp_query".to_string(),
+            ],
+            vec![],
+            vec![
+                "git_commit".to_string(),
+                "git_push".to_string(),
+                "bash".to_string(),
+            ],
+        )
+    }
+
+    /// Returns the current active permission mode.
+    pub fn active_mode(&self) -> PermissionMode {
+        self.active_mode
+    }
+
+    /// Set the active permission mode.
+    pub fn set_active_mode(&mut self, mode: PermissionMode) {
+        self.active_mode = mode;
+    }
+
+    /// Get the required permission mode for a tool.
+    ///
+    /// Returns the explicit mapping if one exists, otherwise the default.
+    pub fn required_mode_for(&self, tool_name: &str) -> PermissionMode {
+        self.tool_permissions
+            .get(tool_name)
+            .copied()
+            .unwrap_or(self.default_required_mode)
+    }
+
+    /// Check if a tool name matches any rule in a given list.
+    ///
+    /// Supports exact match and wildcard (`*`) matching.
+    fn matches_any_rule(&self, tool_name: &str, rules: &[String]) -> bool {
+        rules.iter().any(|rule| rule == "*" || rule == tool_name)
+    }
+
+    /// Authorize a tool invocation.
+    ///
+    /// Evaluates the request through the policy pipeline:
+    ///
+    /// 1. Check explicit deny rules (authoritative)
+    /// 2. Check explicit allow rules (override mode)
+    /// 3. Check context overrides
+    /// 4. Check mode requirement
+    /// 5. Check ask rules (prompt for confirmation)
+    /// 6. Default: allow
+    ///
+    /// Returns `PermissionOutcome::Allowed` or `PermissionOutcome::Denied`
+    /// with structured reasoning.
+    pub fn authorize(
+        &self,
+        tool_name: &str,
+        _tool_input: &str,
+        context: Option<&PermissionContext>,
+        prompter: Option<&mut dyn PermissionPrompter>,
+    ) -> PermissionOutcome {
+        let effective_mode = context
+            .and_then(|c| c.elevated_mode)
+            .unwrap_or(self.active_mode);
+
+        let bypass = context
+            .map(|c| c.temporary_bypass)
+            .unwrap_or(false);
+
+        if bypass {
+            return PermissionOutcome::Allowed;
+        }
+
+        // 1. Check explicit deny rules (authoritative — checked first)
+        if self.matches_any_rule(tool_name, &self.deny_rules) {
+            return PermissionOutcome::Denied {
+                tool: tool_name.to_string(),
+                active_mode: effective_mode.as_str().to_string(),
+                required_mode: self.required_mode_for(tool_name).as_str().to_string(),
+                reason: format!("'{}' is explicitly denied by policy", tool_name),
+            };
+        }
+
+        // 2. Check allow rules (override mode restrictions)
+        if self.matches_any_rule(tool_name, &self.allow_rules) {
+            if self.matches_any_rule(tool_name, &self.ask_rules) {
+                // Even allowed tools may require confirmation if in ask list
+                return self.prompt_or_deny(tool_name, _tool_input, effective_mode, prompter);
+            }
+            return PermissionOutcome::Allowed;
+        }
+
+        // 3. Get required mode for this tool
+        let required = self.required_mode_for(tool_name);
+
+        // 4. Mode check
+        if effective_mode < required {
+            return PermissionOutcome::Denied {
+                tool: tool_name.to_string(),
+                active_mode: effective_mode.as_str().to_string(),
+                required_mode: required.as_str().to_string(),
+                reason: format!(
+                    "'{}' requires '{}' mode, but active mode is '{}'",
+                    tool_name,
+                    required,
+                    effective_mode
+                ),
+            };
+        }
+
+        // 5. Ask rules (prompt for confirmation)
+        if self.matches_any_rule(tool_name, &self.ask_rules) {
+            return self.prompt_or_deny(tool_name, _tool_input, effective_mode, prompter);
+        }
+
+        // 6. Default: allow
+        PermissionOutcome::Allowed
+    }
+
+    /// Helper: prompt for confirmation or deny if no prompter available.
+    fn prompt_or_deny(
+        &self,
+        tool_name: &str,
+        tool_input: &str,
+        effective_mode: PermissionMode,
+        prompter: Option<&mut dyn PermissionPrompter>,
+    ) -> PermissionOutcome {
+        if let Some(p) = prompter {
+            p.prompt(tool_name, tool_input)
+        } else {
+            PermissionOutcome::Denied {
+                tool: tool_name.to_string(),
+                active_mode: effective_mode.as_str().to_string(),
+                required_mode: self.required_mode_for(tool_name).as_str().to_string(),
+                reason: format!(
+                    "'{}' requires confirmation but no interactive prompt is available",
+                    tool_name
+                ),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::permission::domain::prompter::{AllowAllPrompter, DenyAllPrompter};
+
+    fn read_only_policy() -> PermissionPolicy {
+        PermissionPolicy::default_with_mode(PermissionMode::ReadOnly)
+    }
+
+    fn workspace_policy() -> PermissionPolicy {
+        PermissionPolicy::default_with_mode(PermissionMode::WorkspaceWrite)
+    }
+
+    fn dangerous_policy() -> PermissionPolicy {
+        PermissionPolicy::default_with_mode(PermissionMode::DangerousFullAccess)
+    }
+
+    #[test]
+    fn test_read_only_denies_write_file() {
+        let policy = read_only_policy();
+        let outcome = policy.authorize("write_file", "/tmp/test", None, None);
+        assert!(outcome.is_denied());
+        assert!(outcome.to_string().contains("write_file"));
+        assert!(outcome.to_string().contains("read_only"));
+    }
+
+    #[test]
+    fn test_read_only_allows_read_file() {
+        let policy = read_only_policy();
+        let outcome = policy.authorize("read_file", "foo.txt", None, None);
+        assert!(outcome.is_allowed());
+    }
+
+    #[test]
+    fn test_workspace_write_allows_write_file() {
+        let policy = workspace_policy();
+        let outcome = policy.authorize("write_file", "foo.txt", None, None);
+        assert!(outcome.is_allowed());
+    }
+
+    #[test]
+    fn test_workspace_write_denies_delete_file() {
+        let policy = workspace_policy();
+        let outcome = policy.authorize("delete_file", "/tmp/x", None, None);
+        assert!(outcome.is_denied());
+    }
+
+    #[test]
+    fn test_dangerous_allows_everything() {
+        let policy = dangerous_policy();
+        assert!(policy.authorize("write_file", "/tmp/x", None, None).is_allowed());
+        assert!(policy.authorize("delete_file", "/tmp/x", None, None).is_allowed());
+        // git_push is in ask rules so needs a prompter, but DangerousFullAccess
+        // passes the mode check so it should be allowed if prompter approves
+        let mut prompter = AllowAllPrompter::new();
+        assert!(policy.authorize("git_push", "origin main", None, Some(&mut prompter)).is_allowed());
+    }
+
+    #[test]
+    fn test_deny_rules_authoritative() {
+        let mut policy = workspace_policy();
+        policy.deny_rules = vec!["write_file".to_string()];
+        let outcome = policy.authorize("write_file", "/tmp/x", None, None);
+        assert!(outcome.is_denied());
+        assert!(outcome.to_string().contains("explicitly denied"));
+    }
+
+    #[test]
+    fn test_allow_rules_override_mode() {
+        let custom = PermissionPolicy::new(
+            PermissionMode::ReadOnly,
+            HashMap::from([("bash".to_string(), PermissionMode::WorkspaceWrite)]),
+            vec!["bash".to_string()], // allow bash explicitly
+            vec![],
+            vec![],
+        );
+        let outcome = custom.authorize("bash", "ls", None, None);
+        assert!(outcome.is_allowed());
+    }
+
+    #[test]
+    fn test_ask_rules_prompt_with_allow_all() {
+        let mut policy = workspace_policy();
+        policy.ask_rules = vec!["bash".to_string()];
+        let mut prompter = AllowAllPrompter::new();
+        let outcome = policy.authorize("bash", "ls", None, Some(&mut prompter));
+        assert!(outcome.is_allowed());
+    }
+
+    #[test]
+    fn test_ask_rules_deny_without_prompter() {
+        let mut policy = workspace_policy();
+        policy.ask_rules = vec!["bash".to_string()];
+        let outcome = policy.authorize("bash", "ls", None, None);
+        assert!(outcome.is_denied());
+        assert!(outcome.to_string().contains("no interactive prompt"));
+    }
+
+    #[test]
+    fn test_ask_rules_deny_with_deny_all() {
+        let mut policy = workspace_policy();
+        policy.ask_rules = vec!["bash".to_string()];
+        let mut prompter = DenyAllPrompter::new();
+        let outcome = policy.authorize("bash", "ls", None, Some(&mut prompter));
+        assert!(outcome.is_denied());
+    }
+
+    #[test]
+    fn test_context_elevation() {
+        let policy = read_only_policy();
+        let context = PermissionContext::elevate(PermissionMode::WorkspaceWrite, "Need to write");
+        let outcome = policy.authorize("write_file", "/tmp/test", Some(&context), None);
+        assert!(outcome.is_allowed());
+    }
+
+    #[test]
+    fn test_context_bypass() {
+        let policy = read_only_policy();
+        let context = PermissionContext::bypass("Emergency bypass");
+        let outcome = policy.authorize("delete_file", "/tmp/x", Some(&context), None);
+        assert!(outcome.is_allowed());
+    }
+
+    #[test]
+    fn test_unknown_tool_defaults_to_workspace_write() {
+        let policy = read_only_policy();
+        let outcome = policy.authorize("unknown_tool", "input", None, None);
+        // Unknown tools default to WorkspaceWrite requirement,
+        // but active mode is ReadOnly, so it's denied
+        assert!(outcome.is_denied());
+
+        let policy = workspace_policy();
+        let outcome = policy.authorize("unknown_tool", "input", None, None);
+        assert!(outcome.is_allowed());
+    }
+
+    #[test]
+    fn test_wildcard_allow_rule() {
+        let mut policy = read_only_policy();
+        policy.allow_rules = vec!["*".to_string()];
+        let outcome = policy.authorize("write_file", "/tmp/test", None, None);
+        assert!(outcome.is_allowed());
+    }
+
+    #[test]
+    fn test_wildcard_deny_rule() {
+        let mut policy = workspace_policy();
+        policy.deny_rules = vec!["*".to_string()];
+        let outcome = policy.authorize("read_file", "test.txt", None, None);
+        assert!(outcome.is_denied());
+    }
+
+    #[test]
+    fn test_required_mode_for() {
+        let policy = workspace_policy();
+        assert_eq!(policy.required_mode_for("read_file"), PermissionMode::ReadOnly);
+        assert_eq!(policy.required_mode_for("write_file"), PermissionMode::WorkspaceWrite);
+        assert_eq!(policy.required_mode_for("delete_file"), PermissionMode::DangerousFullAccess);
+        assert_eq!(policy.required_mode_for("unknown_tool"), PermissionMode::WorkspaceWrite);
+    }
+
+    #[test]
+    fn test_set_active_mode() {
+        let mut policy = read_only_policy();
+        assert_eq!(policy.active_mode(), PermissionMode::ReadOnly);
+        policy.set_active_mode(PermissionMode::DangerousFullAccess);
+        assert_eq!(policy.active_mode(), PermissionMode::DangerousFullAccess);
+    }
+}

--- a/engine/src/permission/domain/prompter.rs
+++ b/engine/src/permission/domain/prompter.rs
@@ -1,0 +1,168 @@
+//! PermissionPrompter — trait for interactive confirmation.
+//!
+//! @canonical .pi/architecture/modules/permission-enforcer.md#prompter
+//! Implements: Contract Freeze — PermissionPrompter trait
+//! Issue: issue-contract-freeze
+//!
+//! Provides an interactive confirmation flow for tools that require
+//! human approval before execution. The prompter is used by the
+//! PermissionPolicy when a tool matches the "ask" rules.
+//!
+//! # Contract (Frozen)
+//! - Trait is object-safe (no async methods, no generic parameters)
+//! - `prompt()` returns `PermissionOutcome` — the prompter makes the final decision
+//! - `prompt_many()` allows batch confirmation for multiple tools at once
+
+use serde::{Deserialize, Serialize};
+
+use super::outcome::PermissionOutcome;
+
+/// User response from an interactive permission prompt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PromptResponse {
+    /// The user approved the operation.
+    Approved,
+
+    /// The user denied the operation.
+    Denied,
+
+    /// The user requested a modification (e.g., different args).
+    Modify {
+        /// Suggested modification or reason.
+        suggestion: String,
+    },
+
+    /// The prompt timed out without a response.
+    Timeout,
+}
+
+/// Trait for interactive permission confirmation.
+///
+/// Implementations can provide TUI prompts, CLI stdin prompts,
+/// or API-based confirmation flows.
+pub trait PermissionPrompter: Send {
+    /// Prompt the user for approval of a tool invocation.
+    ///
+    /// Returns `PermissionOutcome::Allowed` if approved,
+    /// `PermissionOutcome::Denied` if rejected.
+    fn prompt(&mut self, tool_name: &str, tool_input: &str) -> PermissionOutcome;
+
+    /// Prompt the user for multiple tool invocations at once.
+    ///
+    /// Each entry in the slice is a (tool_name, tool_input) pair.
+    /// Returns outcomes in the same order.
+    fn prompt_many(
+        &mut self,
+        tools: &[(&str, &str)],
+    ) -> Vec<PermissionOutcome>;
+
+    /// Returns `true` if this prompter is capable of interactive prompting.
+    /// Returns `false` for headless/non-interactive environments.
+    fn is_interactive(&self) -> bool;
+}
+
+/// A permission prompter that denies all prompts (safe default for CI/headless).
+///
+/// Useful as a fallback when no interactive prompter is available.
+#[derive(Debug, Clone, Default)]
+pub struct DenyAllPrompter;
+
+impl DenyAllPrompter {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl PermissionPrompter for DenyAllPrompter {
+    fn prompt(&mut self, tool_name: &str, _tool_input: &str) -> PermissionOutcome {
+        PermissionOutcome::Denied {
+            tool: tool_name.to_string(),
+            active_mode: "workspace_write".to_string(),
+            required_mode: "workspace_write".to_string(),
+            reason: "Interactive confirmation not available in headless mode".to_string(),
+        }
+    }
+
+    fn prompt_many(&mut self, tools: &[(&str, &str)]) -> Vec<PermissionOutcome> {
+        tools
+            .iter()
+            .map(|(tool_name, _)| PermissionOutcome::Denied {
+                tool: tool_name.to_string(),
+                active_mode: "workspace_write".to_string(),
+                required_mode: "workspace_write".to_string(),
+                reason: "Interactive confirmation not available in headless mode".to_string(),
+            })
+            .collect()
+    }
+
+    fn is_interactive(&self) -> bool {
+        false
+    }
+}
+
+/// A permission prompter that approves all prompts (for testing).
+#[derive(Debug, Clone, Default)]
+pub struct AllowAllPrompter;
+
+impl AllowAllPrompter {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl PermissionPrompter for AllowAllPrompter {
+    fn prompt(&mut self, _tool_name: &str, _tool_input: &str) -> PermissionOutcome {
+        PermissionOutcome::Allowed
+    }
+
+    fn prompt_many(&mut self, tools: &[(&str, &str)]) -> Vec<PermissionOutcome> {
+        tools.iter().map(|_| PermissionOutcome::Allowed).collect()
+    }
+
+    fn is_interactive(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deny_all_prompter() {
+        let mut prompter = DenyAllPrompter::new();
+        assert!(!prompter.is_interactive());
+
+        let outcome = prompter.prompt("bash", "rm -rf /");
+        assert!(outcome.is_denied());
+    }
+
+    #[test]
+    fn test_allow_all_prompter() {
+        let mut prompter = AllowAllPrompter::new();
+        assert!(!prompter.is_interactive());
+
+        let outcome = prompter.prompt("bash", "rm -rf /");
+        assert!(outcome.is_allowed());
+    }
+
+    #[test]
+    fn test_prompt_many_deny_all() {
+        let mut prompter = DenyAllPrompter::new();
+        let tools = [("bash", "ls"), ("write_file", "/tmp/test")];
+        let outcomes = prompter.prompt_many(&tools);
+        assert_eq!(outcomes.len(), 2);
+        assert!(outcomes[0].is_denied());
+        assert!(outcomes[1].is_denied());
+    }
+
+    #[test]
+    fn test_prompt_many_allow_all() {
+        let mut prompter = AllowAllPrompter::new();
+        let tools = [("bash", "ls"), ("write_file", "/tmp/test")];
+        let outcomes = prompter.prompt_many(&tools);
+        assert_eq!(outcomes.len(), 2);
+        assert!(outcomes[0].is_allowed());
+        assert!(outcomes[1].is_allowed());
+    }
+}

--- a/engine/src/permission/infrastructure/mod.rs
+++ b/engine/src/permission/infrastructure/mod.rs
@@ -1,0 +1,16 @@
+//! Infrastructure layer interfaces for the Permission Enforcer bounded context.
+//!
+//! @canonical .pi/architecture/modules/permission-enforcer.md
+//! Implements: Contract Freeze — repository interfaces
+//! Issue: issue-contract-freeze
+//!
+//! This module defines repository interfaces that abstract data access
+//! behind traits. Implementations are provided by the concrete
+//! infrastructure module.
+//!
+//! The primary repository is `PermissionConfigRepository` for loading
+//! and persisting permission configuration.
+
+pub mod repository;
+
+pub use repository::*;

--- a/engine/src/permission/infrastructure/repository/mod.rs
+++ b/engine/src/permission/infrastructure/repository/mod.rs
@@ -1,0 +1,46 @@
+//! Repository interfaces for the Permission Enforcer bounded context.
+//!
+//! @canonical .pi/architecture/modules/permission-enforcer.md
+//! Implements: Contract Freeze — repository interfaces for permission data
+//! Issue: issue-contract-freeze
+//!
+//! Permission configuration is typically loaded from `.rigorix/permissions.toml`
+//! at startup. For advanced use cases — runtime policy updates, per-session
+//! permission overrides, or persistence of override state — repository
+//! interfaces are provided.
+//!
+//! # Contract (Frozen)
+//! - All repository methods are async
+//! - All methods return domain error types
+//! - No framework-specific annotations on trait definitions
+
+use async_trait::async_trait;
+
+use crate::permission::domain::{PermissionConfig, PermissionError};
+
+/// Repository for loading and persisting permission configuration.
+///
+/// The default implementation loads from the `.rigorix/permissions.toml` file.
+/// Custom implementations may load from a database, remote API, or
+/// environment variables.
+#[async_trait]
+pub trait PermissionConfigRepository: Send + Sync {
+    /// Load the permission configuration.
+    ///
+    /// Returns the full `PermissionConfig` including default mode,
+    /// allow/deny/ask rules, and per-tool permission mappings.
+    /// If no configuration is found, returns the default configuration.
+    async fn load_config(&self) -> Result<PermissionConfig, PermissionError>;
+
+    /// Save the permission configuration.
+    ///
+    /// Persists any runtime modifications to the permission config.
+    /// If persistence is not supported, returns `Ok(())` without error.
+    async fn save_config(&self, config: &PermissionConfig) -> Result<(), PermissionError>;
+
+    /// Reload the configuration from the original source.
+    ///
+    /// Discards any in-memory overrides and reloads from the
+    /// original configuration source.
+    async fn reload_config(&self) -> Result<PermissionConfig, PermissionError>;
+}

--- a/engine/src/permission/interfaces/http/mod.rs
+++ b/engine/src/permission/interfaces/http/mod.rs
@@ -1,0 +1,223 @@
+//! HTTP API contracts for Permission Enforcer endpoints.
+//!
+//! @canonical .pi/architecture/modules/permission-enforcer.md
+//! Implements: Contract Freeze — HTTP endpoint contracts and error formats
+//! Issue: issue-contract-freeze
+//!
+//! Defines endpoint paths, methods, request/response schemas, and error
+//! response formats. These contracts are framework-agnostic — they describe
+//! the API surface that any HTTP server implementation must satisfy.
+//!
+//! # Contract (Frozen)
+//! - All endpoints documented with method, path, request, and response types
+//! - Error responses follow a unified format
+//! - No framework-specific annotations (axum/actix/warp annotations added by implementation)
+
+use serde::{Deserialize, Serialize};
+
+use crate::permission::application::dto::{
+    CheckFileWriteOutput, CheckPermissionOutput, PermissionStatusOutput,
+};
+use crate::permission::domain::PermissionMode;
+
+// ---------------------------------------------------------------------------
+// API Base Path
+// ---------------------------------------------------------------------------
+
+/// All permission endpoints are served under this base path.
+pub const API_BASE_PATH: &str = "/api/v1/permission";
+
+// ---------------------------------------------------------------------------
+// Endpoint: GET /api/v1/permission/status
+// ---------------------------------------------------------------------------
+
+/// GET /api/v1/permission/status
+///
+/// Get the current permission status (active mode and config summary).
+///
+/// **Response:** `200 OK` with `PermissionStatusResponse`
+pub const PERMISSION_STATUS_PATH: &str = "/api/v1/permission/status";
+pub const PERMISSION_STATUS_METHOD: &str = "GET";
+
+/// Response body for GET /api/v1/permission/status.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PermissionStatusResponse {
+    pub active_mode: PermissionMode,
+    pub allow_count: u32,
+    pub deny_count: u32,
+    pub ask_count: u32,
+    pub tool_permission_count: u32,
+}
+
+impl From<PermissionStatusOutput> for PermissionStatusResponse {
+    fn from(output: PermissionStatusOutput) -> Self {
+        Self {
+            active_mode: output.active_mode,
+            allow_count: output.config_summary.allow_count,
+            deny_count: output.config_summary.deny_count,
+            ask_count: output.config_summary.ask_count,
+            tool_permission_count: output.config_summary.tool_permission_count,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/permission/evaluate
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/permission/evaluate
+///
+/// Evaluate whether a tool call is allowed by the current permission policy.
+/// Returns the decision with reasoning and required/active mode info.
+///
+/// **Request:** `EvaluateToolPermissionRequest`
+/// **Response:** `200 OK` with `EvaluateToolPermissionResponse`
+pub const EVALUATE_PERMISSION_PATH: &str = "/api/v1/permission/evaluate";
+pub const EVALUATE_PERMISSION_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/permission/evaluate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvaluateToolPermissionRequest {
+    /// The name of the tool being evaluated.
+    pub tool: String,
+    /// The input/arguments to the tool.
+    pub input: String,
+}
+
+/// Response body for POST /api/v1/permission/evaluate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvaluateToolPermissionResponse {
+    pub outcome: String,
+    pub active_mode: String,
+    pub required_mode: String,
+    pub reason: Option<String>,
+    pub requires_confirmation: bool,
+}
+
+impl From<CheckPermissionOutput> for EvaluateToolPermissionResponse {
+    fn from(output: CheckPermissionOutput) -> Self {
+        Self {
+            outcome: output.outcome,
+            active_mode: output.active_mode,
+            required_mode: output.required_mode,
+            reason: output.reason,
+            requires_confirmation: output.requires_confirmation,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/permission/mode
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/permission/mode
+///
+/// Set the active permission mode.
+///
+/// **Request:** `SetPermissionModeRequest`
+/// **Response:** `200 OK` with `SetPermissionModeResponse`
+pub const SET_MODE_PATH: &str = "/api/v1/permission/mode";
+pub const SET_MODE_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/permission/mode.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetPermissionModeRequest {
+    /// The new permission mode.
+    pub mode: PermissionMode,
+    /// Optional reason for the mode change.
+    pub reason: Option<String>,
+}
+
+/// Response body for POST /api/v1/permission/mode.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetPermissionModeResponse {
+    /// The previous mode.
+    pub previous_mode: PermissionMode,
+    /// The current (new) mode.
+    pub current_mode: PermissionMode,
+    /// Whether the change was successful.
+    pub success: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/permission/file-write
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/permission/file-write
+///
+/// Check whether a file write at the given path is allowed.
+///
+/// **Request:** `CheckFileWriteRequest`
+/// **Response:** `200 OK` with `CheckFileWriteResponse`
+pub const FILE_WRITE_PATH: &str = "/api/v1/permission/file-write";
+pub const FILE_WRITE_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/permission/file-write.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckFileWriteRequest {
+    /// The path to check.
+    pub path: String,
+    /// The workspace root.
+    pub workspace_root: String,
+}
+
+/// Response body for POST /api/v1/permission/file-write.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckFileWriteResponse {
+    pub allowed: bool,
+    pub active_mode: String,
+    pub within_workspace: bool,
+    pub reason: Option<String>,
+}
+
+impl From<CheckFileWriteOutput> for CheckFileWriteResponse {
+    fn from(output: CheckFileWriteOutput) -> Self {
+        Self {
+            allowed: output.allowed,
+            active_mode: output.active_mode,
+            within_workspace: output.within_workspace,
+            reason: output.reason,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unified Error Response Format
+// ---------------------------------------------------------------------------
+
+/// Standard error response for all Permission API endpoints.
+///
+/// All 4xx/5xx responses use this format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiErrorResponse {
+    /// HTTP status code.
+    pub status: u16,
+    /// Machine-readable error code.
+    pub code: String,
+    /// Human-readable error message.
+    pub message: String,
+    /// Detailed error context (optional).
+    pub details: Option<serde_json::Value>,
+    /// Request ID for tracing (if available).
+    pub request_id: Option<String>,
+}
+
+/// Standardized error codes for Permission API.
+pub mod error_codes {
+    /// Tool call denied by permission policy.
+    pub const PERMISSION_DENIED: &str = "PERMISSION_DENIED";
+    /// Invalid permission mode.
+    pub const INVALID_MODE: &str = "INVALID_PERMISSION_MODE";
+    /// Policy not found.
+    pub const POLICY_NOT_FOUND: &str = "PERMISSION_POLICY_NOT_FOUND";
+    /// Internal server error.
+    pub const INTERNAL_ERROR: &str = "PERMISSION_INTERNAL_ERROR";
+}
+
+/// HTTP status code mappings for Permission errors.
+pub mod status_codes {
+    pub const PERMISSION_DENIED: u16 = 403;
+    pub const INVALID_MODE: u16 = 400;
+    pub const POLICY_NOT_FOUND: u16 = 404;
+    pub const INTERNAL_ERROR: u16 = 500;
+}

--- a/engine/src/permission/interfaces/mod.rs
+++ b/engine/src/permission/interfaces/mod.rs
@@ -1,0 +1,20 @@
+//! Interface adapters for the Permission Enforcer bounded context.
+//!
+//! @canonical .pi/architecture/modules/permission-enforcer.md
+//! Implements: Contract Freeze — HTTP API endpoint contracts
+//! Issue: issue-contract-freeze
+//!
+//! This module defines API contracts (HTTP, CLI, etc.) that external
+//! actors use to interact with the permission enforcement system.
+//!
+//! # Permission API Context
+//!
+//! Permission is primarily triggered by:
+//! 1. Tool call evaluation — every tool invocation passes through the enforcer
+//! 2. File write boundary checks — workspace path validation
+//! 3. Bash command classification — intent-aware gating
+//!
+//! The HTTP API provides external monitoring and override capabilities
+//! (e.g., querying permission status, setting mode, evaluating tools).
+
+pub mod http;

--- a/engine/src/permission/mod.rs
+++ b/engine/src/permission/mod.rs
@@ -1,0 +1,56 @@
+//! Permission Enforcer bounded context.
+//!
+//! @canonical .pi/architecture/modules/permission-enforcer.md
+//! Implements: Contract Freeze — permission-enforcer module root
+//! Issue: issue-contract-freeze
+//!
+//! Provides a three-tier permission mode hierarchy (`ReadOnly` →
+//! `WorkspaceWrite` → `DangerousFullAccess`) that gates every tool
+//! invocation. The active permission mode caps the maximum risk level
+//! a tool can execute. Tools requesting a higher `required_mode` than
+//! the active mode are denied with structured reasoning.
+//!
+//! # Architecture
+//!
+//! ```text
+//! permission/
+//! ├── domain/             # Domain entities: PermissionMode, PermissionPolicy,
+//! │   │                     PermissionOutcome, BashClassifier, PermissionConfig,
+//! │   │                     PermissionError, PermissionEvent
+//! │   ├── mode.rs         # PermissionMode enum (ReadOnly, WorkspaceWrite, DangerousFullAccess)
+//! │   ├── policy.rs       # PermissionPolicy with authorize() logic
+//! │   ├── outcome.rs      # PermissionOutcome = Allowed | Denied { reason }
+//! │   ├── context.rs      # PermissionContext for temporal overrides
+//! │   ├── bash_classifier.rs  # BashClassifier + CommandIntent
+//! │   ├── config.rs       # PermissionConfig for allow/deny/ask rules
+//! │   ├── prompter.rs     # PermissionPrompter trait for interactive confirmation
+//! │   ├── error.rs        # PermissionError enum
+//! │   └── event/          # PermissionEvent payload schemas
+//! ├── application/        # Service traits, DTOs, factory interfaces
+//! │   ├── enforcer.rs     # PermissionEnforcer trait
+//! │   ├── factory.rs      # PermissionEnforcerFactory interface
+//! │   └── dto/            # Input/Output DTOs
+//! ├── infrastructure/     # Repository interfaces
+//! │   └── repository/     # PermissionConfigRepository trait
+//! └── interfaces/         # API contracts
+//!     └── http/           # REST endpoint contracts
+//! ```
+//!
+//! # Contract Freeze Notice
+//!
+//! ALL files in this module are frozen contracts.
+//! - No implementation changes without explicit contract change approval
+//! - Implementation PRs MUST reference these interfaces
+//! - DTO schemas serve as the canonical data contract
+//!
+//! # Related Components
+//!
+//! - `ExecutionEnforcer` (in `crate::enforcement::application::service`) handles
+//!   execution hard caps (retries, time, tool calls)
+//! - `PermissionEnforcer` (this module) handles mode-based permission gating
+//! - Both are used by the execution engine for different enforcement concerns
+
+pub mod application;
+pub mod domain;
+pub mod infrastructure;
+pub mod interfaces;


### PR DESCRIPTION
## Summary

Frozen contracts for the permission-enforcer bounded context — 19 files across Clean Architecture layers with full implementations and 81 tests.

## Components

| Component | File | Tests |
|-----------|------|-------|
| PermissionMode | `src/permission/domain/mode.rs` | 8 |
| PermissionPolicy | `src/permission/domain/policy.rs` | 18 |
| PermissionOutcome / EnforcementResult | `src/permission/domain/outcome.rs` | 7 |
| BashClassifier | `src/permission/domain/bash_classifier.rs` | 35 |
| PermissionConfig | `src/permission/domain/config.rs` | 5 |
| PermissionContext | `src/permission/domain/context.rs` | 5 |
| PermissionPrompter | `src/permission/domain/prompter.rs` | 5 |
| PermissionEvent | `src/permission/domain/event/mod.rs` | 3 |
| PermissionEnforcer trait | `src/permission/application/enforcer.rs` | - |
| PermissionEnforcerFactory trait | `src/permission/application/factory.rs` | - |
| API contracts | `src/permission/interfaces/http/mod.rs` | - |
| DTOs | `src/permission/application/dto/mod.rs` | 2 |

## Test Results
- **81 permission module tests** - all passing
- **1318 total tests** - 0 failures

Closes #458 (contract freeze tracking)