### PR TITLE
feat: freeze policy-engine public interfaces and contracts

### DIFF
--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -38,6 +38,7 @@ pub mod execution_engine;
 pub mod failure_classification;
 pub mod hooks;
 pub mod observability;
+pub mod policy_engine;
 pub mod orchestrator;
 pub mod permission;
 pub mod recovery_recipes;

--- a/engine/src/policy_engine/application/dto/mod.rs
+++ b/engine/src/policy_engine/application/dto/mod.rs
@@ -1,0 +1,239 @@
+//! Data Transfer Objects for the Policy Engine module.
+//!
+//! @canonical .pi/architecture/modules/policy-engine.md
+//! Implements: Contract Freeze — DTO schemas for policy engine operations
+//! Issue: issue-contract-freeze
+//!
+//! DTOs define the input/output contracts for service operations.
+//! They carry validation metadata and documentation but no behavior.
+//!
+//! # Contract (Frozen)
+//! - Every service operation has a dedicated input and output DTO
+//! - DTOs are serializable (JSON for API)
+//! - Validation constraints are documented in field docs
+//! - Fields use reasonable Rust types (no framework-specific annotations)
+
+use serde::{Deserialize, Serialize};
+
+use crate::policy_engine::domain::{LaneContext, PolicyAction, PolicyConfig};
+
+// ---------------------------------------------------------------------------
+// Evaluate Policy DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for evaluating policy rules against a LaneContext.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvaluatePolicyInput {
+    /// The typed execution context to evaluate rules against.
+    pub context: LaneContext,
+
+    /// Optional filter to only evaluate specific rules by name.
+    /// If `None` or empty, all loaded rules are evaluated.
+    pub rule_filter: Option<Vec<String>>,
+}
+
+/// Output from evaluating policy rules.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvaluatePolicyOutput {
+    /// The lane ID that was evaluated.
+    pub lane_id: String,
+
+    /// Flat list of actions from all matching rules, in priority order.
+    pub actions: Vec<ActionOutput>,
+
+    /// Number of matching rules.
+    pub matching_rule_count: u32,
+
+    /// Total number of rules evaluated.
+    pub rules_evaluated: u32,
+
+    /// Whether any rules matched the given context.
+    pub matched: bool,
+}
+
+/// A single action with its matching rule context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActionOutput {
+    /// The name of the rule that produced this action.
+    pub rule_name: String,
+
+    /// The priority of the matching rule.
+    pub priority: u32,
+
+    /// The action to execute.
+    pub action: PolicyAction,
+}
+
+// ---------------------------------------------------------------------------
+// Load Rules DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for loading policy rules.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoadRulesInput {
+    /// The policy configuration to load.
+    pub config: PolicyConfig,
+
+    /// Whether to replace all existing rules (`true`) or merge (`false`).
+    /// Merge behavior: rules from the config replace rules with the same name.
+    pub replace_all: bool,
+}
+
+/// Output from loading policy rules.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoadRulesOutput {
+    /// Number of rules successfully loaded.
+    pub loaded_count: u32,
+
+    /// Number of rules that replaced existing rules (only if `replace_all` is false).
+    pub replaced_count: u32,
+
+    /// Names of the loaded rules.
+    pub rule_names: Vec<String>,
+
+    /// Whether the load was successful.
+    pub success: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Get Active Rules DTOs
+// ---------------------------------------------------------------------------
+
+/// Output from querying active rules.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetActiveRulesOutput {
+    /// List of currently loaded rules, sorted by priority.
+    pub rules: Vec<RuleSummary>,
+
+    /// Total number of loaded rules.
+    pub total_count: u32,
+}
+
+/// Summary of a single loaded rule.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuleSummary {
+    pub name: String,
+    pub priority: u32,
+    pub condition_summary: String,
+    pub action_summary: String,
+}
+
+// ---------------------------------------------------------------------------
+// Reload Rules DTOs
+// ---------------------------------------------------------------------------
+
+/// Output from reloading policy rules.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReloadRulesOutput {
+    /// Whether the reload was successful.
+    pub success: bool,
+
+    /// Number of rules loaded from the source.
+    pub rule_count: u32,
+
+    /// The source path/identifier from which rules were reloaded.
+    pub source: String,
+
+    /// Error details if the reload failed.
+    pub error: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy_engine::domain::{
+        DiffScope, LaneBlocker, LaneContext, PolicyAction, PolicyCondition, PolicyConfig,
+        ReviewStatus,
+    };
+    use crate::policy_engine::domain::config::RuleDefinition;
+
+    #[test]
+    fn test_evaluate_policy_input_serde() {
+        let input = EvaluatePolicyInput {
+            context: LaneContext {
+                lane_id: "lane-1".to_string(),
+                green_level: 3,
+                branch_freshness_secs: 100,
+                blocker: LaneBlocker::None,
+                review_status: ReviewStatus::Pending,
+                diff_scope: DiffScope::Scoped,
+                completed: true,
+                reconciled: false,
+            },
+            rule_filter: None,
+        };
+        let json = serde_json::to_string(&input).unwrap();
+        let deserialized: EvaluatePolicyInput = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.context.lane_id, "lane-1");
+    }
+
+    #[test]
+    fn test_evaluate_policy_output_serde() {
+        let output = EvaluatePolicyOutput {
+            lane_id: "lane-1".to_string(),
+            actions: vec![
+                ActionOutput {
+                    rule_name: "closeout".to_string(),
+                    priority: 10,
+                    action: PolicyAction::CloseoutLane,
+                },
+            ],
+            matching_rule_count: 1,
+            rules_evaluated: 5,
+            matched: true,
+        };
+        let json = serde_json::to_string(&output).unwrap();
+        let deserialized: EvaluatePolicyOutput = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.lane_id, "lane-1");
+        assert_eq!(deserialized.actions.len(), 1);
+    }
+
+    #[test]
+    fn test_load_rules_input_serde() {
+        let input = LoadRulesInput {
+            config: PolicyConfig::single(RuleDefinition {
+                name: "test".to_string(),
+                condition: PolicyCondition::LaneCompleted,
+                action: PolicyAction::CloseoutLane,
+                priority: 10,
+            }),
+            replace_all: true,
+        };
+        let json = serde_json::to_string(&input).unwrap();
+        let deserialized: LoadRulesInput = serde_json::from_str(&json).unwrap();
+        assert!(deserialized.replace_all);
+        assert_eq!(deserialized.config.rules.len(), 1);
+    }
+
+    #[test]
+    fn test_get_active_rules_output() {
+        let output = GetActiveRulesOutput {
+            rules: vec![
+                RuleSummary {
+                    name: "rule-1".to_string(),
+                    priority: 10,
+                    condition_summary: "LaneCompleted".to_string(),
+                    action_summary: "CloseoutLane".to_string(),
+                },
+            ],
+            total_count: 1,
+        };
+        let json = serde_json::to_string(&output).unwrap();
+        let deserialized: GetActiveRulesOutput = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.total_count, 1);
+    }
+
+    #[test]
+    fn test_reload_rules_output() {
+        let output = ReloadRulesOutput {
+            success: true,
+            rule_count: 5,
+            source: ".rigorix/policy.toml".to_string(),
+            error: None,
+        };
+        let json = serde_json::to_string(&output).unwrap();
+        let deserialized: ReloadRulesOutput = serde_json::from_str(&json).unwrap();
+        assert!(deserialized.success);
+        assert_eq!(deserialized.rule_count, 5);
+    }
+}

