### PR TITLE
feat: add policy-engine proofing scripts and architecture readiness docs (#476, #477)

### DIFF
--- a/engine/.pi/scripts/ci/check_policy-engine_contracts.sh
+++ b/engine/.pi/scripts/ci/check_policy-engine_contracts.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# ============================================================================
+# check_policy-engine_contracts.sh
+#
+# Validates that every contract interface from the policy-engine module has
+# a concrete implementation. Uses grep/find to detect trait definitions and
+# their implementing structs.
+#
+# Usage: bash .pi/scripts/ci/check_policy-engine_contracts.sh [--help]
+#
+# Exit codes: 0 = all contracts implemented, 1 = violations found
+# ============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PI_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SRC_DIR="$(cd "$PI_DIR/.." && pwd)/engine/src"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+log_pass() { echo "  ✓ PASS: $1"; ((PASS++)); }
+log_fail() { echo "  ✗ FAIL: $1"; ERRORS+=("$1"); ((FAIL++)); }
+
+# Determine source directory
+if [ ! -d "$SRC_DIR" ]; then
+    SRC_DIR="$(cd "$PI_DIR/.." && pwd)/src"
+fi
+if [ ! -d "$SRC_DIR" ]; then
+    log_fail "Source directory not found"
+    exit 1
+fi
+
+echo ""
+echo "═══ Policy Engine Contract Implementation Check ═══"
+echo "Source: $SRC_DIR/policy_engine"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Check 1: Module Structure — all layers exist
+# ---------------------------------------------------------------------------
+echo "--- Module Structure ---"
+
+for layer in domain application infrastructure interfaces; do
+    if [ -f "$SRC_DIR/policy_engine/$layer/mod.rs" ]; then
+        log_pass "policy_engine/$layer/ exists"
+    else
+        log_fail "policy_engine/$layer/ missing"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Check 2: Domain Entities
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Domain Entities ---"
+
+if grep -q 'pub struct PolicyRule' "$SRC_DIR/policy_engine/domain/rule.rs" 2>/dev/null; then
+    log_pass "PolicyRule struct exists"
+else
+    log_fail "PolicyRule struct not found"
+fi
+
+if grep -q 'pub enum PolicyCondition' "$SRC_DIR/policy_engine/domain/condition.rs" 2>/dev/null; then
+    log_pass "PolicyCondition enum exists"
+else
+    log_fail "PolicyCondition enum not found"
+fi
+
+if grep -q 'pub enum PolicyAction' "$SRC_DIR/policy_engine/domain/action.rs" 2>/dev/null; then
+    log_pass "PolicyAction enum exists"
+else
+    log_fail "PolicyAction enum not found"
+fi
+
+if grep -q 'pub enum ReconcileReason' "$SRC_DIR/policy_engine/domain/action.rs" 2>/dev/null; then
+    log_pass "ReconcileReason enum exists"
+else
+    log_fail "ReconcileReason enum not found"
+fi
+
+if grep -q 'pub struct LaneContext' "$SRC_DIR/policy_engine/domain/context.rs" 2>/dev/null; then
+    log_pass "LaneContext struct exists"
+else
+    log_fail "LaneContext struct not found"
+fi
+
+for entity in LaneBlocker ReviewStatus DiffScope; do
+    if grep -q "pub enum $entity" "$SRC_DIR/policy_engine/domain/context.rs" 2>/dev/null; then
+        log_pass "$entity enum exists"
+    else
+        log_fail "$entity enum not found"
+    fi
+done
+
+if grep -q 'pub struct PolicyConfig' "$SRC_DIR/policy_engine/domain/config.rs" 2>/dev/null; then
+    log_pass "PolicyConfig struct exists"
+else
+    log_fail "PolicyConfig struct not found"
+fi
+
+if grep -q 'pub struct RuleDefinition' "$SRC_DIR/policy_engine/domain/config.rs" 2>/dev/null; then
+    log_pass "RuleDefinition struct exists"
+else
+    log_fail "RuleDefinition struct not found"
+fi
+
+if grep -q 'pub enum PolicyEngineError' "$SRC_DIR/policy_engine/domain/error.rs" 2>/dev/null; then
+    log_pass "PolicyEngineError enum exists"
+else
+    log_fail "PolicyEngineError enum not found"
+fi
+
+if grep -q 'pub enum PolicyEvent' "$SRC_DIR/policy_engine/domain/event/mod.rs" 2>/dev/null; then
+    log_pass "PolicyEvent enum exists"
+else
+    log_fail "PolicyEvent enum not found"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 3: Domain logic methods exist
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Domain Logic ---"
+
+if grep -q 'fn matches' "$SRC_DIR/policy_engine/domain/condition.rs" 2>/dev/null; then
+    log_pass "PolicyCondition::matches() exists"
+else
+    log_fail "PolicyCondition::matches() not found"
+fi
+
+if grep -q 'fn flatten_into' "$SRC_DIR/policy_engine/domain/action.rs" 2>/dev/null; then
+    log_pass "PolicyAction::flatten_into() exists"
+else
+    log_fail "PolicyAction::flatten_into() not found"
+fi
+
+if grep -q 'fn into_rules' "$SRC_DIR/policy_engine/domain/config.rs" 2>/dev/null; then
+    log_pass "PolicyConfig::into_rules() exists"
+else
+    log_fail "PolicyConfig::into_rules() not found"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 4: Service Contracts
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Service Contracts ---"
+
+if grep -q 'pub trait PolicyEngineService' "$SRC_DIR/policy_engine/application/engine.rs" 2>/dev/null; then
+    if grep -q 'impl.*PolicyEngineService' "$SRC_DIR/policy_engine/application/engine_impl.rs" 2>/dev/null; then
+        log_pass "PolicyEngineService → PolicyEngineServiceImpl"
+    else
+        log_fail "PolicyEngineService trait has no implementation"
+    fi
+else
+    log_fail "PolicyEngineService trait not found"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 5: Factory Contracts
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Factory Contracts ---"
+
+if grep -q 'pub trait PolicyEngineFactory' "$SRC_DIR/policy_engine/application/factory.rs" 2>/dev/null; then
+    if grep -q 'impl.*PolicyEngineFactory' "$SRC_DIR/policy_engine/application/factory_impl.rs" 2>/dev/null; then
+        log_pass "PolicyEngineFactory → PolicyEngineFactoryImpl"
+    else
+        log_fail "PolicyEngineFactory trait has no implementation"
+    fi
+else
+    log_fail "PolicyEngineFactory trait not found"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 6: DTO schemas exist
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- DTO Schemas ---"
+
+DTO_COUNT=$(grep -c 'pub struct.*\(Input\|Output\)' "$SRC_DIR/policy_engine/application/dto/mod.rs" 2>/dev/null || echo 0)
+if [ "$DTO_COUNT" -ge 4 ]; then
+    log_pass "DTO schemas exist ($DTO_COUNT input/output DTOs)"
+else
+    log_fail "Fewer than 4 DTO schemas found ($DTO_COUNT)"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 7: API contracts exist
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- API Contracts ---"
+
+if grep -q 'pub const.*_PATH' "$SRC_DIR/policy_engine/interfaces/http/mod.rs" 2>/dev/null; then
+    ENDPOINT_COUNT=$(grep -c 'pub const.*_PATH' "$SRC_DIR/policy_engine/interfaces/http/mod.rs" || echo 0)
+    log_pass "API endpoint contracts exist ($ENDPOINT_COUNT endpoints)"
+else
+    log_fail "No API endpoint contracts found"
+fi
+
+for response_type in EvaluatePolicyResponse GetRulesResponse LoadRulesResponse ReloadRulesResponse; do
+    if grep -q "pub struct $response_type" "$SRC_DIR/policy_engine/interfaces/http/mod.rs" 2>/dev/null; then
+        log_pass "$response_type struct exists"
+    else
+        log_fail "$response_type struct not found"
+    fi
+done
+
+if grep -q 'pub struct ApiErrorResponse' "$SRC_DIR/policy_engine/interfaces/http/mod.rs" 2>/dev/null; then
+    log_pass "Error response format defined"
+else
+    log_fail "Error response format not found"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 8: Repository contracts
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Repository Contracts ---"
+
+if grep -q 'pub trait PolicyRepository' "$SRC_DIR/policy_engine/infrastructure/repository/mod.rs" 2>/dev/null; then
+    if grep -q 'impl.*PolicyRepository' "$SRC_DIR/policy_engine/infrastructure/default_policy_repository.rs" 2>/dev/null; then
+        log_pass "PolicyRepository → DefaultPolicyRepository"
+    else
+        log_fail "PolicyRepository trait has no implementation"
+    fi
+else
+    log_fail "PolicyRepository trait not found"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 9: Event schemas
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Event Schemas ---"
+
+for variant in RuleMatched ActionsDispatched ConfigLoaded EvaluationPerformed; do
+    if grep -q "$variant" "$SRC_DIR/policy_engine/domain/event/mod.rs" 2>/dev/null; then
+        log_pass "PolicyEvent::$variant variant exists"
+    else
+        log_fail "PolicyEvent::$variant variant not found"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "═══ Summary ═══"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo ""
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo "FAILURES:"
+    for err in "${ERRORS[@]}"; do
+        echo "  - $err"
+    done
+    echo ""
+    echo "Some policy-engine contracts are missing implementations."
+    exit 1
+fi
+
+echo "All policy-engine contracts have implementations."
+exit 0

--- a/engine/.pi/scripts/ci/check_policy-engine_coverage.sh
+++ b/engine/.pi/scripts/ci/check_policy-engine_coverage.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# ============================================================================
+# check_policy-engine_coverage.sh
+#
+# Validates that the policy-engine module has adequate test coverage.
+# Checks that test files exist for each layer and module.
+#
+# Usage: bash .pi/scripts/ci/check_policy-engine_coverage.sh [--help]
+#
+# Exit codes: 0 = coverage adequate, 1 = insufficient coverage
+# ============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PI_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SRC_DIR="$(cd "$PI_DIR/.." && pwd)/engine/src"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+log_pass() { echo "  ✓ PASS: $1"; ((PASS++)); }
+log_fail() { echo "  ✗ FAIL: $1"; ERRORS+=("$1"); ((FAIL++)); }
+
+# Determine source directory
+if [ ! -d "$SRC_DIR" ]; then
+    SRC_DIR="$(cd "$PI_DIR/.." && pwd)/src"
+fi
+if [ ! -d "$SRC_DIR" ]; then
+    log_fail "Source directory not found"
+    exit 1
+fi
+
+echo ""
+echo "═══ Policy Engine Coverage Check ═══"
+echo "Source: $SRC_DIR/policy_engine"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Check 1: Each domain file has tests
+# ---------------------------------------------------------------------------
+echo "--- Domain Tests ---"
+
+for file in rule condition action context config error; do
+    FILE_PATH="$SRC_DIR/policy_engine/domain/$file.rs"
+    if [ -f "$FILE_PATH" ]; then
+        TEST_COUNT=$(grep -c '#\[test\]' "$FILE_PATH" 2>/dev/null || echo 0)
+        if [ "$TEST_COUNT" -ge 1 ]; then
+            log_pass "$file.rs has $TEST_COUNT tests"
+        else
+            log_fail "$file.rs has no tests"
+        fi
+    else
+        log_fail "$file.rs not found"
+    fi
+done
+
+if [ -f "$SRC_DIR/policy_engine/domain/event/mod.rs" ]; then
+    TEST_COUNT=$(grep -c '#\[test\]' "$SRC_DIR/policy_engine/domain/event/mod.rs" 2>/dev/null || echo 0)
+    if [ "$TEST_COUNT" -ge 1 ]; then
+        log_pass "event/mod.rs has $TEST_COUNT tests"
+    else
+        log_fail "event/mod.rs has no tests"
+    fi
+else
+    log_fail "event/mod.rs not found"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 2: Application layer tests
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Application Tests ---"
+
+for file in engine_impl factory_impl; do
+    FILE_PATH="$SRC_DIR/policy_engine/application/$file.rs"
+    if [ -f "$FILE_PATH" ]; then
+        TEST_COUNT=$(grep -c '#\[test\]' "$FILE_PATH" 2>/dev/null)
+        TOKIO_COUNT=$(grep -c '#\[tokio::test\]' "$FILE_PATH" 2>/dev/null)
+        TOTAL=$((TEST_COUNT + TOKIO_COUNT))
+        if [ "$TOTAL" -ge 1 ]; then
+            log_pass "$file.rs has $TOTAL tests"
+        else
+            log_fail "$file.rs has no tests"
+        fi
+    else
+        log_fail "$file.rs not found"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Check 3: Infrastructure tests
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Infrastructure Tests ---"
+
+if [ -f "$SRC_DIR/policy_engine/infrastructure/default_policy_repository.rs" ]; then
+    TEST_COUNT=$(grep -c '#\[test\]' "$SRC_DIR/policy_engine/infrastructure/default_policy_repository.rs" 2>/dev/null)
+    TOKIO_COUNT=$(grep -c '#\[tokio::test\]' "$SRC_DIR/policy_engine/infrastructure/default_policy_repository.rs" 2>/dev/null)
+    TOTAL=$((TEST_COUNT + TOKIO_COUNT))
+    if [ "$TOTAL" -ge 1 ]; then
+        log_pass "default_policy_repository.rs has $TOTAL tests"
+    else
+        log_fail "default_policy_repository.rs has no tests"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Check 4: DTO tests
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- DTO Tests ---"
+
+if [ -f "$SRC_DIR/policy_engine/application/dto/mod.rs" ]; then
+    TEST_COUNT=$(grep -c '#\[test\]' "$SRC_DIR/policy_engine/application/dto/mod.rs" 2>/dev/null || echo 0)
+    if [ "$TEST_COUNT" -ge 1 ]; then
+        log_pass "dto/mod.rs has $TEST_COUNT tests"
+    else
+        log_fail "dto/mod.rs has no tests"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Check 5: HTTP contract tests
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- HTTP Contract Tests ---"
+
+if [ -f "$SRC_DIR/policy_engine/interfaces/http/mod.rs" ]; then
+    TEST_COUNT=$(grep -c '#\[test\]' "$SRC_DIR/policy_engine/interfaces/http/mod.rs" 2>/dev/null || echo 0)
+    if [ "$TEST_COUNT" -ge 1 ]; then
+        log_pass "http/mod.rs has $TEST_COUNT tests"
+    else
+        log_fail "http/mod.rs has no tests"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "═══ Summary ═══"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo ""
+
+TOTAL_TESTS=$(grep -r '#\[test\]\|#\[tokio::test\]' "$SRC_DIR/policy_engine/" 2>/dev/null | wc -l | tr -d ' ')
+echo "  Total tests in policy_engine module: $TOTAL_TESTS"
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    echo "FAILURES:"
+    for err in "${ERRORS[@]}"; do
+        echo "  - $err"
+    done
+    echo ""
+    echo "Coverage inadequate."
+    exit 1
+fi
+
+echo ""
+echo "Coverage adequate."
+exit 0

--- a/engine/docs/dr-plan-policy-engine.md
+++ b/engine/docs/dr-plan-policy-engine.md
@@ -1,0 +1,110 @@
+# Disaster Recovery Plan: Policy Engine
+
+## Overview
+
+The Policy Engine is a stateless evaluation component with in-memory rule storage. Rules are loaded from optional configuration files (`.rigorix/policy.toml`) or from programmatic defaults. No persistent state is maintained — full recovery is achieved by reloading rules.
+
+## RTO/RPO Targets
+
+| Metric | Target | Notes |
+|--------|--------|-------|
+| RTO (Recovery Time) | < 1 second | Stateless — just recreate engine and load rules |
+| RPO (Recovery Point) | N/A | No mutable state to lose |
+
+## Failure Scenarios
+
+### Scenario 1: Corrupted Configuration File
+
+**Impact**: Rules fail to load, engine falls back to defaults.
+
+**Detection**: 
+- `PolicyRepository::load_config()` returns `DeserializationError`
+- Error logged with file path and parse error details
+
+**Recovery**:
+1. Check `.rigorix/policy.toml` for syntax errors
+2. Fix the TOML syntax
+3. Call `PolicyEngineService::reload_rules()` or recreate the engine
+
+**Prevention**:
+- Validate TOML before saving (TOML parser catches issues)
+- Keep a backup of working config
+
+### Scenario 2: Missing Configuration File
+
+**Impact**: No user-defined rules loaded. Default rules used.
+
+**Detection**:
+- `DefaultPolicyRepository::load_config()` returns `InvalidConfiguration` with "file not found"
+- Factory falls back to `create_default()` if configured
+
+**Recovery**:
+1. Create `.rigorix/policy.toml` with desired rules
+2. Load rules via `load_rules()` or `create_with_repository()`
+
+**Prevention**:
+- The `.rigorix/policy.toml` is optional — no recovery action needed if defaults are acceptable
+
+### Scenario 3: Engine In-Memory State Corruption
+
+**Impact**: Rules are lost or corrupted in memory.
+
+**Detection**:
+- `evaluate()` returns unexpected results
+- `rule_count()` returns 0 unexpectedly
+
+**Recovery**:
+1. Call `load_rules()` to reload from source
+2. If source is unavailable, recreate engine via `create_default()`
+
+**Prevention**:
+- Engine uses `RwLock` for thread-safe access
+- Immutable `PolicyRule` struct prevents mutation after loading
+
+### Scenario 4: Integration Failure (Quality Gates / Risk Gating Down)
+
+**Impact**: Conditions that depend on external state (`GreenAt`, `StartupBlocked`) may fail.
+
+**Detection**:
+- `PolicyCondition::matches()` returns unexpected results
+- No panic — condition gracefully evaluates based on available context
+
+**Recovery**:
+1. Restore dependent service (Quality Gates, Risk Gating)
+2. Re-evaluate with updated `LaneContext`
+3. The engine itself is unaffected — only the context data is incomplete
+
+**Prevention**:
+- LaneContext is provided by the orchestrator as a complete snapshot
+- Context is immutable once constructed
+
+## Backup Strategy
+
+| Asset | Backup Method | Frequency | Retention |
+|-------|--------------|-----------|-----------|
+| `.rigorix/policy.toml` | Regular file backup (git) | Per commit | Full git history |
+
+## Restore Procedure
+
+1. **Restore configuration file** from git: `git checkout <commit> -- .rigorix/policy.toml`
+2. **Recreate PolicyEngine** with restored config:
+   ```
+   let repo = DefaultPolicyRepository::new(path);
+   let config = repo.load_config().await?;
+   let factory = PolicyEngineFactoryImpl::new();
+   let engine = factory.create_from_config(config).await?;
+   ```
+3. **Verify** engine has expected rules: `engine.rule_count()`
+4. **Resume** normal operation — engine is ready immediately
+
+## Failover
+
+No failover required — the Policy Engine is stateless and can be recreated on any node.
+
+## DR Testing Schedule
+
+| Test | Frequency | Success Criteria |
+|-----|-----------|-----------------|
+| Missing config recovery | Per release | Default rules load successfully |
+| Config restore from git | Per release | Rules match git content |
+| Engine recreation | Per CI run | `create_default()` returns engine with 4 rules |

--- a/engine/docs/runbook-policy-engine.md
+++ b/engine/docs/runbook-policy-engine.md
@@ -1,0 +1,108 @@
+# Policy Engine Runbook
+
+## Overview
+
+The Policy Engine evaluates declarative `PolicyRule`s against a typed execution context (`LaneContext`) and produces a flat list of actions in priority order. It replaces hardcoded if-else enforcement chains with user-configurable rules loaded from `.rigorix/policy.toml`.
+
+## Architecture
+
+```
+Config (.rigorix/policy.toml)
+       │
+       ▼
+PolicyRepository (load_config)
+       │
+       ▼
+PolicyEngineFactory (create_from_config)
+       │
+       ▼
+PolicyEngineService (evaluate)
+       │
+       ▼
+Orchestrator (executes actions)
+```
+
+## Startup Sequence
+
+1. **Configuration Loading**: On startup, the `PolicyEngineFactoryImpl` loads rules from:
+   - `PolicyConfig` (programmatic) — via `create_from_config()`
+   - `DefaultPolicyRepository` (file-based) — via `create_with_repository()`
+   - Default rules — via `create_default()` (4 built-in rules)
+
+2. **Initialization**: The factory returns a `PolicyEngineServiceImpl` with rules loaded in memory, sorted by priority.
+
+3. **Readiness**: The engine is ready immediately after construction. `has_rules()` returns `true` once rules are loaded.
+
+## Common Operations
+
+### Rule Evaluation
+```
+PolicyEngineService::evaluate(EvaluatePolicyInput {
+    context: LaneContext { ... },
+    rule_filter: None,  // or specific rule names
+})
+```
+Returns `EvaluatePolicyOutput` with matched actions in priority order.
+
+### Rule Loading
+```
+PolicyEngineService::load_rules(LoadRulesInput {
+    config: PolicyConfig { rules: [...] },
+    replace_all: true,  // replaces all existing rules
+})
+```
+
+### Rule Querying
+```
+PolicyEngineService::get_active_rules()  // returns all rules sorted by priority
+PolicyEngineService::rule_count()        // returns number of loaded rules
+```
+
+## Configuration
+
+### Default Configuration (`create_default()`)
+| Rule Name | Condition | Action | Priority |
+|-----------|-----------|--------|----------|
+| closeout-completed-lane | LaneCompleted AND GreenAt(3) | CloseoutLane | 10 |
+| cleanup-completed-session | LaneCompleted | CleanupSession | 20 |
+| reconcile-empty-diff | LaneCompleted AND ScopedDiff | Reconcile(EmptyDiff) | 15 |
+| escalate-startup-blocked | StartupBlocked | Escalate("blocked") | 5 |
+
+### User Configuration (`.rigorix/policy.toml`)
+```toml
+[[rules]]
+name = "custom-rule"
+condition = { type = "lane_completed" }
+action = { type = "closeout_lane" }
+priority = 10
+```
+
+## Common Failure Modes
+
+| Failure | Symptom | Recovery |
+|---------|---------|----------|
+| No rules loaded | `evaluate()` returns empty actions | Call `load_rules()` or recreate engine via factory |
+| Invalid TOML config | `RepositoryError` / `DeserializationError` | Fix `.rigorix/policy.toml` syntax |
+| File not found | `InvalidConfiguration` | Use defaults — optional config |
+| Empty config | Factory returns error | Use `create_default()` instead |
+| Lock contention | `InvalidState` (lock error) | Engine uses RwLock — should not occur in single-threaded orchestrator |
+
+## Dependencies
+
+- **Quality Gates**: `GreenAt` condition reads quality level from context
+- **Execution Engine**: Provides completion state for `LaneCompleted`
+- **Risk Gating**: Provides blocker state for `StartupBlocked`
+- **Event System**: Emits `PolicyEvent` on evaluation
+
+## Related Components
+
+- `Orchestrator` — calls `evaluate()` after execution, dispatches actions
+- `Enforcement` — enforces execution limits (resource budgets)
+- `Permission` — gates tool calls by permission mode
+
+## Graceful Shutdown
+
+The Policy Engine is stateless (rules are in-memory). On shutdown:
+1. No special cleanup needed
+2. Pending evaluations will be interrupted
+3. Rules are re-loaded from config on next startup


### PR DESCRIPTION
## Summary

Proofing scripts and architecture readiness documentation for the policy-engine module.

## What's Included

### Proofing (#476)
- `check_policy-engine_contracts.sh` — validates 33 contract checkpoints (entities, traits, implementations, DTOs, API, repository, events)
- `check_policy-engine_coverage.sh` — validates test coverage across all layers

### Architecture Readiness (#477)
- `docs/runbook-policy-engine.md` — startup sequence, common operations, failure modes, dependencies
- `docs/dr-plan-policy-engine.md` — failure scenarios, RTO/RPO, backup/restore, DR testing schedule

## Verification

- 33/33 contract checks pass
- 75 tests found across all layers
- Coverage check passes

Closes #476, #477