### PR TITLE
feat: add proofing and CI enforcement scripts for llm-step module

### DIFF
--- a/engine/.pi/.guardian-pipeline-state.json
+++ b/engine/.pi/.guardian-pipeline-state.json
@@ -50,7 +50,7 @@
       }
     }
   ],
-  "currentItemIndex": 3,
+  "currentItemIndex": 4,
   "currentStepIndex": 0,
   "status": "running",
   "retryCount": 0,
@@ -167,9 +167,45 @@
           "reason": ""
         }
       ]
+    },
+    {
+      "item": "issue-llmstepservice",
+      "status": "done",
+      "stepResults": [
+        {
+          "step": "implement",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "implement",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "validate",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "validate",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "create-mr",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "merge",
+          "status": "passed",
+          "reason": ""
+        }
+      ]
     }
   ],
   "mergeOnValid": true,
   "createdAt": "2026-06-19T18:13:39.446Z",
-  "updatedAt": "2026-06-19T18:35:17.962Z"
+  "updatedAt": "2026-06-19T18:39:01.129Z"
 }

--- a/engine/.pi/scripts/ci/check_llm-step_contracts.sh
+++ b/engine/.pi/scripts/ci/check_llm-step_contracts.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+# ============================================================================
+# check_llm-step_contracts.sh
+#
+# Validates that every contract interface from the llm-step module has a
+# concrete implementation. Uses grep/find to detect trait definitions and
+# their implementing structs.
+#
+# Usage: bash .pi/scripts/ci/check_llm-step_contracts.sh [--help]
+#
+# Exit codes: 0 = all contracts implemented, 1 = violations found
+# ============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PI_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Determine source directory
+if [ -d "$(cd "$PI_DIR/.." && pwd)/engine/src" ]; then
+    SRC_DIR="$(cd "$PI_DIR/.." && pwd)/engine/src"
+elif [ -d "$(cd "$PI_DIR/.." && pwd)/src" ]; then
+    SRC_DIR="$(cd "$PI_DIR/.." && pwd)/src"
+else
+    echo "ERROR: Source directory not found"
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+MODULE="llm_step"
+
+log_pass() { echo "  ✓ PASS: $1"; ((PASS++)); }
+log_fail() { echo "  ✗ FAIL: $1"; ERRORS+=("$1"); ((FAIL++)); }
+
+echo ""
+echo "═══ LLM-Step Contract Implementation Check ═══"
+echo "Source: $SRC_DIR/$MODULE"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Check 1: Service Contracts — LlmStepService
+# ---------------------------------------------------------------------------
+echo "--- Service Contracts ---"
+
+if grep -q 'pub trait LlmStepService' "$SRC_DIR/$MODULE/application/service.rs" 2>/dev/null; then
+    if grep -q 'impl.*LlmStepService' "$SRC_DIR/$MODULE/application/service_impl.rs" 2>/dev/null; then
+        log_pass "LlmStepService → LlmStepServiceImpl"
+    else
+        log_fail "LlmStepService trait has no implementation"
+    fi
+else
+    log_fail "LlmStepService trait not found"
+fi
+
+if grep -q 'pub trait LlmContextBuilderService' "$SRC_DIR/$MODULE/application/service.rs" 2>/dev/null; then
+    if grep -q 'impl.*LlmContextBuilderService' "$SRC_DIR/$MODULE/application/service_impl.rs" 2>/dev/null; then
+        log_pass "LlmContextBuilderService → LlmContextBuilderServiceImpl"
+    else
+        log_fail "LlmContextBuilderService trait has no implementation"
+    fi
+else
+    log_fail "LlmContextBuilderService trait not found"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 2: Factory Contracts
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Factory Contracts ---"
+
+if grep -q 'pub trait LlmStepFactory' "$SRC_DIR/$MODULE/application/factory.rs" 2>/dev/null; then
+    if grep -q 'impl.*LlmStepFactory' "$SRC_DIR/$MODULE/application/factory_impl.rs" 2>/dev/null; then
+        log_pass "LlmStepFactory → LlmStepFactoryImpl"
+    else
+        log_fail "LlmStepFactory trait has no implementation"
+    fi
+else
+    log_fail "LlmStepFactory trait not found"
+fi
+
+if grep -q 'pub trait LlmContextBuilderFactory' "$SRC_DIR/$MODULE/application/factory.rs" 2>/dev/null; then
+    if grep -q 'impl.*LlmContextBuilderFactory' "$SRC_DIR/$MODULE/application/factory_impl.rs" 2>/dev/null; then
+        log_pass "LlmContextBuilderFactory → LlmContextBuilderFactoryImpl"
+    else
+        log_fail "LlmContextBuilderFactory trait has no implementation"
+    fi
+else
+    log_fail "LlmContextBuilderFactory trait not found"
+fi
+
+if grep -q 'pub trait LlmProviderClientFactory' "$SRC_DIR/$MODULE/application/factory.rs" 2>/dev/null; then
+    if grep -q 'impl.*LlmProviderClientFactory' "$SRC_DIR/$MODULE/application/factory_impl.rs" 2>/dev/null; then
+        log_pass "LlmProviderClientFactory → LlmProviderClientFactoryImpl"
+    else
+        log_fail "LlmProviderClientFactory trait has no implementation"
+    fi
+else
+    log_fail "LlmProviderClientFactory trait not found"
+fi
+
+if grep -q 'pub trait LlmProviderClient' "$SRC_DIR/$MODULE/application/factory.rs" 2>/dev/null; then
+    log_pass "LlmProviderClient trait defined"
+else
+    log_fail "LlmProviderClient trait not found"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 3: Repository Contracts
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Repository Contracts ---"
+
+REPO_FILE="$SRC_DIR/$MODULE/infrastructure/repository/mod.rs"
+
+if grep -q 'pub trait LlmGenerateNodeRepository' "$REPO_FILE" 2>/dev/null; then
+    if grep -q 'impl.*LlmGenerateNodeRepository' "$SRC_DIR/$MODULE/infrastructure/repository/node_repository_impl.rs" 2>/dev/null; then
+        log_pass "LlmGenerateNodeRepository → InMemoryNodeRepository"
+    else
+        log_fail "LlmGenerateNodeRepository trait has no implementation"
+    fi
+else
+    log_fail "LlmGenerateNodeRepository trait not found"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 4: Domain Entities and Types
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Domain Entities ---"
+
+DOMAIN_DIR="$SRC_DIR/$MODULE/domain"
+
+if grep -q 'pub struct LlmGenerateNode' "$DOMAIN_DIR/generate_node.rs" 2>/dev/null; then
+    log_pass "LlmGenerateNode struct exists"
+else
+    log_fail "LlmGenerateNode struct not found"
+fi
+
+if grep -q 'pub struct LlmModelConfig' "$DOMAIN_DIR/generate_node.rs" 2>/dev/null; then
+    log_pass "LlmModelConfig struct exists"
+else
+    log_fail "LlmModelConfig struct not found"
+fi
+
+if grep -q 'pub struct LlmOutputSchema' "$DOMAIN_DIR/generate_node.rs" 2>/dev/null; then
+    log_pass "LlmOutputSchema struct exists"
+else
+    log_fail "LlmOutputSchema struct not found"
+fi
+
+if grep -q 'pub enum LlmOutputFormat' "$DOMAIN_DIR/generate_node.rs" 2>/dev/null; then
+    log_pass "LlmOutputFormat enum exists"
+else
+    log_fail "LlmOutputFormat enum not found"
+fi
+
+if grep -q 'pub enum LlmGenerateNodeState' "$DOMAIN_DIR/generate_node.rs" 2>/dev/null; then
+    log_pass "LlmGenerateNodeState enum exists"
+else
+    log_fail "LlmGenerateNodeState enum not found"
+fi
+
+if grep -q 'pub struct LlmGenerationOutput' "$DOMAIN_DIR/generate_node.rs" 2>/dev/null; then
+    log_pass "LlmGenerationOutput struct exists"
+else
+    log_fail "LlmGenerationOutput struct not found"
+fi
+
+if grep -q 'pub struct LlmStepContext' "$DOMAIN_DIR/step_context.rs" 2>/dev/null; then
+    log_pass "LlmStepContext struct exists"
+else
+    log_fail "LlmStepContext struct not found"
+fi
+
+if grep -q 'pub struct SourceContext' "$DOMAIN_DIR/step_context.rs" 2>/dev/null; then
+    log_pass "SourceContext struct exists"
+else
+    log_fail "SourceContext struct not found"
+fi
+
+if grep -q 'pub struct FailureContext' "$DOMAIN_DIR/step_context.rs" 2>/dev/null; then
+    log_pass "FailureContext struct exists"
+else
+    log_fail "FailureContext struct not found"
+fi
+
+if grep -q 'pub struct ExecutionContext' "$DOMAIN_DIR/step_context.rs" 2>/dev/null; then
+    log_pass "ExecutionContext struct exists"
+else
+    log_fail "ExecutionContext struct not found"
+fi
+
+if grep -q 'pub struct PreviousAttempt' "$DOMAIN_DIR/step_context.rs" 2>/dev/null; then
+    log_pass "PreviousAttempt struct exists"
+else
+    log_fail "PreviousAttempt struct not found"
+fi
+
+if grep -q 'pub enum LlmStepError' "$DOMAIN_DIR/error.rs" 2>/dev/null; then
+    log_pass "LlmStepError enum exists"
+else
+    log_fail "LlmStepError enum not found"
+fi
+
+if grep -q 'pub enum LlmStepEvent' "$DOMAIN_DIR/event/mod.rs" 2>/dev/null; then
+    log_pass "LlmStepEvent enum exists"
+else
+    log_fail "LlmStepEvent enum not found"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 5: DTOs exist
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- DTOs ---"
+
+DTO_FILE="$SRC_DIR/$MODULE/application/dto/mod.rs"
+
+for dto in CreateNodeInput CreateNodeOutput BuildContextInput BuildContextOutput \
+           GenerateInput GenerateOutput ExecuteStepInput ExecuteStepOutput \
+           GetSourceContextInput GetSourceContextOutput GetFailureContextInput GetFailureContextOutput \
+           RetryGenerationInput RetryGenerationOutput ValidateNodeConfigInput ValidateNodeConfigOutput \
+           LlmStepSummary; do
+    if grep -q "pub struct $dto" "$DTO_FILE" 2>/dev/null; then
+        log_pass "$dto DTO exists"
+    else
+        log_fail "$dto DTO not found"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Check 6: HTTP Contracts
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- HTTP Contracts ---"
+
+HTTP_FILE="$SRC_DIR/$MODULE/interfaces/http/mod.rs"
+
+for endpoint in API_BASE_PATH CREATE_NODE_PATH GET_NODE_PATH BUILD_CONTEXT_PATH \
+                EXECUTE_STEP_PATH RETRY_STEP_PATH LIST_NODES_PATH DELETE_NODE_PATH \
+                VALIDATE_CONFIG_PATH HEALTH_PATH; do
+    if grep -q "pub const $endpoint" "$HTTP_FILE" 2>/dev/null; then
+        log_pass "HTTP endpoint $endpoint exists"
+    else
+        log_fail "HTTP endpoint $endpoint not found"
+    fi
+done
+
+if grep -q 'pub struct ApiErrorResponse' "$HTTP_FILE" 2>/dev/null; then
+    log_pass "ApiErrorResponse exists"
+else
+    log_fail "ApiErrorResponse not found"
+fi
+
+if grep -q 'pub mod error_codes' "$HTTP_FILE" 2>/dev/null; then
+    log_pass "Error codes defined"
+else
+    log_fail "Error codes not defined"
+fi
+
+if grep -q 'pub mod status_codes' "$HTTP_FILE" 2>/dev/null; then
+    log_pass "Status codes defined"
+else
+    log_fail "Status codes not defined"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 7: Provider Client Implementations
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Provider Clients ---"
+
+CLIENT_FILE="$SRC_DIR/$MODULE/infrastructure/llm_provider_client_impl.rs"
+
+if grep -q 'impl.*LlmProviderClient for MockLlmProviderClient' "$CLIENT_FILE" 2>/dev/null; then
+    log_pass "MockLlmProviderClient implements LlmProviderClient"
+else
+    log_fail "MockLlmProviderClient implementation not found"
+fi
+
+if grep -q 'impl.*LlmProviderClient for AnthropicProviderClient' "$CLIENT_FILE" 2>/dev/null; then
+    log_pass "AnthropicProviderClient implements LlmProviderClient"
+else
+    log_fail "AnthropicProviderClient implementation not found"
+fi
+
+if grep -q 'impl.*LlmProviderClient for OpenAiProviderClient' "$CLIENT_FILE" 2>/dev/null; then
+    log_pass "OpenAiProviderClient implements LlmProviderClient"
+else
+    log_fail "OpenAiProviderClient implementation not found"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "═══ Summary ═══"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo ""
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo "FAILURES:"
+    for err in "${ERRORS[@]}"; do
+        echo "  - $err"
+    done
+    echo ""
+    echo "Some llm-step contracts are missing implementations."
+    exit 1
+fi
+
+echo "All llm-step contracts have implementations."
+exit 0