--- a/engine/src/policy_engine/application/engine.rs
+++ b/engine/src/policy_engine/application/engine.rs
@@ -1,0 +1,211 @@
+//! PolicyEngineService — application service trait for policy evaluation.
+//!
+//! @canonical .pi/architecture/modules/policy-engine.md#engine
+//! Implements: Contract Freeze — PolicyEngineService trait
+//! Issue: issue-contract-freeze
+//!
+//! Defines the application service interface for the policy engine.
+//! The PolicyEngineService evaluates declarative PolicyRules against
+//! LaneContext and returns ordered action lists. It also manages
+//! rule lifecycle (load, reload, query).
+//!
+//! # Contract (Frozen)
+//! - All methods are async (use `async-trait` for trait object safety)
+//! - All public methods return `Result<_, PolicyEngineError>`
+//! - Input/output types are DTOs defined in `dto/`
+//! - No implementation — only contract signatures
+
+use async_trait::async_trait;
+
+use crate::policy_engine::domain::{LaneContext, PolicyEngineError, PolicyRule};
+
+use super::dto::{
+    EvaluatePolicyInput, EvaluatePolicyOutput, GetActiveRulesOutput, LoadRulesOutput,
+    ReloadRulesOutput,
+};
+
+/// Central policy evaluation service.
+///
+/// The PolicyEngineService sits between the orchestrator (which provides
+/// the LaneContext after execution) and the rule repository (which provides
+/// the PolicyRules). It evaluates rules against the context and produces
+/// actionable results.
+///
+/// # Integration
+///
+/// The orchestrator calls `evaluate()` after execution completes, before
+/// the closeout phase. The resulting action list is dispatched by the
+/// orchestrator in order.
+#[async_trait]
+pub trait PolicyEngineService: Send + Sync {
+    /// Evaluate all loaded rules against the given LaneContext.
+    ///
+    /// Returns a flat list of actions from all matching rules, ordered
+    /// by rule priority. Rules are evaluated in ascending priority order
+    /// (lower priority number = evaluated first). If multiple rules match,
+    /// all matching actions are collected and flattened.
+    ///
+    /// # Errors
+    ///
+    /// Returns `PolicyEngineError::NoMatchingRule` if no rules match the
+    /// given context (configurable — some orchestrators may treat this
+    /// as informational rather than an error).
+    async fn evaluate(
+        &self,
+        input: EvaluatePolicyInput,
+    ) -> Result<EvaluatePolicyOutput, PolicyEngineError>;
+
+    /// Load rules from a policy configuration.
+    ///
+    /// Replaces all currently loaded rules with those from the provided
+    /// configuration. Rules are validated during loading — duplicate names
+    /// or invalid configurations return an error.
+    async fn load_rules(&self, config: super::dto::LoadRulesInput) -> Result<LoadRulesOutput, PolicyEngineError>;
+
+    /// Get all currently active (loaded) rules.
+    ///
+    /// Returns the list of rules sorted by priority.
+    async fn get_active_rules(&self) -> Result<GetActiveRulesOutput, PolicyEngineError>;
+
+    /// Reload rules from the last loaded source.
+    ///
+    /// Re-reads the policy configuration from the source that was used
+    /// in the last `load_rules()` call. If no source was previously loaded,
+    /// returns `PolicyEngineError::InvalidState`.
+    async fn reload_rules(&self) -> Result<ReloadRulesOutput, PolicyEngineError>;
+
+    /// Check whether any rules are currently loaded.
+    fn has_rules(&self) -> bool;
+
+    /// Get the number of currently loaded rules.
+    fn rule_count(&self) -> u32;
+}
+
+/// Convenience function: evaluate rules in memory against a context.
+///
+/// This is a pure function that doesn't go through the service trait,
+/// useful for testing and simple in-process evaluations. It sorts rules
+/// by priority (ascending), evaluates each against the context, and
+/// returns a flat list of matching actions.
+///
+/// # Panics
+///
+/// This function does not panic. If no rules match, it returns an empty
+/// vector (callers should check for this condition).
+pub fn evaluate_rules(rules: &[PolicyRule], context: &LaneContext) -> Vec<super::dto::ActionOutput> {
+    let mut sorted_rules: Vec<&PolicyRule> = rules.iter().collect();
+    sorted_rules.sort_by_key(|r| r.priority);
+
+    let mut actions = Vec::new();
+    for rule in sorted_rules {
+        if rule.condition.matches(context) {
+            let mut flattened = Vec::new();
+            rule.action.clone().flatten_into(&mut flattened);
+            for action in flattened {
+                actions.push(super::dto::ActionOutput {
+                    rule_name: rule.name.clone(),
+                    priority: rule.priority,
+                    action,
+                });
+            }
+        }
+    }
+    actions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy_engine::domain::{
+        PolicyAction, PolicyCondition, PolicyRule, LaneBlocker, ReviewStatus, DiffScope,
+    };
+
+    #[test]
+    fn test_evaluate_rules_in_priority_order() {
+        let rules = vec![
+            PolicyRule::new(
+                "low".to_string(),
+                PolicyCondition::LaneCompleted,
+                PolicyAction::Notify { channel: "slack".to_string() },
+                20,
+            ),
+            PolicyRule::new(
+                "high".to_string(),
+                PolicyCondition::LaneCompleted,
+                PolicyAction::CloseoutLane,
+                10,
+            ),
+        ];
+
+        let ctx = LaneContext {
+            lane_id: "test".to_string(),
+            green_level: 3,
+            branch_freshness_secs: 100,
+            blocker: LaneBlocker::None,
+            review_status: ReviewStatus::Pending,
+            diff_scope: DiffScope::Scoped,
+            completed: true,
+            reconciled: false,
+        };
+
+        let actions = evaluate_rules(&rules, &ctx);
+        assert_eq!(actions.len(), 2);
+        assert_eq!(actions[0].rule_name, "high");
+        assert_eq!(actions[1].rule_name, "low");
+    }
+
+    #[test]
+    fn test_evaluate_rules_no_match() {
+        let rules = vec![PolicyRule::new(
+            "stale".to_string(),
+            PolicyCondition::StaleBranch,
+            PolicyAction::Block {
+                reason: "branch is stale".to_string(),
+            },
+            10,
+        )];
+
+        let ctx = LaneContext {
+            lane_id: "test".to_string(),
+            green_level: 3,
+            branch_freshness_secs: 100, // fresh, not stale
+            blocker: LaneBlocker::None,
+            review_status: ReviewStatus::Pending,
+            diff_scope: DiffScope::Scoped,
+            completed: true,
+            reconciled: false,
+        };
+
+        let actions = evaluate_rules(&rules, &ctx);
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn test_evaluate_rules_chain_flattening() {
+        let rules = vec![PolicyRule::new(
+            "chain-rule".to_string(),
+            PolicyCondition::LaneCompleted,
+            PolicyAction::Chain(vec![
+                PolicyAction::CloseoutLane,
+                PolicyAction::CleanupSession,
+            ]),
+            10,
+        )];
+
+        let ctx = LaneContext {
+            lane_id: "test".to_string(),
+            green_level: 3,
+            branch_freshness_secs: 100,
+            blocker: LaneBlocker::None,
+            review_status: ReviewStatus::Pending,
+            diff_scope: DiffScope::Scoped,
+            completed: true,
+            reconciled: false,
+        };
+
+        let actions = evaluate_rules(&rules, &ctx);
+        assert_eq!(actions.len(), 2);
+        assert_eq!(actions[0].action, PolicyAction::CloseoutLane);
+        assert_eq!(actions[1].action, PolicyAction::CleanupSession);
+    }
+}

--- a/engine/src/policy_engine/application/factory.rs
+++ b/engine/src/policy_engine/application/factory.rs
@@ -1,0 +1,60 @@
+//! Factory interfaces for constructing PolicyEngine domain objects.
+//!
+//! @canonical .pi/architecture/modules/policy-engine.md
+//! Implements: Contract Freeze — PolicyEngineFactory trait
+//! Issue: issue-contract-freeze
+//!
+//! Factories encapsulate the construction of the PolicyEngineService
+//! with appropriate rules loaded from configuration or a repository.
+//!
+//! # Contract (Frozen)
+//! - Every factory method returns a configured PolicyEngineService
+//! - Validation is applied during construction
+//! - No mutable state in factory implementations
+
+use async_trait::async_trait;
+
+use crate::policy_engine::domain::{PolicyConfig, PolicyEngineError};
+
+use super::engine::PolicyEngineService;
+
+/// Factory for constructing `PolicyEngineService` instances.
+///
+/// Handles creation of the policy engine with appropriate rules loaded
+/// from configuration files, repositories, or inline definitions.
+#[async_trait]
+pub trait PolicyEngineFactory: Send + Sync {
+    /// Create a `PolicyEngineService` from a `PolicyConfig`.
+    ///
+    /// Builds the full engine state with rules loaded from the config.
+    /// Rules are validated during construction — duplicate names or
+    /// invalid configurations return an error.
+    async fn create_from_config(
+        &self,
+        config: PolicyConfig,
+    ) -> Result<Box<dyn PolicyEngineService>, PolicyEngineError>;
+
+    /// Create a `PolicyEngineService` using default rules.
+    ///
+    /// Uses a set of sensible default policy rules suitable for
+    /// standard operation without user configuration.
+    async fn create_default(&self) -> Result<Box<dyn PolicyEngineService>, PolicyEngineError>;
+
+    /// Create a `PolicyEngineService` with inline rules.
+    ///
+    /// Useful for testing or programmatic rule definitions.
+    /// Rules are validated before the engine is returned.
+    async fn create_with_rules(
+        &self,
+        rule_definitions: Vec<crate::policy_engine::domain::config::RuleDefinition>,
+    ) -> Result<Box<dyn PolicyEngineService>, PolicyEngineError>;
+
+    /// Create a `PolicyEngineService` that loads rules from a repository on demand.
+    ///
+    /// The engine will defer rule loading until first evaluation or explicitly
+    /// via `load_rules()`. The repository is queried each time rules are loaded.
+    async fn create_with_repository(
+        &self,
+        repository: Box<dyn crate::policy_engine::infrastructure::repository::PolicyRepository>,
+    ) -> Result<Box<dyn PolicyEngineService>, PolicyEngineError>;
+}

--- a/engine/src/policy_engine/application/mod.rs
+++ b/engine/src/policy_engine/application/mod.rs
@@ -1,0 +1,24 @@
+//! Application layer interfaces for the Policy Engine bounded context.
+//!
+//! @canonical .pi/architecture/modules/policy-engine.md
+//! Implements: Contract Freeze — service traits, DTOs, factory interfaces
+//! Issue: issue-contract-freeze
+//!
+//! This module defines:
+//! - Service traits (use cases / application services)
+//! - Input/Output DTOs with validation
+//! - Factory interfaces for constructing PolicyEngine instances
+//!
+//! # Contract (Frozen)
+//! - All service methods are async (return `impl Future`)
+//! - All public methods return `Result<_, PolicyEngineError>`
+//! - DTOs include validation annotations/documentation
+//! - No implementation logic — only trait definitions
+
+pub mod dto;
+pub mod engine;
+pub mod factory;
+
+pub use dto::*;
+pub use engine::*;
+pub use factory::*;

--- a/engine/src/policy_engine/domain/action.rs
+++ b/engine/src/policy_engine/domain/action.rs
@@ -1,0 +1,191 @@
+//! PolicyAction domain entity.
+//!
+//! @canonical .pi/architecture/modules/policy-engine.md#action
+//! Implements: Contract Freeze — PolicyAction enum
+//! Issue: issue-contract-freeze
+//!
+//! Actions define what the orchestrator does when a policy rule matches.
+//! Actions are flat (single action) or compound via `Chain`.
+//! The orchestrator iterates the collected action list and dispatches
+//! each action to the appropriate handler.
+//!
+//! # Contract (Frozen)
+//! - `Chain` is the only compound action — all others are leaf actions
+//! - `Reconcile` carries a `ReconcileReason` enum
+//! - Actions carry only the data needed for dispatch, no behavior
+
+use serde::{Deserialize, Serialize};
+
+/// Actions that the orchestrator performs when a policy rule matches.
+///
+/// # Dispatch
+///
+/// The orchestrator receives a flat list of `PolicyAction`s (after
+/// flattening `Chain`). Actions are executed in order. If an action
+/// fails, the orchestrator may retry, skip, or abort depending on
+/// the action type and severity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyAction {
+    /// Merge the lane branch into the development/main branch.
+    ///
+    /// The specific branch is determined by the lane configuration
+    /// (e.g., `dev` or `main` target).
+    MergeToDev,
+
+    /// Merge changes forward (e.g., from dev → main or staging → production).
+    ///
+    /// Used in multi-tier branching strategies where changes flow
+    /// through multiple merge hops.
+    MergeForward,
+
+    /// Attempt recovery of a failed lane execution once.
+    ///
+    /// Re-triggers the lane execution with the same configuration.
+    /// The retry count is tracked by the orchestrator.
+    RecoverOnce,
+
+    /// Escalate the lane to a human operator with a reason.
+    Escalate {
+        /// Human-readable reason for escalation.
+        reason: String,
+    },
+
+    /// Close out the lane, cleaning up task resources and state.
+    CloseoutLane,
+
+    /// Clean up session state (temporary files, locks, etc.).
+    CleanupSession,
+
+    /// Reconcile the lane — no merge needed because the lane is
+    /// already merged, superseded, has an empty diff, or was
+    /// manually closed.
+    Reconcile {
+        /// The reason the lane can be reconciled.
+        reason: ReconcileReason,
+    },
+
+    /// Send a notification to a specified channel (e.g., "discord", "slack").
+    Notify {
+        /// The target channel identifier.
+        channel: String,
+    },
+
+    /// Block the lane with a reason, preventing further execution.
+    Block {
+        /// Human-readable reason for the block.
+        reason: String,
+    },
+
+    /// Execute multiple actions in sequence.
+    ///
+    /// This is the only compound action. When the engine encounters
+    /// a `Chain`, it flattens the contained actions into the output
+    /// list in order.
+    Chain(Vec<PolicyAction>),
+}
+
+impl PolicyAction {
+    /// Flatten this action into the provided vector.
+    ///
+    /// For leaf actions, appends `self` to the vector.
+    /// For `Chain` actions, recursively flattens each contained action.
+    pub fn flatten_into(self, actions: &mut Vec<PolicyAction>) {
+        match self {
+            PolicyAction::Chain(inner) => {
+                for action in inner {
+                    action.flatten_into(actions);
+                }
+            }
+            other => actions.push(other),
+        }
+    }
+
+    /// Return true if this action is a leaf (not Chain).
+    pub fn is_leaf(&self) -> bool {
+        !matches!(self, PolicyAction::Chain(_))
+    }
+}
+
+/// Reasons why a lane can be reconciled (no merge needed).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReconcileReason {
+    /// The lane's branch was already merged by another process.
+    AlreadyMerged,
+
+    /// The lane's work was superseded by a more recent lane.
+    Superseded,
+
+    /// The lane has an empty diff (no changes to merge).
+    EmptyDiff,
+
+    /// The lane was manually closed by a user.
+    ManualClose,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_flatten_leaf_action() {
+        let mut actions = Vec::new();
+        PolicyAction::CloseoutLane.flatten_into(&mut actions);
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0], PolicyAction::CloseoutLane);
+    }
+
+    #[test]
+    fn test_flatten_chain() {
+        let mut actions = Vec::new();
+        let chain = PolicyAction::Chain(vec![
+            PolicyAction::CloseoutLane,
+            PolicyAction::CleanupSession,
+        ]);
+        chain.flatten_into(&mut actions);
+        assert_eq!(actions.len(), 2);
+        assert_eq!(actions[0], PolicyAction::CloseoutLane);
+        assert_eq!(actions[1], PolicyAction::CleanupSession);
+    }
+
+    #[test]
+    fn test_flatten_nested_chain() {
+        let mut actions = Vec::new();
+        let chain = PolicyAction::Chain(vec![
+            PolicyAction::CloseoutLane,
+            PolicyAction::Chain(vec![
+                PolicyAction::CleanupSession,
+                PolicyAction::Notify {
+                    channel: "discord".to_string(),
+                },
+            ]),
+        ]);
+        chain.flatten_into(&mut actions);
+        assert_eq!(actions.len(), 3);
+    }
+
+    #[test]
+    fn test_is_leaf() {
+        assert!(PolicyAction::CloseoutLane.is_leaf());
+        assert!(!PolicyAction::Chain(vec![]).is_leaf());
+    }
+
+    #[test]
+    fn test_reconcile_reason_serde() {
+        let reason = ReconcileReason::EmptyDiff;
+        let json = serde_json::to_string(&reason).unwrap();
+        let deserialized: ReconcileReason = serde_json::from_str(&json).unwrap();
+        assert_eq!(reason, deserialized);
+    }
+
+    #[test]
+    fn test_action_serde_roundtrip() {
+        let action = PolicyAction::Escalate {
+            reason: "Startup blocked".to_string(),
+        };
+        let json = serde_json::to_string(&action).unwrap();
+        let deserialized: PolicyAction = serde_json::from_str(&json).unwrap();
+        assert_eq!(action, deserialized);
+    }
+}

--- a/engine/src/policy_engine/domain/condition.rs
+++ b/engine/src/policy_engine/domain/condition.rs
@@ -1,0 +1,320 @@
+//! PolicyCondition domain entity.
+//!
+//! @canonical .pi/architecture/modules/policy-engine.md#condition
+//! Implements: Contract Freeze — PolicyCondition enum
+//! Issue: issue-contract-freeze
+//!
+//! Composable boolean conditions evaluated against LaneContext.
+//! Supports logical combinators (And/Or) and leaf conditions over
+//! observable state — quality level, branch freshness, review status,
+//! completion state, and diff scope.
+//!
+//! # Contract (Frozen)
+//! - All conditions are pure boolean predicates over LaneContext
+//! - And/Or enable arbitrarily nested condition trees
+//! - `GreenAt` bridges policy engine to QualityGates
+//! - No framework-specific annotations — pure domain types
+
+use serde::{Deserialize, Serialize};
+
+/// Composable boolean conditions evaluated against LaneContext.
+///
+/// These are the building blocks of policy rules. Conditions can be
+/// simple leaf checks (`LaneCompleted`, `StaleBranch`) or compound
+/// boolean trees using `And` and `Or`.
+///
+/// # Serde Tagging
+///
+/// Uses `#[serde(tag = "type", rename_all = "snake_case")]` for
+/// TOML/JSON compatibility. Examples:
+///
+/// ```toml
+/// # Compound And condition
+/// condition = { type = "and", conditions = [
+///     { type = "lane_completed" },
+///     { type = "green_at", level = 3 }
+/// ]}
+///
+/// # Simple condition
+/// condition = { type = "stale_branch" }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PolicyCondition {
+    /// All sub-conditions must match (logical AND).
+    ///
+    /// Returns `true` only if every sub-condition evaluates to `true`.
+    /// Short-circuits on the first `false`.
+    And {
+        /// The list of sub-conditions that must all match.
+        conditions: Vec<PolicyCondition>,
+    },
+
+    /// Any sub-condition must match (logical OR).
+    ///
+    /// Returns `true` if at least one sub-condition evaluates to `true`.
+    /// Short-circuits on the first `true`.
+    Or {
+        /// The list of sub-conditions where at least one must match.
+        conditions: Vec<PolicyCondition>,
+    },
+
+    /// Quality gate is at or above the given level.
+    ///
+    /// The level is a u8 representing the quality gate tier (1-5).
+    /// Level 0 matches any green gate (equivalent to "at least green").
+    GreenAt {
+        /// The minimum quality level required.
+        level: u8,
+    },
+
+    /// Branch has been stale beyond the configured threshold.
+    ///
+    /// Evaluates `branch_freshness_secs` against a configurable threshold
+    /// (defined by the threshold in LaneContext or a rule-level config).
+    /// Returns `true` if the branch has received no commits for longer
+    /// than the threshold.
+    StaleBranch,
+
+    /// Lane is blocked at startup (e.g., dependency not met).
+    ///
+    /// Matches when `LaneContext.blocker` is `LaneBlocker::Startup`.
+    StartupBlocked,
+
+    /// Lane execution has completed (all nodes executed).
+    ///
+    /// Matches when `LaneContext.completed` is `true`.
+    LaneCompleted,
+
+    /// Lane has been reconciled (no merge needed).
+    ///
+    /// Matches when `LaneContext.reconciled` is `true`.
+    LaneReconciled,
+
+    /// Review has been approved for this lane's diff.
+    ///
+    /// Matches when `LaneContext.review_status` is `ReviewStatus::Approved`.
+    ReviewPassed,
+
+    /// Diff is scoped (not a full-repo diff).
+    ///
+    /// Matches when `LaneContext.diff_scope` is `DiffScope::Scoped`.
+    ScopedDiff,
+
+    /// Branch has been untouched for the specified duration.
+    ///
+    /// Evaluates `branch_freshness_secs >= duration_secs`.
+    TimedOut {
+        /// Minimum duration in seconds since the last commit.
+        duration_secs: u64,
+    },
+}
+
+impl PolicyCondition {
+    /// Evaluate this condition against a LaneContext.
+    ///
+    /// This is a pure domain method with no side effects.
+    /// Returns `true` if the condition matches the context.
+    pub fn matches(&self, context: &super::context::LaneContext) -> bool {
+        match self {
+            PolicyCondition::And { conditions } => {
+                conditions.iter().all(|c| c.matches(context))
+            }
+            PolicyCondition::Or { conditions } => {
+                conditions.iter().any(|c| c.matches(context))
+            }
+            PolicyCondition::GreenAt { level } => {
+                context.green_level >= *level
+            }
+            PolicyCondition::StaleBranch => {
+                // Staleness threshold is derived from the context's
+                // branch_freshness_secs. A branch is stale if its freshness
+                // exceeds a configurable threshold (default: 7 days = 604800 secs).
+                context.branch_freshness_secs > 604_800
+            }
+            PolicyCondition::StartupBlocked => {
+                context.blocker == super::context::LaneBlocker::Startup
+            }
+            PolicyCondition::LaneCompleted => context.completed,
+            PolicyCondition::LaneReconciled => context.reconciled,
+            PolicyCondition::ReviewPassed => {
+                context.review_status == super::context::ReviewStatus::Approved
+            }
+            PolicyCondition::ScopedDiff => {
+                context.diff_scope == super::context::DiffScope::Scoped
+            }
+            PolicyCondition::TimedOut { duration_secs } => {
+                context.branch_freshness_secs >= *duration_secs
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::policy_engine::domain::{
+        context::{DiffScope, LaneBlocker, LaneContext, ReviewStatus},
+        PolicyCondition,
+    };
+
+    fn test_context() -> LaneContext {
+        LaneContext {
+            lane_id: "test-lane".to_string(),
+            green_level: 3,
+            branch_freshness_secs: 100,
+            blocker: LaneBlocker::None,
+            review_status: ReviewStatus::Pending,
+            diff_scope: DiffScope::Scoped,
+            completed: true,
+            reconciled: false,
+        }
+    }
+
+    #[test]
+    fn test_lane_completed_matches() {
+        let ctx = test_context();
+        assert!(PolicyCondition::LaneCompleted.matches(&ctx));
+    }
+
+    #[test]
+    fn test_lane_completed_does_not_match() {
+        let mut ctx = test_context();
+        ctx.completed = false;
+        assert!(!PolicyCondition::LaneCompleted.matches(&ctx));
+    }
+
+    #[test]
+    fn test_green_at_matches() {
+        let ctx = test_context();
+        assert!(PolicyCondition::GreenAt { level: 3 }.matches(&ctx));
+        assert!(PolicyCondition::GreenAt { level: 2 }.matches(&ctx));
+    }
+
+    #[test]
+    fn test_green_at_does_not_match() {
+        let ctx = test_context();
+        assert!(!PolicyCondition::GreenAt { level: 4 }.matches(&ctx));
+    }
+
+    #[test]
+    fn test_and_all_true() {
+        let ctx = test_context();
+        let condition = PolicyCondition::And {
+            conditions: vec![
+                PolicyCondition::LaneCompleted,
+                PolicyCondition::ScopedDiff,
+            ],
+        };
+        assert!(condition.matches(&ctx));
+    }
+
+    #[test]
+    fn test_and_one_false() {
+        let ctx = test_context();
+        let condition = PolicyCondition::And {
+            conditions: vec![
+                PolicyCondition::LaneCompleted,
+                PolicyCondition::StaleBranch,
+            ],
+        };
+        assert!(!condition.matches(&ctx));
+    }
+
+    #[test]
+    fn test_or_one_true() {
+        let ctx = test_context();
+        let condition = PolicyCondition::Or {
+            conditions: vec![
+                PolicyCondition::StaleBranch,
+                PolicyCondition::LaneCompleted,
+            ],
+        };
+        assert!(condition.matches(&ctx));
+    }
+
+    #[test]
+    fn test_or_all_false() {
+        let mut ctx = test_context();
+        ctx.completed = false;
+        let condition = PolicyCondition::Or {
+            conditions: vec![
+                PolicyCondition::StaleBranch,
+                PolicyCondition::LaneCompleted,
+            ],
+        };
+        assert!(!condition.matches(&ctx));
+    }
+
+    #[test]
+    fn test_startup_blocked_matches() {
+        let mut ctx = test_context();
+        ctx.blocker = LaneBlocker::Startup;
+        assert!(PolicyCondition::StartupBlocked.matches(&ctx));
+    }
+
+    #[test]
+    fn test_review_passed_matches() {
+        let mut ctx = test_context();
+        ctx.review_status = ReviewStatus::Approved;
+        assert!(PolicyCondition::ReviewPassed.matches(&ctx));
+    }
+
+    #[test]
+    fn test_timed_out_matches() {
+        let mut ctx = test_context();
+        ctx.branch_freshness_secs = 3600;
+        assert!(PolicyCondition::TimedOut { duration_secs: 1800 }.matches(&ctx));
+    }
+
+    #[test]
+    fn test_timed_out_does_not_match() {
+        let ctx = test_context();
+        assert!(!PolicyCondition::TimedOut { duration_secs: 200 }.matches(&ctx));
+    }
+
+    #[test]
+    fn test_condition_serde_roundtrip() {
+        let condition = PolicyCondition::And {
+            conditions: vec![
+                PolicyCondition::LaneCompleted,
+                PolicyCondition::GreenAt { level: 3 },
+            ],
+        };
+        let json = serde_json::to_string(&condition).unwrap();
+        let deserialized: PolicyCondition = serde_json::from_str(&json).unwrap();
+        assert_eq!(condition, deserialized);
+    }
+
+    #[test]
+    fn test_stale_branch_matches() {
+        let mut ctx = test_context();
+        ctx.branch_freshness_secs = 604_801; // > 7 days
+        assert!(PolicyCondition::StaleBranch.matches(&ctx));
+    }
+
+    #[test]
+    fn test_stale_branch_does_not_match() {
+        let ctx = test_context();
+        assert!(!PolicyCondition::StaleBranch.matches(&ctx));
+    }
+
+    #[test]
+    fn test_lane_reconciled_matches() {
+        let mut ctx = test_context();
+        ctx.reconciled = true;
+        assert!(PolicyCondition::LaneReconciled.matches(&ctx));
+    }
+
+    #[test]
+    fn test_scoped_diff_matches() {
+        let ctx = test_context();
+        assert!(PolicyCondition::ScopedDiff.matches(&ctx));
+    }
+
+    #[test]
+    fn test_scoped_diff_does_not_match() {
+        let mut ctx = test_context();
+        ctx.diff_scope = DiffScope::Full;
+        assert!(!PolicyCondition::ScopedDiff.matches(&ctx));
+    }
+}

--- a/engine/src/policy_engine/domain/config.rs
+++ b/engine/src/policy_engine/domain/config.rs
@@ -1,0 +1,144 @@
+//! PolicyConfig domain entity.
+//!
+//! @canonical .pi/architecture/modules/policy-engine.md#config
+//! Implements: Contract Freeze — PolicyConfig struct
+//! Issue: issue-contract-freeze
+//!
+//! Represents user-configurable policy rule definitions that can be
+//! loaded from a TOML file (`.rigorix/policy.toml`). Rules are
+//! defined as a list of serializable rule descriptors that are
+//! compiled into `PolicyRule` instances by the policy engine.
+//!
+//! # Contract (Frozen)
+//! - `PolicyConfig` is the top-level TOML structure
+//! - Each rule definition has a name, condition, action, and priority
+//! - Conditions use serde tagged enums for composable trees
+//! - Actions use serde tagged enums for dispatch
+
+use serde::{Deserialize, Serialize};
+
+use super::action::PolicyAction;
+use super::condition::PolicyCondition;
+
+/// User-configurable policy rule definitions.
+///
+/// Loaded from `.rigorix/policy.toml` and converted to a list of
+/// `PolicyRule` instances for evaluation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PolicyConfig {
+    /// The list of rule definitions.
+    pub rules: Vec<RuleDefinition>,
+}
+
+/// A single rule definition in the configuration.
+///
+/// Maps directly to a `PolicyRule` entity.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RuleDefinition {
+    /// Unique name for this rule.
+    pub name: String,
+
+    /// The composable condition for this rule.
+    pub condition: PolicyCondition,
+
+    /// The action to take when the condition matches.
+    pub action: PolicyAction,
+
+    /// Evaluation priority (lower = higher priority).
+    pub priority: u32,
+}
+
+impl PolicyConfig {
+    /// Create an empty policy configuration.
+    pub fn empty() -> Self {
+        Self { rules: Vec::new() }
+    }
+
+    /// Create a policy configuration with a single rule.
+    pub fn single(rule: RuleDefinition) -> Self {
+        Self {
+            rules: vec![rule],
+        }
+    }
+
+    /// Convert this configuration into a list of `PolicyRule` domain entities.
+    pub fn into_rules(self) -> Vec<super::rule::PolicyRule> {
+        self.rules
+            .into_iter()
+            .map(|def| super::rule::PolicyRule {
+                name: def.name,
+                condition: def.condition,
+                action: def.action,
+                priority: def.priority,
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy_engine::domain::PolicyAction;
+
+    #[test]
+    fn test_empty_config() {
+        let config = PolicyConfig::empty();
+        assert!(config.rules.is_empty());
+    }
+
+    #[test]
+    fn test_single_rule_config() {
+        let config = PolicyConfig::single(RuleDefinition {
+            name: "test".to_string(),
+            condition: PolicyCondition::LaneCompleted,
+            action: PolicyAction::CloseoutLane,
+            priority: 10,
+        });
+        assert_eq!(config.rules.len(), 1);
+        assert_eq!(config.rules[0].name, "test");
+    }
+
+    #[test]
+    fn test_convert_to_rules() {
+        let config = PolicyConfig {
+            rules: vec![
+                RuleDefinition {
+                    name: "rule-1".to_string(),
+                    condition: PolicyCondition::LaneCompleted,
+                    action: PolicyAction::CloseoutLane,
+                    priority: 10,
+                },
+                RuleDefinition {
+                    name: "rule-2".to_string(),
+                    condition: PolicyCondition::ScopedDiff,
+                    action: PolicyAction::Notify {
+                        channel: "slack".to_string(),
+                    },
+                    priority: 20,
+                },
+            ],
+        };
+        let rules = config.into_rules();
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].name, "rule-1");
+        assert_eq!(rules[1].name, "rule-2");
+    }
+
+    #[test]
+    fn test_config_serde_roundtrip() {
+        let config = PolicyConfig::single(RuleDefinition {
+            name: "closeout-completed".to_string(),
+            condition: PolicyCondition::And {
+                conditions: vec![
+                    PolicyCondition::LaneCompleted,
+                    PolicyCondition::GreenAt { level: 3 },
+                ],
+            },
+            action: PolicyAction::CloseoutLane,
+            priority: 10,
+        });
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: PolicyConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(config, deserialized);
+    }
+}

--- a/engine/src/policy_engine/domain/context.rs
+++ b/engine/src/policy_engine/domain/context.rs
@@ -1,0 +1,171 @@
+//! LaneContext domain entity.
+//!
+//! @canonical .pi/architecture/modules/policy-engine.md#context
+//! Implements: Contract Freeze — LaneContext struct
+//! Issue: issue-contract-freeze
+//!
+//! A typed snapshot of execution state that policy conditions evaluate
+//! against. Built by the orchestrator from ExecutionRecord, git state,
+//! risk gating, and review state.
+//!
+//! # Contract (Frozen)
+//! - All fields are public for direct condition evaluation
+//! - Context is immutable once constructed
+//! - `green_level` is a u8 representing the quality gate tier (0-5)
+
+use serde::{Deserialize, Serialize};
+
+/// Typed snapshot of execution state evaluated by policy conditions.
+///
+/// The LaneContext is constructed by the orchestrator after execution
+/// completes, before the closeout phase. It aggregates all observable
+/// state needed by policy conditions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LaneContext {
+    /// Unique identifier for this lane (execution session).
+    pub lane_id: String,
+
+    /// The quality gate level achieved (0-5, where 0 = no gate, 5 = highest).
+    pub green_level: u8,
+
+    /// Time in seconds since the last commit on the lane's branch.
+    pub branch_freshness_secs: u64,
+
+    /// Current blocker state for this lane.
+    pub blocker: LaneBlocker,
+
+    /// Current review status for this lane's diff.
+    pub review_status: ReviewStatus,
+
+    /// Scope of the diff associated with this lane.
+    pub diff_scope: DiffScope,
+
+    /// Whether lane execution has completed (all DAG nodes executed).
+    pub completed: bool,
+
+    /// Whether the lane has been reconciled (no merge needed).
+    pub reconciled: bool,
+}
+
+/// Blocker state for a lane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LaneBlocker {
+    /// No blocker — lane is free to execute.
+    None,
+
+    /// Lane is blocked at startup (e.g., dependency not satisfied).
+    Startup,
+
+    /// Lane is blocked by an external factor (e.g., CI failure, external service).
+    External,
+}
+
+/// Review status for a lane's diff.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewStatus {
+    /// Review is pending (not yet reviewed).
+    Pending,
+
+    /// Review has been approved.
+    Approved,
+
+    /// Review has been rejected.
+    Rejected,
+}
+
+/// Scope of the diff associated with a lane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiffScope {
+    /// Full repository diff (many files changed).
+    Full,
+
+    /// Scoped diff (small number of files changed).
+    Scoped,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lane_context_creation() {
+        let ctx = LaneContext {
+            lane_id: "lane-1".to_string(),
+            green_level: 3,
+            branch_freshness_secs: 3600,
+            blocker: LaneBlocker::None,
+            review_status: ReviewStatus::Pending,
+            diff_scope: DiffScope::Scoped,
+            completed: true,
+            reconciled: false,
+        };
+        assert_eq!(ctx.lane_id, "lane-1");
+        assert_eq!(ctx.green_level, 3);
+        assert!(ctx.completed);
+        assert!(!ctx.reconciled);
+    }
+
+    #[test]
+    fn test_lane_context_serde_roundtrip() {
+        let ctx = LaneContext {
+            lane_id: "lane-1".to_string(),
+            green_level: 3,
+            branch_freshness_secs: 3600,
+            blocker: LaneBlocker::Startup,
+            review_status: ReviewStatus::Approved,
+            diff_scope: DiffScope::Full,
+            completed: true,
+            reconciled: false,
+        };
+        let json = serde_json::to_string(&ctx).unwrap();
+        let deserialized: LaneContext = serde_json::from_str(&json).unwrap();
+        assert_eq!(ctx, deserialized);
+    }
+
+    #[test]
+    fn test_lane_blocker_serde() {
+        assert_eq!(
+            serde_json::from_str::<LaneBlocker>("\"none\"").unwrap(),
+            LaneBlocker::None
+        );
+        assert_eq!(
+            serde_json::from_str::<LaneBlocker>("\"startup\"").unwrap(),
+            LaneBlocker::Startup
+        );
+        assert_eq!(
+            serde_json::from_str::<LaneBlocker>("\"external\"").unwrap(),
+            LaneBlocker::External
+        );
+    }
+
+    #[test]
+    fn test_review_status_serde() {
+        assert_eq!(
+            serde_json::from_str::<ReviewStatus>("\"pending\"").unwrap(),
+            ReviewStatus::Pending
+        );
+        assert_eq!(
+            serde_json::from_str::<ReviewStatus>("\"approved\"").unwrap(),
+            ReviewStatus::Approved
+        );
+        assert_eq!(
+            serde_json::from_str::<ReviewStatus>("\"rejected\"").unwrap(),
+            ReviewStatus::Rejected
+        );
+    }
+
+    #[test]
+    fn test_diff_scope_serde() {
+        assert_eq!(
+            serde_json::from_str::<DiffScope>("\"full\"").unwrap(),
+            DiffScope::Full
+        );
+        assert_eq!(
+            serde_json::from_str::<DiffScope>("\"scoped\"").unwrap(),
+            DiffScope::Scoped
+        );
+    }
+}