--- a/engine/.pi/scripts/ci/check_llm-step_coverage.sh
+++ b/engine/.pi/scripts/ci/check_llm-step_coverage.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# ============================================================================
+# check_llm-step_coverage.sh
+#
+# Enforces minimum code coverage thresholds for the llm-step module.
+# Uses cargo-tarpaulin or llvm-cov to measure line coverage.
+# Falls back to test count if no coverage tool is available.
+#
+# Usage: bash .pi/scripts/ci/check_llm-step_coverage.sh [--help]
+#
+# Exit codes: 0 = coverage meets thresholds, 1 = below threshold
+# ============================================================================
+set -uo pipefail
+
+MIN_COVERAGE=80
+MIN_TEST_COUNT=36
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+log_pass() { echo "  ✓ PASS: $1"; ((PASS++)); }
+log_fail() { echo "  ✗ FAIL: $1"; ERRORS+=("$1"); ((FAIL++)); }
+
+echo ""
+echo "═══ LLM-Step Coverage Threshold Check ═══"
+echo ""
+
+# Determine if we're in a Rust project
+if [ ! -f "Cargo.toml" ] && [ ! -f "engine/Cargo.toml" ]; then
+    log_fail "No Cargo.toml found (not a Rust project)"
+    echo ""
+    echo "Coverage threshold check FAILED."
+    exit 1
+fi
+
+# Determine project root
+PROJECT_ROOT="."
+if [ -f "engine/Cargo.toml" ]; then
+    PROJECT_ROOT="engine"
+fi
+
+echo "Project: $PROJECT_ROOT"
+echo "Minimum coverage: ${MIN_COVERAGE}%"
+echo ""
+
+# Try tarpaulin first, then llvm-cov
+if command -v cargo-tarpaulin &>/dev/null; then
+    echo "Using cargo-tarpaulin for coverage..."
+    cd "$PROJECT_ROOT"
+
+    COVERAGE_OUTPUT=$(cargo tarpaulin --out Xml --output-dir ../coverage --exclude-files "src/llm_step/interfaces/*" 2>&1 || true)
+    COVERAGE_PCT=$(echo "$COVERAGE_OUTPUT" | grep -oE '[0-9]+\.[0-9]+%' | tail -1 | tr -d '%')
+
+    if [ -z "$COVERAGE_PCT" ]; then
+        if [ -f "../coverage/cobertura.xml" ]; then
+            COVERAGE_PCT=$(grep -oE 'line-rate="[0-9.]+"' ../coverage/cobertura.xml | head -1 | grep -oE '[0-9.]+' | awk '{printf "%.0f", $1 * 100}')
+        fi
+    fi
+
+    if [ -z "$COVERAGE_PCT" ]; then
+        log_fail "Could not determine coverage percentage from tarpaulin output"
+    elif [ "$(printf '%.0f' "$COVERAGE_PCT")" -ge "$MIN_COVERAGE" ]; then
+        log_pass "Coverage: ${COVERAGE_PCT}% (threshold: ${MIN_COVERAGE}%)"
+    else
+        log_fail "Coverage: ${COVERAGE_PCT}% is below threshold of ${MIN_COVERAGE}%"
+    fi
+
+    cd ..
+
+elif command -v cargo-llvm-cov &>/dev/null; then
+    echo "Using cargo-llvm-cov for coverage..."
+    COVERAGE_OUTPUT=$(cargo llvm-cov --workspace --lcov --output-path coverage/lcov.info 2>&1 || true)
+    if [ -f "coverage/lcov.info" ]; then
+        TOTAL_LINES=$(grep -c '^DA:' coverage/lcov.info || true)
+        HIT_LINES=$(grep '^DA:.*,[1-9][0-9]*$' coverage/lcov.info | wc -l | tr -d ' ')
+        if [ "$TOTAL_LINES" -gt 0 ]; then
+            COVERAGE_PCT=$((HIT_LINES * 100 / TOTAL_LINES))
+            if [ "$COVERAGE_PCT" -ge "$MIN_COVERAGE" ]; then
+                log_pass "Coverage: ${COVERAGE_PCT}% (threshold: ${MIN_COVERAGE}%)"
+            else
+                log_fail "Coverage: ${COVERAGE_PCT}% is below threshold of ${MIN_COVERAGE}%"
+            fi
+        else
+            log_fail "No coverage data found"
+        fi
+    else
+        log_fail "No lcov.info generated"
+    fi
+else
+    echo "No coverage tool found (cargo-tarpaulin or cargo-llvm-cov)."
+    echo "Counting test functions as a fallback metric..."
+
+    TEST_COUNT=$(grep -r '^\s*#\[tokio::test\]\|^\s*#\[test\]' "$PROJECT_ROOT/src/llm_step/" 2>/dev/null | wc -l | tr -d ' ')
+    if [ "$TEST_COUNT" -ge "$MIN_TEST_COUNT" ]; then
+        log_pass "Test count: $TEST_COUNT tests in llm_step module (minimum $MIN_TEST_COUNT required)"
+    else
+        log_fail "Only $TEST_COUNT tests found in llm_step module (minimum $MIN_TEST_COUNT required)"
+    fi
+fi
+
+echo ""
+echo "═══ Summary ═══"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo ""
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo "FAILURES:"
+    for err in "${ERRORS[@]}"; do
+        echo "  - $err"
+    done
+    echo ""
+    echo "Coverage thresholds not met."
+    exit 1
+fi
+
+echo "Coverage thresholds satisfied."
+exit 0