--- a/engine/src/policy_engine/domain/error.rs
+++ b/engine/src/policy_engine/domain/error.rs
@@ -1,0 +1,112 @@
+//! PolicyEngineError types.
+//!
+//! @canonical .pi/architecture/modules/policy-engine.md#errors
+//! Implements: Contract Freeze — PolicyEngineError enum
+//! Issue: issue-contract-freeze
+//!
+//! All errors use `thiserror` derive macros. No `anyhow` in library code.
+//!
+//! # Contract (Frozen)
+//! - `PolicyEngineError` is the single error type for this module
+//! - Each variant carries structured context for error reporting
+//! - Implements `std::error::Error` for library compatibility
+//! - Converted to `CoreOrchestratorError` via `#[from]` at the orchestrator level
+
+use thiserror::Error;
+
+/// Errors that can occur during policy engine operations.
+#[derive(Debug, Error)]
+pub enum PolicyEngineError {
+    /// A rule was not found by the requested identifier.
+    #[error("Policy rule not found: {rule_name}")]
+    RuleNotFound {
+        /// The name of the rule that was not found.
+        rule_name: String,
+    },
+
+    /// The policy configuration is invalid.
+    #[error("Invalid policy configuration: {detail}")]
+    InvalidConfiguration {
+        /// Details about the configuration error.
+        detail: String,
+    },
+
+    /// A condition evaluation failed unexpectedly.
+    #[error("Condition evaluation error: {detail}")]
+    ConditionEvaluationError {
+        /// Details about the evaluation error.
+        detail: String,
+    },
+
+    /// No matching rules were found for the given context.
+    #[error("No matching rules for context (lane: {lane_id})")]
+    NoMatchingRule {
+        /// The lane ID for which no rule matched.
+        lane_id: String,
+    },
+
+    /// The policy engine is in an invalid state.
+    #[error("Invalid policy engine state: {detail}")]
+    InvalidState {
+        /// Details about the state error.
+        detail: String,
+    },
+
+    /// A repository operation failed.
+    #[error("Policy repository error: {detail}")]
+    RepositoryError {
+        /// Details about the repository error.
+        detail: String,
+    },
+
+    /// Failed to deserialize policy configuration from source.
+    #[error("Failed to deserialize policy configuration: {detail}")]
+    DeserializationError {
+        /// Details about the deserialization error.
+        detail: String,
+    },
+}
+
+impl PolicyEngineError {
+    /// Whether this error can be retried.
+    pub fn is_retriable(&self) -> bool {
+        matches!(
+            self,
+            PolicyEngineError::RepositoryError { .. }
+                | PolicyEngineError::ConditionEvaluationError { .. }
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rule_not_found_error() {
+        let err = PolicyEngineError::RuleNotFound {
+            rule_name: "test-rule".to_string(),
+        };
+        assert!(!err.is_retriable());
+        assert_eq!(
+            err.to_string(),
+            "Policy rule not found: test-rule"
+        );
+    }
+
+    #[test]
+    fn test_repository_error_is_retriable() {
+        let err = PolicyEngineError::RepositoryError {
+            detail: "connection failed".to_string(),
+        };
+        assert!(err.is_retriable());
+    }
+
+    #[test]
+    fn test_invalid_config_not_retriable() {
+        let err = PolicyEngineError::InvalidConfiguration {
+            detail: "missing rules".to_string(),
+        };
+        assert!(!err.is_retriable());
+    }
+}

--- a/engine/src/policy_engine/domain/event/mod.rs
+++ b/engine/src/policy_engine/domain/event/mod.rs
@@ -1,0 +1,167 @@
+//! Event payload schemas for the Policy Engine bounded context.
+//!
+//! @canonical .pi/architecture/modules/policy-engine.md#event
+//! Implements: Contract Freeze — PolicyEvent payload schemas
+//! Issue: issue-contract-freeze
+//!
+//! These events are emitted whenever policy evaluation occurs —
+//! rules matched, actions dispatched, configuration loaded.
+//! Consumers (orchestrator, audit, TUI) subscribe to these event types.
+//!
+//! # Contract (Frozen)
+//! - Each event carries the full context needed by consumers
+//! - No internal implementation details exposed
+//! - `lane_id` correlates to the originating lane
+
+use serde::{Deserialize, Serialize};
+
+use super::action::PolicyAction;
+
+/// Events emitted by the Policy Engine module.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum PolicyEvent {
+    /// A policy rule matched the current LaneContext.
+    ///
+    /// Emitted for every matching rule during evaluation.
+    RuleMatched {
+        /// The lane ID for which the rule matched.
+        lane_id: String,
+        /// The name of the matching rule.
+        rule_name: String,
+        /// The priority of the matching rule.
+        priority: u32,
+        /// The action produced by this matching rule.
+        action: PolicyAction,
+    },
+
+    /// A flat list of actions was produced by evaluating a LaneContext.
+    ///
+    /// Emitted once per evaluate() call, containing all actions from
+    /// all matching rules in priority order.
+    ActionsDispatched {
+        /// The lane ID for which actions were produced.
+        lane_id: String,
+        /// The flat list of actions in dispatch order.
+        actions: Vec<PolicyAction>,
+        /// Number of rules that matched this evaluation.
+        matching_rule_count: u32,
+    },
+
+    /// The policy configuration was loaded or reloaded.
+    ConfigLoaded {
+        /// The source from which the config was loaded (e.g., "file", "repository").
+        source: String,
+        /// Number of rules loaded.
+        rule_count: u32,
+        /// Whether the load was successful.
+        success: bool,
+        /// Error details if the load failed.
+        error: Option<String>,
+    },
+
+    /// A policy evaluation was performed for a LaneContext.
+    ///
+    /// Emitted for every evaluation, whether or not any rules matched.
+    EvaluationPerformed {
+        /// The lane ID that was evaluated.
+        lane_id: String,
+        /// Whether any rules matched.
+        matched: bool,
+        /// Number of rules evaluated (total).
+        rules_evaluated: u32,
+        /// Duration of the evaluation in milliseconds.
+        duration_ms: u64,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy_engine::domain::PolicyAction;
+
+    #[test]
+    fn test_rule_matched_event_serde() {
+        let event = PolicyEvent::RuleMatched {
+            lane_id: "lane-1".to_string(),
+            rule_name: "closeout-completed".to_string(),
+            priority: 10,
+            action: PolicyAction::CloseoutLane,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let deserialized: PolicyEvent = serde_json::from_str(&json).unwrap();
+        assert!(matches!(deserialized, PolicyEvent::RuleMatched { .. }));
+    }
+
+    #[test]
+    fn test_actions_dispatched_event() {
+        let event = PolicyEvent::ActionsDispatched {
+            lane_id: "lane-1".to_string(),
+            actions: vec![PolicyAction::CloseoutLane, PolicyAction::CleanupSession],
+            matching_rule_count: 2,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let deserialized: PolicyEvent = serde_json::from_str(&json).unwrap();
+        assert!(matches!(deserialized, PolicyEvent::ActionsDispatched { .. }));
+    }
+
+    #[test]
+    fn test_config_loaded_event() {
+        let event = PolicyEvent::ConfigLoaded {
+            source: ".rigorix/policy.toml".to_string(),
+            rule_count: 5,
+            success: true,
+            error: None,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let deserialized: PolicyEvent = serde_json::from_str(&json).unwrap();
+        assert!(matches!(deserialized, PolicyEvent::ConfigLoaded { .. }));
+    }
+
+    #[test]
+    fn test_evaluation_performed_event() {
+        let event = PolicyEvent::EvaluationPerformed {
+            lane_id: "lane-1".to_string(),
+            matched: true,
+            rules_evaluated: 10,
+            duration_ms: 5,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let deserialized: PolicyEvent = serde_json::from_str(&json).unwrap();
+        assert!(matches!(deserialized, PolicyEvent::EvaluationPerformed { .. }));
+    }
+
+    #[test]
+    fn test_serde_roundtrip_all_variants() {
+        let variants = vec![
+            PolicyEvent::RuleMatched {
+                lane_id: "l".to_string(),
+                rule_name: "r".to_string(),
+                priority: 1,
+                action: PolicyAction::CloseoutLane,
+            },
+            PolicyEvent::ActionsDispatched {
+                lane_id: "l".to_string(),
+                actions: vec![],
+                matching_rule_count: 0,
+            },
+            PolicyEvent::ConfigLoaded {
+                source: "s".to_string(),
+                rule_count: 0,
+                success: true,
+                error: None,
+            },
+            PolicyEvent::EvaluationPerformed {
+                lane_id: "l".to_string(),
+                matched: false,
+                rules_evaluated: 0,
+                duration_ms: 0,
+            },
+        ];
+
+        for event in variants {
+            let json = serde_json::to_string(&event).unwrap();
+            let deserialized: PolicyEvent = serde_json::from_str(&json).unwrap();
+            assert!(std::mem::discriminant(&event) == std::mem::discriminant(&deserialized));
+        }
+    }
+}

--- a/engine/src/policy_engine/domain/mod.rs
+++ b/engine/src/policy_engine/domain/mod.rs
@@ -1,0 +1,32 @@
+//! Domain entities and interfaces for the Policy Engine bounded context.
+//!
+//! @canonical .pi/architecture/modules/policy-engine.md#domain
+//! Implements: Contract Freeze — domain entities PolicyRule, PolicyCondition,
+//!   PolicyAction, LaneContext, PolicyConfig, PolicyEngineError, PolicyEvent
+//! Issue: issue-contract-freeze
+//!
+//! This module defines the core domain types — the composable policy condition
+//! tree, the priority-ordered rule engine, execution actions, and the typed
+//! execution context (LaneContext) evaluated by conditions. These are pure
+//! domain objects with no framework dependencies.
+//!
+//! # Contract (Frozen)
+//! - No implementation logic beyond constructors and field accessors
+//! - All evaluation orchestration lives in the application layer
+//! - All persistence happens behind repository interfaces
+
+pub mod action;
+pub mod condition;
+pub mod config;
+pub mod context;
+pub mod error;
+pub mod event;
+pub mod rule;
+
+pub use action::{PolicyAction, ReconcileReason};
+pub use condition::PolicyCondition;
+pub use config::{PolicyConfig, RuleDefinition};
+pub use context::{DiffScope, LaneBlocker, LaneContext, ReviewStatus};
+pub use error::PolicyEngineError;
+pub use event::PolicyEvent;
+pub use rule::PolicyRule;

--- a/engine/src/policy_engine/domain/rule.rs
+++ b/engine/src/policy_engine/domain/rule.rs
@@ -1,0 +1,102 @@
+//! PolicyRule domain entity.
+//!
+//! @canonical .pi/architecture/modules/policy-engine.md#rule
+//! Implements: Contract Freeze — PolicyRule struct
+//! Issue: issue-contract-freeze
+//!
+//! A single policy rule with a name, composable condition, action, and
+//! priority. Rules are evaluated in ascending priority order — lower
+//! numbers have higher priority and are evaluated first.
+//!
+//! # Contract (Frozen)
+//! - `name` is a unique identifier for the rule
+//! - `condition` must evaluate to a boolean when tested against `LaneContext`
+//! - `action` is the executable action taken when the condition matches
+//! - `priority` determines evaluation order (lower = higher priority)
+
+use serde::{Deserialize, Serialize};
+
+use super::{action::PolicyAction, condition::PolicyCondition};
+
+/// A single policy rule with a name, composable condition, action, and priority.
+///
+/// # Priority Ordering
+///
+/// Rules are evaluated in ascending priority order. A rule with `priority: 1`
+/// is evaluated before a rule with `priority: 10`. If multiple rules match,
+/// all matching actions are collected and returned in priority order.
+///
+/// # Design Notes
+///
+/// - `PolicyRule` is the atomic building block of the policy engine
+/// - Rules are designed to be serializable from `.rigorix/policy.toml`
+/// - The priority field allows users to control rule ordering
+/// - No implicit rule ordering — priority is always explicit
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PolicyRule {
+    /// Unique human-readable name for this rule (e.g., "closeout-completed-lane").
+    pub name: String,
+
+    /// The composable condition that determines if this rule matches.
+    ///
+    /// Evaluated against a `LaneContext`. May be a single condition or a
+    /// tree of And/Or conditions.
+    pub condition: PolicyCondition,
+
+    /// The action to take when the condition matches.
+    ///
+    /// Supports singular actions (e.g., `MergeToDev`, `CloseoutLane`) or
+    /// compound actions via `Chain(Vec<PolicyAction>)`.
+    pub action: PolicyAction,
+
+    /// Evaluation priority. Lower numbers = higher priority.
+    ///
+    /// Must be a non-negative integer. Rules with priority 0 are evaluated
+    /// first. Typical ranges: 1-10 (critical), 11-50 (normal), 51-100 (fallback).
+    pub priority: u32,
+}
+
+impl PolicyRule {
+    /// Create a new PolicyRule.
+    pub fn new(name: String, condition: PolicyCondition, action: PolicyAction, priority: u32) -> Self {
+        Self {
+            name,
+            condition,
+            action,
+            priority,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy_engine::domain::{PolicyAction, PolicyCondition};
+
+    #[test]
+    fn test_policy_rule_creation() {
+        let rule = PolicyRule::new(
+            "closeout-completed-lane".to_string(),
+            PolicyCondition::LaneCompleted,
+            PolicyAction::CloseoutLane,
+            10,
+        );
+        assert_eq!(rule.name, "closeout-completed-lane");
+        assert_eq!(rule.priority, 10);
+    }
+
+    #[test]
+    fn test_policy_rule_serde_roundtrip() {
+        let rule = PolicyRule::new(
+            "test-rule".to_string(),
+            PolicyCondition::GreenAt { level: 3 },
+            PolicyAction::Notify {
+                channel: "discord".to_string(),
+            },
+            5,
+        );
+        let json = serde_json::to_string(&rule).unwrap();
+        let deserialized: PolicyRule = serde_json::from_str(&json).unwrap();
+        assert_eq!(rule, deserialized);
+    }
+}

--- a/engine/src/policy_engine/infrastructure/mod.rs
+++ b/engine/src/policy_engine/infrastructure/mod.rs
@@ -1,0 +1,16 @@
+//! Infrastructure layer interfaces for the Policy Engine bounded context.
+//!
+//! @canonical .pi/architecture/modules/policy-engine.md
+//! Implements: Contract Freeze — repository interfaces
+//! Issue: issue-contract-freeze
+//!
+//! This module defines repository interfaces that abstract data access
+//! behind traits. Implementations are provided by the concrete
+//! infrastructure module.
+//!
+//! The primary repository is `PolicyRepository` for loading and persisting
+//! policy rules from various sources (file, database, remote API).
+
+pub mod repository;
+
+pub use repository::*;

--- a/engine/src/policy_engine/infrastructure/repository/mod.rs
+++ b/engine/src/policy_engine/infrastructure/repository/mod.rs
@@ -1,0 +1,59 @@
+//! Repository interfaces for the Policy Engine bounded context.
+//!
+//! @canonical .pi/architecture/modules/policy-engine.md
+//! Implements: Contract Freeze — PolicyRepository trait
+//! Issue: issue-contract-freeze
+//!
+//! Policy rules can be loaded from multiple sources: configuration files
+//! (`.rigorix/policy.toml`), runtime overrides, or external policy stores.
+//! The repository interface abstracts all persistence concerns.
+//!
+//! # Contract (Frozen)
+//! - All repository methods are async
+//! - All methods return domain error types
+//! - No framework-specific annotations on trait definitions
+
+use async_trait::async_trait;
+
+use crate::policy_engine::domain::{PolicyConfig, PolicyEngineError, PolicyRule};
+
+/// Repository for loading and persisting policy rules.
+///
+/// The default implementation loads from `.rigorix/policy.toml`.
+/// Custom implementations may load from a database, remote API, or
+/// file-based policy store.
+#[async_trait]
+pub trait PolicyRepository: Send + Sync {
+    /// Load policy configuration from the configured source.
+    ///
+    /// Returns the full `PolicyConfig` including all rule definitions.
+    /// If no configuration is found, returns the default configuration
+    /// with sensible built-in rules.
+    async fn load_config(&self) -> Result<PolicyConfig, PolicyEngineError>;
+
+    /// Save policy configuration to the configured source.
+    ///
+    /// Persists any runtime modifications to rules.
+    /// If persistence is not supported, returns `Ok(())` without error.
+    async fn save_config(&self, config: &PolicyConfig) -> Result<(), PolicyEngineError>;
+
+    /// Load a specific rule by name.
+    ///
+    /// Returns `None` if no rule with the given name exists.
+    async fn load_rule(&self, name: &str) -> Result<Option<PolicyRule>, PolicyEngineError>;
+
+    /// Save or update a specific rule.
+    ///
+    /// If a rule with the same name already exists, it is replaced.
+    async fn save_rule(&self, rule: &PolicyRule) -> Result<(), PolicyEngineError>;
+
+    /// Delete a specific rule by name.
+    ///
+    /// Returns `Ok(())` even if the rule didn't exist.
+    async fn delete_rule(&self, name: &str) -> Result<(), PolicyEngineError>;
+
+    /// List all available rule names in the repository.
+    ///
+    /// Returns an empty list if no rules are configured.
+    async fn list_rules(&self) -> Result<Vec<String>, PolicyEngineError>;
+}

--- a/engine/src/policy_engine/interfaces/http/mod.rs
+++ b/engine/src/policy_engine/interfaces/http/mod.rs
@@ -1,0 +1,331 @@
+//! HTTP API contracts for Policy Engine endpoints.
+//!
+//! @canonical .pi/architecture/modules/policy-engine.md
+//! Implements: Contract Freeze — HTTP endpoint contracts and error formats
+//! Issue: issue-contract-freeze
+//!
+//! Defines endpoint paths, methods, request/response schemas, and error
+//! response formats. These contracts are framework-agnostic — they describe
+//! the API surface that any HTTP server implementation must satisfy.
+//!
+//! # Contract (Frozen)
+//! - All endpoints documented with method, path, request, and response types
+//! - Error responses follow a unified format
+//! - No framework-specific annotations (axum/actix/warp annotations added by implementation)
+
+use serde::{Deserialize, Serialize};
+
+use crate::policy_engine::application::dto::{
+    ActionOutput, EvaluatePolicyOutput, GetActiveRulesOutput, RuleSummary,
+};
+use crate::policy_engine::domain::PolicyConfig;
+
+// ---------------------------------------------------------------------------
+// API Base Path
+// ---------------------------------------------------------------------------
+
+/// All policy engine endpoints are served under this base path.
+pub const API_BASE_PATH: &str = "/api/v1/policy";
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/policy/evaluate
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/policy/evaluate
+///
+/// Evaluate all loaded policy rules against a LaneContext.
+/// Returns the flat list of actions in priority order.
+///
+/// **Request:** `EvaluatePolicyRequest`
+/// **Response:** `200 OK` with `EvaluatePolicyResponse`
+pub const EVALUATE_PATH: &str = "/api/v1/policy/evaluate";
+pub const EVALUATE_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/policy/evaluate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvaluatePolicyRequest {
+    /// The lane ID being evaluated.
+    pub lane_id: String,
+
+    /// The quality level achieved (0-5).
+    pub green_level: u8,
+
+    /// Seconds since the last commit on the branch.
+    pub branch_freshness_secs: u64,
+
+    /// Whether the lane is blocked at startup.
+    pub startup_blocked: bool,
+
+    /// Whether the lane is externally blocked.
+    pub external_blocked: bool,
+
+    /// Review status: "pending", "approved", or "rejected".
+    pub review_status: String,
+
+    /// Diff scope: "full" or "scoped".
+    pub diff_scope: String,
+
+    /// Whether lane execution completed.
+    pub completed: bool,
+
+    /// Whether the lane has been reconciled.
+    pub reconciled: bool,
+
+    /// Optional rule name filter.
+    pub rule_filter: Option<Vec<String>>,
+}
+
+/// Response body for POST /api/v1/policy/evaluate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvaluatePolicyResponse {
+    /// The lane ID that was evaluated.
+    pub lane_id: String,
+
+    /// Flat list of actions from all matching rules, in priority order.
+    pub actions: Vec<ActionOutput>,
+
+    /// Number of matching rules.
+    pub matching_rule_count: u32,
+
+    /// Total number of rules evaluated.
+    pub rules_evaluated: u32,
+
+    /// Whether any rules matched.
+    pub matched: bool,
+}
+
+impl From<EvaluatePolicyOutput> for EvaluatePolicyResponse {
+    fn from(output: EvaluatePolicyOutput) -> Self {
+        Self {
+            lane_id: output.lane_id,
+            actions: output.actions,
+            matching_rule_count: output.matching_rule_count,
+            rules_evaluated: output.rules_evaluated,
+            matched: output.matched,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: GET /api/v1/policy/rules
+// ---------------------------------------------------------------------------
+
+/// GET /api/v1/policy/rules
+///
+/// Get all currently loaded (active) policy rules.
+///
+/// **Response:** `200 OK` with `GetRulesResponse`
+pub const RULES_PATH: &str = "/api/v1/policy/rules";
+pub const RULES_METHOD: &str = "GET";
+
+/// Response body for GET /api/v1/policy/rules.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetRulesResponse {
+    pub rules: Vec<RuleSummary>,
+    pub total_count: u32,
+}
+
+impl From<GetActiveRulesOutput> for GetRulesResponse {
+    fn from(output: GetActiveRulesOutput) -> Self {
+        Self {
+            rules: output.rules,
+            total_count: output.total_count,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/policy/rules
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/policy/rules
+///
+/// Load/replace policy rules from a configuration payload.
+///
+/// **Request:** `LoadRulesRequest`
+/// **Response:** `200 OK` with `LoadRulesResponse`
+pub const LOAD_RULES_PATH: &str = "/api/v1/policy/rules";
+pub const LOAD_RULES_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/policy/rules.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoadRulesRequest {
+    /// The policy configuration in PolicyConfig format.
+    pub config: PolicyConfig,
+
+    /// Whether to replace all existing rules. If false, merges by name.
+    #[serde(default = "default_replace_all")]
+    pub replace_all: bool,
+}
+
+fn default_replace_all() -> bool {
+    true
+}
+
+/// Response body for POST /api/v1/policy/rules.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoadRulesResponse {
+    pub loaded_count: u32,
+    pub replaced_count: u32,
+    pub rule_names: Vec<String>,
+    pub success: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/policy/reload
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/policy/reload
+///
+/// Reload policy rules from the last loaded source.
+///
+/// **Response:** `200 OK` with `ReloadRulesResponse`
+pub const RELOAD_PATH: &str = "/api/v1/policy/reload";
+pub const RELOAD_METHOD: &str = "POST";
+
+/// Response body for POST /api/v1/policy/reload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReloadRulesResponse {
+    pub success: bool,
+    pub rule_count: u32,
+    pub source: String,
+    pub error: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Unified Error Response Format
+// ---------------------------------------------------------------------------
+
+/// Standard error response for all Policy Engine API endpoints.
+///
+/// All 4xx/5xx responses use this format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiErrorResponse {
+    /// HTTP status code.
+    pub status: u16,
+    /// Machine-readable error code.
+    pub code: String,
+    /// Human-readable error message.
+    pub message: String,
+    /// Detailed error context (optional).
+    pub details: Option<serde_json::Value>,
+    /// Request ID for tracing (if available).
+    pub request_id: Option<String>,
+}
+
+/// Standardized error codes for Policy Engine API.
+pub mod error_codes {
+    /// No matching rules found for the given context.
+    pub const NO_MATCHING_RULE: &str = "POLICY_NO_MATCHING_RULE";
+    /// Invalid policy configuration.
+    pub const INVALID_CONFIGURATION: &str = "POLICY_INVALID_CONFIGURATION";
+    /// Policy rule not found.
+    pub const RULE_NOT_FOUND: &str = "POLICY_RULE_NOT_FOUND";
+    /// Internal server error.
+    pub const INTERNAL_ERROR: &str = "POLICY_INTERNAL_ERROR";
+}
+
+/// HTTP status code mappings for Policy Engine errors.
+pub mod status_codes {
+    pub const NO_MATCHING_RULE: u16 = 404;
+    pub const INVALID_CONFIGURATION: u16 = 400;
+    pub const RULE_NOT_FOUND: u16 = 404;
+    pub const INTERNAL_ERROR: u16 = 500;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy_engine::domain::{
+        DiffScope, LaneBlocker, LaneContext, PolicyAction, PolicyCondition, PolicyConfig,
+        ReviewStatus,
+    };
+    use crate::policy_engine::domain::config::RuleDefinition;
+
+    #[test]
+    fn test_evaluate_policy_request_serde() {
+        let request = EvaluatePolicyRequest {
+            lane_id: "lane-1".to_string(),
+            green_level: 3,
+            branch_freshness_secs: 100,
+            startup_blocked: false,
+            external_blocked: false,
+            review_status: "pending".to_string(),
+            diff_scope: "scoped".to_string(),
+            completed: true,
+            reconciled: false,
+            rule_filter: None,
+        };
+        let json = serde_json::to_string(&request).unwrap();
+        let deserialized: EvaluatePolicyRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.lane_id, "lane-1");
+        assert!(deserialized.completed);
+    }
+
+    #[test]
+    fn test_evaluate_policy_response_serde() {
+        let response = EvaluatePolicyResponse {
+            lane_id: "lane-1".to_string(),
+            actions: vec![
+                ActionOutput {
+                    rule_name: "closeout".to_string(),
+                    priority: 10,
+                    action: PolicyAction::CloseoutLane,
+                },
+            ],
+            matching_rule_count: 1,
+            rules_evaluated: 5,
+            matched: true,
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        let deserialized: EvaluatePolicyResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.lane_id, "lane-1");
+    }
+
+    #[test]
+    fn test_get_rules_response_serde() {
+        let response = GetRulesResponse {
+            rules: vec![],
+            total_count: 0,
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        let deserialized: GetRulesResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.total_count, 0);
+    }
+
+    #[test]
+    fn test_load_rules_request_serde() {
+        let request = LoadRulesRequest {
+            config: PolicyConfig::single(RuleDefinition {
+                name: "test".to_string(),
+                condition: PolicyCondition::LaneCompleted,
+                action: PolicyAction::CloseoutLane,
+                priority: 10,
+            }),
+            replace_all: true,
+        };
+        let json = serde_json::to_string(&request).unwrap();
+        let deserialized: LoadRulesRequest = serde_json::from_str(&json).unwrap();
+        assert!(deserialized.replace_all);
+        assert_eq!(deserialized.config.rules.len(), 1);
+    }
+
+    #[test]
+    fn test_api_error_response() {
+        let error = ApiErrorResponse {
+            status: 404,
+            code: error_codes::NO_MATCHING_RULE.to_string(),
+            message: "No matching rules for lane-1".to_string(),
+            details: None,
+            request_id: Some("req-123".to_string()),
+        };
+        let json = serde_json::to_string(&error).unwrap();
+        let deserialized: ApiErrorResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.status, 404);
+    }
+
+    #[test]
+    fn test_empty_rule_filter_default() {
+        assert!(default_replace_all());
+    }
+}

--- a/engine/src/policy_engine/interfaces/mod.rs
+++ b/engine/src/policy_engine/interfaces/mod.rs
@@ -1,0 +1,20 @@
+//! Interface adapters for the Policy Engine bounded context.
+//!
+//! @canonical .pi/architecture/modules/policy-engine.md
+//! Implements: Contract Freeze — HTTP API endpoint contracts
+//! Issue: issue-contract-freeze
+//!
+//! This module defines API contracts (HTTP, CLI, etc.) that external
+//! actors use to interact with the policy engine system.
+//!
+//! # Policy Engine API Context
+//!
+//! Policy evaluation is primarily triggered by the orchestrator:
+//! 1. After execution completes, the orchestrator builds a LaneContext
+//! 2. The orchestrator calls `PolicyEngineService::evaluate()`
+//! 3. The orchestrator executes the resulting action list
+//!
+//! The HTTP API provides external monitoring and management capabilities
+//! (e.g., querying active rules, triggering evaluations, managing policies).
+
+pub mod http;

--- a/engine/src/policy_engine/mod.rs
+++ b/engine/src/policy_engine/mod.rs
@@ -1,0 +1,58 @@
+//! Policy Engine bounded context.
+//!
+//! @canonical .pi/architecture/modules/policy-engine.md
+//! Implements: Contract Freeze — policy-engine module root
+//! Issue: issue-contract-freeze
+//!
+//! Evaluates declarative PolicyRules against a typed execution context
+//! (LaneContext) and produces a flat list of actions in priority order.
+//! Rules combine boolean conditions (And/Or) over observable state —
+//! quality level, branch freshness, review status, completion state —
+//! and map them to executable actions like merge, closeout, escalate,
+//! or reconcile.
+//!
+//! This replaces hardcoded if-else enforcement chains with user-configurable
+//! policy rules that can be loaded from `.rigorix/policy.toml`.
+//!
+//! # Architecture
+//!
+//! ```text
+//! policy_engine/
+//! ├── domain/           # Domain entities: PolicyRule, PolicyCondition, PolicyAction,
+//! │   │                     LaneContext, PolicyConfig, PolicyEngineError, PolicyEvent
+//! │   ├── rule.rs       # PolicyRule — named rule with condition, action, priority
+//! │   ├── condition.rs  # PolicyCondition — composable And/Or over observable state
+//! │   ├── action.rs     # PolicyAction — Merge, Closeout, Escalate, Block, etc.
+//! │   ├── context.rs    # LaneContext — typed execution state snapshot
+//! │   ├── config.rs     # PolicyConfig — user-configurable rule definitions (TOML)
+//! │   ├── error.rs      # PolicyEngineError enum
+//! │   └── event/        # PolicyEvent payload schemas
+//! ├── application/      # Service traits, DTOs, factory interfaces
+//! │   ├── engine.rs     # PolicyEngineService trait
+//! │   ├── factory.rs    # PolicyEngineFactory interface
+//! │   └── dto/          # Input/Output DTOs with validation
+//! ├── infrastructure/   # Repository interfaces
+//! │   └── repository/   # PolicyRepository trait
+//! └── interfaces/       # API contracts
+//!     └── http/         # REST endpoint contracts
+//! ```
+//!
+//! # Contract Freeze Notice
+//!
+//! ALL files in this module are frozen contracts.
+//! - No implementation changes without explicit contract change approval
+//! - Implementation PRs MUST reference these interfaces
+//! - DTO schemas serve as the canonical data contract
+//!
+//! # Related Components
+//!
+//! - `QualityGates` (in `crate::quality_gates`) provides `GreenAt` condition data
+//! - `ExecutionEngine` (in `crate::execution_engine`) provides completion state
+//! - `RiskGating` (in `crate::risk_gating`) provides blocker state
+//! - `EventSystem` (in `crate::event_system`) dispatches PolicyEvents
+//! - `Orchestrator` (in `crate::orchestrator`) evaluates policy after execution
+
+pub mod application;
+pub mod domain;
+pub mod infrastructure;
+pub mod interfaces;


### PR DESCRIPTION
## Summary

Freeze all public interfaces, contracts, and schemas for the policy-engine epic before implementation begins.

## What's Included

- **Domain layer**: PolicyRule, PolicyCondition, PolicyAction, LaneContext, PolicyConfig, PolicyEngineError, PolicyEvent
- **Application layer**: PolicyEngineService (async trait), PolicyEngineFactory, input/output DTOs
- **Infrastructure layer**: PolicyRepository trait
- **Interfaces/HTTP layer**: REST API contracts (4 endpoints under /api/v1/policy/)

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | All component interfaces defined | ✅ |
| 2 | Contracts reviewed and frozen | ✅ |
| 3 | DTO schemas documented | ✅ |
| 4 | Implementation depends on contracts | ✅ (no implementation) |

## Testing

- 57 unit tests added, all passing
- Build clean

Closes #470