--- a/engine/.pi/scripts/ci/run_hardening_stages.sh
+++ b/engine/.pi/scripts/ci/run_hardening_stages.sh
@@ -319,6 +319,11 @@ run_stage "29" "recovery-recipes_proofing" \
 run_stage "30" "quality-gates_proofing" \
     "${SCRIPTS_DIR}/stage_quality-gates_proofing.sh" \
     "always"
+
+# Stage 31: LLM-Step Proofing
+run_stage "31" "llm-step_proofing" \
+    "${SCRIPTS_DIR}/stage_llm-step_proofing.sh" \
+    "always"
 # ── Summary ──
 
 echo ""

--- a/engine/.pi/scripts/ci/stage_llm-step_proofing.sh
+++ b/engine/.pi/scripts/ci/stage_llm-step_proofing.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# ============================================================================
+# stage_llm-step_proofing.sh
+#
+# CI stage wrapper that runs all llm-step proofing checks:
+#   1. Contract implementation check — all interfaces have implementations
+#   2. Coverage threshold check — meets minimum coverage
+#
+# Usage: bash .pi/scripts/ci/stage_llm-step_proofing.sh [--help]
+#
+# Exit codes: 0 = all checks pass, 1 = any check fails
+# ============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+log_pass() { echo "  ✓ PASS: $1"; ((PASS++)); }
+log_fail() { echo "  ✗ FAIL: $1"; ERRORS+=("$1"); ((FAIL++)); }
+
+echo ""
+echo "╔══════════════════════════════════════════════╗"
+echo "║        LLM-Step Proofing Stage               ║"
+echo "╚══════════════════════════════════════════════╝"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Check 1: Contract Implementation Check
+# ---------------------------------------------------------------------------
+echo "--- 1. Contract Implementation Check ---"
+echo ""
+
+if bash "${SCRIPT_DIR}/check_llm-step_contracts.sh" 2>&1; then
+    log_pass "Contract implementation check passed"
+else
+    log_fail "Contract implementation check failed"
+fi
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# Check 2: Coverage Threshold Check
+# ---------------------------------------------------------------------------
+echo "--- 2. Coverage Threshold Check ---"
+echo ""
+
+if bash "${SCRIPT_DIR}/check_llm-step_coverage.sh" 2>&1; then
+    log_pass "Coverage threshold check passed"
+else
+    log_fail "Coverage threshold check failed"
+fi
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# Check 3: Script Self-Validation
+# ---------------------------------------------------------------------------
+echo "--- 3. Script Self-Validation ---"
+echo ""
+
+for script in "$SCRIPT_DIR"/check_llm-step_*.sh; do
+    name=$(basename "$script")
+    if [ -f "$script" ] && [ -x "$script" ]; then
+        log_pass "Script is executable: $name"
+    elif [ -f "$script" ]; then
+        chmod +x "$script"
+        if [ -x "$script" ]; then
+            log_pass "Script made executable: $name"
+        else
+            log_fail "Script is not executable: $name"
+        fi
+    fi
+done
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "═══ Stage Summary ═══"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo ""
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo "FAILURES:"
+    for err in "${ERRORS[@]}"; do
+        echo "  - $err"
+    done
+    echo ""
+    echo "LLM-step proofing stage FAILED."
+    exit 1
+fi
+
+echo "LLM-step proofing stage PASSED."
+exit 0


### PR DESCRIPTION
## Summary

Create deterministic, automated validation scripts that prove every contract from the freeze phase is correctly implemented and tested.

### Scripts Created

| Script | Purpose |
|--------|---------|
| `check_llm-step_contracts.sh` | Validates 53 contract items (services, factories, repos, domain entities, DTOs, HTTP, providers) |
| `check_llm-step_coverage.sh` | Enforces 80% coverage threshold (falls back to 36 test count) |
| `stage_llm-step_proofing.sh` | CI stage wrapper running both checks |

### CI Integration
- Added stage 31 (llm-step_proofing) to run_hardening_stages.sh

### Verification
All 56 checks (53 contract + 1 coverage + 2 self-validation) pass with 0 failures.

### Related Issues
- Closes #486
- Relates to #481