### PR TITLE
feat: contract freeze for failure-parser epic (#495)

### DIFF
--- a/engine/.pi/.guardian-epic-state.json
+++ b/engine/.pi/.guardian-epic-state.json
@@ -1,31 +1,39 @@
 {
-  "name": "\"llm-step\"",
-  "trackingIssueId": "481",
+  "name": "\"failure-parser\"",
+  "trackingIssueId": "494",
   "epicId": null,
   "slices": [
     {
-      "module": "llm-step",
+      "module": "failure-parser",
       "components": [
         {
-          "name": "LlmGenerateNode",
+          "name": "TemplateFailure",
           "status": "planned",
-          "description": "The execution engine sees this as just another node type — but internally it calls the LLM",
+          "description": "Typed classification of template execution failures",
           "dependencies": [
             "none"
           ]
         },
         {
-          "name": "LlmStepContext",
+          "name": "FailureParserService",
           "status": "planned",
-          "description": "Provides the LLM with source code context and previous failure analysis",
+          "description": "Parse raw output into structured failures with suggestions",
           "dependencies": [
             "none"
           ]
         },
         {
-          "name": "LlmStepService",
+          "name": "TypeScript Parser",
           "status": "planned",
-          "description": "Application service for LLM generation during execution",
+          "description": "Parse `tsc --noEmit --pretty false` output into structured failures",
+          "dependencies": [
+            "none"
+          ]
+        },
+        {
+          "name": "Suggested Fix Generation",
+          "status": "planned",
+          "description": "**How suggestions are derived:**",
           "dependencies": [
             "none"
           ]
@@ -33,25 +41,33 @@
       ],
       "nextLogicalSlice": [
         {
-          "name": "LlmGenerateNode",
+          "name": "TemplateFailure",
           "status": "planned",
-          "description": "The execution engine sees this as just another node type — but internally it calls the LLM",
+          "description": "Typed classification of template execution failures",
           "dependencies": [
             "none"
           ]
         },
         {
-          "name": "LlmStepContext",
+          "name": "FailureParserService",
           "status": "planned",
-          "description": "Provides the LLM with source code context and previous failure analysis",
+          "description": "Parse raw output into structured failures with suggestions",
           "dependencies": [
             "none"
           ]
         },
         {
-          "name": "LlmStepService",
+          "name": "TypeScript Parser",
           "status": "planned",
-          "description": "Application service for LLM generation during execution",
+          "description": "Parse `tsc --noEmit --pretty false` output into structured failures",
+          "dependencies": [
+            "none"
+          ]
+        },
+        {
+          "name": "Suggested Fix Generation",
+          "status": "planned",
+          "description": "**How suggestions are derived:**",
           "dependencies": [
             "none"
           ]
@@ -64,40 +80,46 @@
       "id": "issue-contract-freeze",
       "title": "Contract Freeze: Define interfaces and contracts",
       "status": "planned",
-      "remoteIssueId": "482"
+      "remoteIssueId": "495"
     },
     {
-      "id": "issue-llmgeneratenode",
-      "title": "LlmGenerateNode: The execution engine sees this as just another node type — but internally it cal",
+      "id": "issue-templatefailure",
+      "title": "TemplateFailure: Typed classification of template execution failures",
       "status": "planned",
-      "remoteIssueId": "483"
+      "remoteIssueId": "496"
     },
     {
-      "id": "issue-llmstepcontext",
-      "title": "LlmStepContext: Provides the LLM with source code context and previous failure analysis",
+      "id": "issue-failureparserservice",
+      "title": "FailureParserService: Parse raw output into structured failures with suggestions",
       "status": "planned",
-      "remoteIssueId": "484"
+      "remoteIssueId": "497"
     },
     {
-      "id": "issue-llmstepservice",
-      "title": "LlmStepService: Application service for LLM generation during execution",
+      "id": "issue-typescript-parser",
+      "title": "TypeScript Parser: Parse `tsc --noEmit --pretty false` output into structured failures",
       "status": "planned",
-      "remoteIssueId": "485"
+      "remoteIssueId": "498"
+    },
+    {
+      "id": "issue-suggested-fix-generation",
+      "title": "Suggested Fix Generation: **How suggestions are derived:**",
+      "status": "planned",
+      "remoteIssueId": "499"
     },
     {
       "id": "issue-proofing",
       "title": "Proofing: Validation scripts + CI integration",
       "status": "planned",
-      "remoteIssueId": "486"
+      "remoteIssueId": "500"
     },
     {
       "id": "issue-architecture-readiness",
       "title": "Architecture Readiness: Runbook, DR, docs, CI enforcement",
       "status": "planned",
-      "remoteIssueId": "487"
+      "remoteIssueId": "501"
     }
   ],
   "status": "planning",
   "currentIssueIndex": 0,
-  "createdAt": "2026-06-19T18:13:39.424Z"
+  "createdAt": "2026-06-19T18:53:34.616Z"
 }

--- a/engine/.pi/.guardian-pipeline-state.json
+++ b/engine/.pi/.guardian-pipeline-state.json
@@ -1,11 +1,12 @@
 {
-  "id": "PL-3939",
-  "name": "\"llm-step\"",
+  "id": "PL-5680",
+  "name": "\"failure-parser\"",
   "items": [
     "issue-contract-freeze",
-    "issue-llmgeneratenode",
-    "issue-llmstepcontext",
-    "issue-llmstepservice",
+    "issue-templatefailure",
+    "issue-failureparserservice",
+    "issue-typescript-parser",
+    "issue-suggested-fix-generation",
     "issue-proofing",
     "issue-architecture-readiness"
   ],
@@ -50,198 +51,12 @@
       }
     }
   ],
-  "currentItemIndex": 5,
+  "currentItemIndex": 0,
   "currentStepIndex": 0,
   "status": "running",
   "retryCount": 0,
-  "results": [
-    {
-      "item": "issue-contract-freeze",
-      "status": "done",
-      "stepResults": [
-        {
-          "step": "implement",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "implement",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "validate",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "validate",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "create-mr",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "create-mr",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "merge",
-          "status": "passed",
-          "reason": ""
-        }
-      ]
-    },
-    {
-      "item": "issue-llmgeneratenode",
-      "status": "done",
-      "stepResults": [
-        {
-          "step": "implement",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "implement",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "validate",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "validate",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "create-mr",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "merge",
-          "status": "passed",
-          "reason": ""
-        }
-      ]
-    },
-    {
-      "item": "issue-llmstepcontext",
-      "status": "done",
-      "stepResults": [
-        {
-          "step": "implement",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "implement",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "validate",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "validate",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "create-mr",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "merge",
-          "status": "passed",
-          "reason": ""
-        }
-      ]
-    },
-    {
-      "item": "issue-llmstepservice",
-      "status": "done",
-      "stepResults": [
-        {
-          "step": "implement",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "implement",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "validate",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "validate",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "create-mr",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "merge",
-          "status": "passed",
-          "reason": ""
-        }
-      ]
-    },
-    {
-      "item": "issue-proofing",
-      "status": "done",
-      "stepResults": [
-        {
-          "step": "implement",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "implement",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "validate",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "validate",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "create-mr",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "merge",
-          "status": "passed",
-          "reason": ""
-        }
-      ]
-    }
-  ],
+  "results": [],
   "mergeOnValid": true,
-  "createdAt": "2026-06-19T18:13:39.446Z",
-  "updatedAt": "2026-06-19T18:41:57.340Z"
+  "createdAt": "2026-06-19T18:53:34.644Z",
+  "updatedAt": "2026-06-19T18:53:34.644Z"
 }

--- a/engine/.pi/issues/issue-architecture-readiness.md
+++ b/engine/.pi/issues/issue-architecture-readiness.md
@@ -1,9 +1,9 @@
 ---
 guardian_issue:
   id: "ISSUE-READINESS"
-  epic: ""llm-step""
+  epic: ""failure-parser""
   component: "Architecture Readiness"
-  module: "llm-step"
+  module: "failure-parser"
   status: planned
   priority: critical
   dependencies: []
@@ -32,7 +32,7 @@ guardian_issue:
       - Verify proofing scripts + validators in CI
 
   canonical_references:
-    - module: ".pi/architecture/modules/llm-step.md"
+    - module: ".pi/architecture/modules/failure-parser.md"
 
   acceptance_criteria:
     - "Runbook created and reviewed"
@@ -58,30 +58,30 @@ guardian_issue:
     and CI will catch regressions (proofing scripts + validators).
 
   file_changes:
-    - "create: docs/runbook-llm-step.md"
-    - "create: docs/dr-plan-llm-step.md"
+    - "create: docs/runbook-failure-parser.md"
+    - "create: docs/dr-plan-failure-parser.md"
     - "modify: .pi/architecture/CHANGELOG.md"
-    - "modify: .pi/architecture/modules/llm-step.md"
+    - "modify: .pi/architecture/modules/failure-parser.md"
 ---
 
-# Architecture Readiness: llm-step
+# Architecture Readiness: failure-parser
 
 ## Intent
 
-Make the llm-step module production-ready. This is the final issue in every epic
+Make the failure-parser module production-ready. This is the final issue in every epic
 — it closes the loop between implementation and operability.
 
 ## Deliverables
 
 ### Runbook
-`docs/runbook-llm-step.md` covering:
+`docs/runbook-failure-parser.md` covering:
 - Startup sequence and dependencies
 - Graceful shutdown procedure
 - Common failure modes and recovery
 - Configuration reference
 
 ### DR Plan
-`docs/dr-plan-llm-step.md` covering:
+`docs/dr-plan-failure-parser.md` covering:
 - Backup strategy and schedule
 - Restore procedure
 - Failover plan

--- a/engine/.pi/issues/issue-contract-freeze.md
+++ b/engine/.pi/issues/issue-contract-freeze.md
@@ -1,9 +1,9 @@
 ---
 guardian_issue:
   id: "ISSUE-CONTRACT-FREEZE"
-  epic: ""llm-step""
+  epic: ""failure-parser""
   component: "Contract Freeze"
-  module: "llm-step"
+  module: "failure-parser"
   status: planned
   priority: critical
   dependencies: []
@@ -29,7 +29,7 @@ guardian_issue:
       - REST/event contracts
 
   canonical_references:
-    - module: ".pi/architecture/modules/llm-step.md"
+    - module: ".pi/architecture/modules/failure-parser.md"
 
   acceptance_criteria:
     - "All component interfaces defined as interfaces/types"
@@ -47,24 +47,25 @@ guardian_issue:
     interfaces, types, DTOs, event schemas, API paths, error formats.
 
   file_changes:
-    - "create: src/llm-step/contracts/"
-    - "create: src/llm-step/contracts/dtos/"
-    - "create: src/llm-step/contracts/events/"
+    - "create: src/failure-parser/contracts/"
+    - "create: src/failure-parser/contracts/dtos/"
+    - "create: src/failure-parser/contracts/events/"
 ---
 
-# Contract Freeze: llm-step
+# Contract Freeze: failure-parser
 
 ## Intent
 
-Define and freeze all public interfaces, contracts, and schemas for the llm-step
+Define and freeze all public interfaces, contracts, and schemas for the failure-parser
 epic before any implementation begins. This prevents architecture drift — implementation
 must satisfy contracts, not the other way around.
 
 ## Included Components
 
-- LlmGenerateNode
-- LlmStepContext
-- LlmStepService
+- TemplateFailure
+- FailureParserService
+- TypeScript Parser
+- Suggested Fix Generation
 
 ## What Must Be Frozen
 

--- a/engine/.pi/issues/issue-failureparserservice.md
+++ b/engine/.pi/issues/issue-failureparserservice.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-FAILURE-PARSER-2"
+  epic: "TBD"
+  component: "FailureParserService"
+  module: "failure-parser"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement FailureParserService for the failure-parser module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for failureparserservice
+    application:
+      - New service/handler for failureparserservice
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/failure-parser.md#failureparserservice"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Parse raw output into structured failures with suggestions
+
+  file_changes:
+    - "create: src/failure-parser/failureparserservice/"
+    - "create: tests/unit/failure-parser/failureparserservice/"
+    - "create: tests/integration/failure-parser/failureparserservice/"
+---
+
+# ISSUE-FAILURE-PARSER-2: FailureParserService
+
+## Intent
+
+Parse raw output into structured failures with suggestions
+
+## Architecture Context
+
+- **Module:** failure-parser
+- **Component:** FailureParserService
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement FailureParserService for the failure-parser module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for failureparserservice
+
+### Application
+- New service/handler for failureparserservice
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/failure-parser.md#failureparserservice`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-proofing.md
+++ b/engine/.pi/issues/issue-proofing.md
@@ -1,9 +1,9 @@
 ---
 guardian_issue:
   id: "ISSUE-PROOFING"
-  epic: ""llm-step""
+  epic: ""failure-parser""
   component: "Proofing & CI Enforcement"
-  module: "llm-step"
+  module: "failure-parser"
   status: planned
   priority: critical
   dependencies: []
@@ -26,7 +26,7 @@ guardian_issue:
       - Updated CI stage configuration
 
   canonical_references:
-    - module: ".pi/architecture/modules/llm-step.md"
+    - module: ".pi/architecture/modules/failure-parser.md"
 
   acceptance_criteria:
     - "All proofing scripts created and executable"
@@ -47,12 +47,12 @@ guardian_issue:
     every build for zero token cost.
 
   file_changes:
-    - "create: .pi/scripts/ci/check_llm-step_contracts.sh"
-    - "create: .pi/scripts/ci/check_llm-step_coverage.sh"
+    - "create: .pi/scripts/ci/check_failure-parser_contracts.sh"
+    - "create: .pi/scripts/ci/check_failure-parser_coverage.sh"
     - "modify: .pi/scripts/ci/run_hardening_stages.sh"
 ---
 
-# Proofing & CI Enforcement: llm-step
+# Proofing & CI Enforcement: failure-parser
 
 ## Intent
 
@@ -81,17 +81,17 @@ on every PR. No LLM cost. No human review. Just pass or fail.
 
 | Script | Purpose | Location |
 |--------|---------|----------|
-| check_llm-step_contracts.sh | Validate contract implementation | .pi/scripts/ci/ |
-| check_llm-step_coverage.sh | Enforce coverage thresholds | .pi/scripts/ci/ |
-| stage_llm-step_proofing.sh | CI stage wrapper | .pi/scripts/ci/ |
+| check_failure-parser_contracts.sh | Validate contract implementation | .pi/scripts/ci/ |
+| check_failure-parser_coverage.sh | Enforce coverage thresholds | .pi/scripts/ci/ |
+| stage_failure-parser_proofing.sh | CI stage wrapper | .pi/scripts/ci/ |
 
 ## CI Pipeline Update
 
 Add the new stage to `run_hardening_stages.sh`:
 
 ```bash
-run_stage "11" "llm-step_proofing" \
-    "${SCRIPTS_DIR}/stage_llm-step_proofing.sh" \
+run_stage "11" "failure-parser_proofing" \
+    "${SCRIPTS_DIR}/stage_failure-parser_proofing.sh" \
     "always"
 ```
 

--- a/engine/.pi/issues/issue-suggested-fix-generation.md
+++ b/engine/.pi/issues/issue-suggested-fix-generation.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-FAILURE-PARSER-4"
+  epic: "TBD"
+  component: "Suggested Fix Generation"
+  module: "failure-parser"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement Suggested Fix Generation for the failure-parser module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for suggested-fix-generation
+    application:
+      - New service/handler for suggested-fix-generation
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/failure-parser.md#suggested-fix-generation"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    **How suggestions are derived:**
+
+  file_changes:
+    - "create: src/failure-parser/suggested-fix-generation/"
+    - "create: tests/unit/failure-parser/suggested-fix-generation/"
+    - "create: tests/integration/failure-parser/suggested-fix-generation/"
+---
+
+# ISSUE-FAILURE-PARSER-4: Suggested Fix Generation
+
+## Intent
+
+**How suggestions are derived:**
+
+## Architecture Context
+
+- **Module:** failure-parser
+- **Component:** Suggested Fix Generation
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement Suggested Fix Generation for the failure-parser module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for suggested-fix-generation
+
+### Application
+- New service/handler for suggested-fix-generation
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/failure-parser.md#suggested-fix-generation`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-templatefailure.md
+++ b/engine/.pi/issues/issue-templatefailure.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-FAILURE-PARSER-1"
+  epic: "TBD"
+  component: "TemplateFailure"
+  module: "failure-parser"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement TemplateFailure for the failure-parser module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for templatefailure
+    application:
+      - New service/handler for templatefailure
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/failure-parser.md#templatefailure"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Typed classification of template execution failures
+
+  file_changes:
+    - "create: src/failure-parser/templatefailure/"
+    - "create: tests/unit/failure-parser/templatefailure/"
+    - "create: tests/integration/failure-parser/templatefailure/"
+---
+
+# ISSUE-FAILURE-PARSER-1: TemplateFailure
+
+## Intent
+
+Typed classification of template execution failures
+
+## Architecture Context
+
+- **Module:** failure-parser
+- **Component:** TemplateFailure
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement TemplateFailure for the failure-parser module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for templatefailure
+
+### Application
+- New service/handler for templatefailure
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/failure-parser.md#templatefailure`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/.pi/issues/issue-typescript-parser.md
+++ b/engine/.pi/issues/issue-typescript-parser.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-FAILURE-PARSER-3"
+  epic: "TBD"
+  component: "TypeScript Parser"
+  module: "failure-parser"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement TypeScript Parser for the failure-parser module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for typescript-parser
+    application:
+      - New service/handler for typescript-parser
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/failure-parser.md#typescript-parser"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Parse `tsc --noEmit --pretty false` output into structured failures
+
+  file_changes:
+    - "create: src/failure-parser/typescript-parser/"
+    - "create: tests/unit/failure-parser/typescript-parser/"
+    - "create: tests/integration/failure-parser/typescript-parser/"
+---
+
+# ISSUE-FAILURE-PARSER-3: TypeScript Parser
+
+## Intent
+
+Parse `tsc --noEmit --pretty false` output into structured failures
+
+## Architecture Context
+
+- **Module:** failure-parser
+- **Component:** TypeScript Parser
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement TypeScript Parser for the failure-parser module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for typescript-parser
+
+### Application
+- New service/handler for typescript-parser
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/failure-parser.md#typescript-parser`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/engine/src/failure_parser/application/dto/mod.rs
+++ b/engine/src/failure_parser/application/dto/mod.rs
@@ -1,0 +1,246 @@
+//! Data Transfer Objects for the Failure Parser module.
+//!
+//! @canonical .pi/architecture/modules/failure-parser.md
+//! Implements: Contract Freeze — DTO schemas for failure parsing
+//! Issue: #495
+//!
+//! DTOs define the input/output contracts for service operations.
+//! They carry validation metadata and documentation but no behavior.
+//!
+//! # Contract (Frozen)
+//! - Every service operation has a dedicated input and output DTO
+//! - DTOs are serializable (JSON for API)
+//! - Validation constraints are documented in field docs
+//! - Fields use reasonable Rust types (no framework-specific annotations)
+
+use serde::{Deserialize, Serialize};
+
+use crate::failure_parser::domain::{
+    detail::FailureDetail,
+    failure::TemplateFailure,
+    ParsedFailure, SourceContext,
+};
+
+// ---------------------------------------------------------------------------
+// Parse Output DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for parsing raw compiler/test output.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParseOutputInput {
+    /// The tool that produced the output (e.g., "tsc", "jest", "rustc", "pytest").
+    /// Must be a known tool with a registered parser.
+    pub tool: String,
+
+    /// The raw stdout from the tool execution.
+    pub stdout: String,
+
+    /// The raw stderr from the tool execution (may be empty).
+    pub stderr: String,
+
+    /// The process exit code. Non-zero indicates failure.
+    pub exit_code: i32,
+
+    /// Available source context for suggestion generation.
+    pub source_context: SourceContext,
+
+    /// Working directory where the tool was executed.
+    /// Used for resolving relative paths in error output.
+    pub working_directory: String,
+}
+
+/// Result from parsing raw compiler/test output.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ParseOutputResult {
+    /// The complete parsed result with all failures.
+    pub parsed: ParsedFailure,
+
+    /// Human-readable analysis summary for LLM consumption.
+    pub llm_summary: String,
+
+    /// Whether the output was successfully parsed.
+    pub success: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Format for LLM DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for formatting failures into LLM-readable summary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FormatForLlmInput {
+    /// The failures to format.
+    pub failures: Vec<TemplateFailure>,
+
+    /// Optional title for the analysis block.
+    pub title: Option<String>,
+}
+
+/// Output from formatting failures for LLM.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FormatForLlmOutput {
+    /// The formatted analysis string.
+    pub formatted: String,
+
+    /// Total failures included in the analysis.
+    pub count: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Suggest Fix DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for generating a suggested fix for a failure.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SuggestFixInput {
+    /// The failure to generate a fix for.
+    pub failure: TemplateFailure,
+
+    /// Available source context for generating suggestions.
+    pub source_context: SourceContext,
+
+    /// Minimum confidence threshold (0.0–1.0) for returning a suggestion.
+    /// Suggestions below this threshold are returned as None.
+    #[serde(default = "default_confidence_threshold")]
+    pub min_confidence: f64,
+}
+
+fn default_confidence_threshold() -> f64 {
+    0.5
+}
+
+/// Output from generating a suggested fix.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SuggestFixOutput {
+    /// The generated fix suggestion, if one could be determined.
+    pub suggestion: Option<String>,
+
+    /// Confidence in the suggestion (0.0–1.0).
+    pub confidence: f64,
+
+    /// Why this suggestion was chosen (for traceability).
+    pub rationale: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Register Parser DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for registering a new parser.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegisterParserInput {
+    /// The tool name this parser handles.
+    pub tool: String,
+    /// Human-readable description of the parser.
+    pub description: String,
+}
+
+/// Result from registering a new parser.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RegisterParserResult {
+    /// Whether the registration was successful.
+    pub success: bool,
+    /// Total number of parsers now in the registry.
+    pub total_parsers: usize,
+    /// Human-readable message.
+    pub message: String,
+}
+
+// ---------------------------------------------------------------------------
+// Parser Metadata DTOs
+// ---------------------------------------------------------------------------
+
+/// Metadata about a registered parser.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ParserMetadata {
+    /// The tool name this parser handles.
+    pub tool: String,
+    /// Human-readable description.
+    pub description: String,
+    /// Whether this is a built-in parser.
+    pub is_builtin: bool,
+}
+
+/// Result from listing available parsers.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ListParsersResult {
+    /// Available parsers.
+    pub parsers: Vec<ParserMetadata>,
+    /// Total count.
+    pub total: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Classify Failure DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for classifying a failure's severity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClassifySeverityInput {
+    /// The failures to classify.
+    pub failures: Vec<FailureDetail>,
+}
+
+/// Output from classifying failure severity.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ClassifySeverityOutput {
+    /// The computed overall severity.
+    pub overall_severity: String,
+    /// Number of compile-blocking errors.
+    pub compile_blocks: usize,
+    /// Number of test-blocking errors.
+    pub test_blocks: usize,
+    /// Number of warnings.
+    pub warnings: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_output_input_serialization() {
+        let input = ParseOutputInput {
+            tool: "tsc".into(),
+            stdout: "error TS2339: ...".into(),
+            stderr: String::new(),
+            exit_code: 2,
+            source_context: SourceContext::empty(),
+            working_directory: "/project".into(),
+        };
+        let json = serde_json::to_string(&input).unwrap();
+        let deserialized: ParseOutputInput = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.tool, "tsc");
+        assert_eq!(deserialized.exit_code, 2);
+    }
+
+    #[test]
+    fn test_default_confidence_threshold() {
+        let input = SuggestFixInput {
+            failure: TemplateFailure::MissingSymbol {
+                symbol: "x".into(),
+                available: vec![],
+                suggestion: None,
+                location: crate::failure_parser::domain::failure::SourceLocation::new(
+                    "test.ts", 1, None,
+                ),
+            },
+            source_context: SourceContext::empty(),
+            min_confidence: 0.5,
+        };
+        assert_eq!(input.min_confidence, 0.5);
+    }
+
+    #[test]
+    fn test_suggest_fix_output_serialization() {
+        let output = SuggestFixOutput {
+            suggestion: Some("Use 'add' instead".into()),
+            confidence: 0.95,
+            rationale: Some("Exact substring match".into()),
+        };
+        let json = serde_json::to_string(&output).unwrap();
+        let deserialized: SuggestFixOutput = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.suggestion, Some("Use 'add' instead".into()));
+        assert!((deserialized.confidence - 0.95).abs() < 1e-10);
+    }
+}

--- a/engine/src/failure_parser/application/factory.rs
+++ b/engine/src/failure_parser/application/factory.rs
@@ -1,0 +1,80 @@
+//! Factory interfaces for constructing Failure Parser service instances.
+//!
+//! @canonical .pi/architecture/modules/failure-parser.md
+//! Implements: Contract Freeze — ParserFactory, FailureParserServiceFactory traits
+//! Issue: #495
+//!
+//! Factories encapsulate the construction of complex domain objects,
+//! allowing implementations to inject dependencies and apply defaults
+//! without exposing construction logic to callers.
+//!
+//! # Contract (Frozen)
+//! - Every factory method returns a configured domain object
+//! - Validation is applied during construction
+//! - No mutable state in factory implementations
+
+use async_trait::async_trait;
+
+use crate::failure_parser::domain::{FailureParserError, LanguageParser};
+
+use super::service::{FailureParserService, FixSuggestionService};
+
+/// Factory for constructing `LanguageParser` instances.
+///
+/// Implementations create and configure parser instances for specific
+/// tools, injecting any required dependencies.
+#[async_trait]
+pub trait ParserFactory: Send + Sync {
+    /// Create a TypeScript compiler parser.
+    ///
+    /// Parses `tsc --noEmit --pretty false` output format.
+    async fn create_tsc_parser(&self) -> Result<Box<dyn LanguageParser>, FailureParserError>;
+
+    /// Create a Jest test runner parser.
+    ///
+    /// Parses Jest test output (assertion errors, reference errors).
+    async fn create_jest_parser(&self) -> Result<Box<dyn LanguageParser>, FailureParserError>;
+
+    /// Create a Rust compiler parser.
+    ///
+    /// Parses `rustc --json=diagnostic` output.
+    async fn create_rustc_parser(&self) -> Result<Box<dyn LanguageParser>, FailureParserError>;
+
+    /// Create a Python test parser.
+    ///
+    /// Parses pytest output.
+    async fn create_pytest_parser(&self) -> Result<Box<dyn LanguageParser>, FailureParserError>;
+
+    /// Create all built-in parsers.
+    ///
+    /// Returns a vector of (tool_name, parser) pairs that can be
+    /// registered in the ParserRegistry.
+    async fn create_all_builtin(
+        &self,
+    ) -> Result<Vec<Box<dyn LanguageParser>>, FailureParserError>;
+}
+
+/// Factory for constructing `FailureParserService` instances.
+///
+/// Creates the main parser service with all built-in parsers registered.
+#[async_trait]
+pub trait FailureParserServiceFactory: Send + Sync {
+    /// Create a fully configured FailureParserService.
+    ///
+    /// Registers all built-in parsers and returns a ready-to-use
+    /// service instance.
+    async fn create_service(&self) -> Result<Box<dyn FailureParserService>, FailureParserError>;
+
+    /// Create a FailureParserService with additional custom parsers.
+    async fn create_service_with_custom_parsers(
+        &self,
+        custom_parsers: Vec<Box<dyn LanguageParser>>,
+    ) -> Result<Box<dyn FailureParserService>, FailureParserError>;
+}
+
+/// Factory for constructing `FixSuggestionService` instances.
+#[async_trait]
+pub trait FixSuggestionServiceFactory: Send + Sync {
+    /// Create a FixSuggestionService instance.
+    async fn create(&self) -> Result<Box<dyn FixSuggestionService>, FailureParserError>;
+}

--- a/engine/src/failure_parser/application/mod.rs
+++ b/engine/src/failure_parser/application/mod.rs
@@ -1,0 +1,24 @@
+//! Application layer interfaces for the Failure Parser bounded context.
+//!
+//! @canonical .pi/architecture/modules/failure-parser.md
+//! Implements: Contract Freeze — service traits, DTOs, factory interfaces
+//! Issue: #495
+//!
+//! This module defines:
+//! - Service traits (use cases / application services)
+//! - Input/Output DTOs with validation
+//! - Factory interfaces for constructing parser and service instances
+//!
+//! # Contract (Frozen)
+//! - All service methods are async (return `impl Future`)
+//! - All public methods return `Result<_, FailureParserError>`
+//! - DTOs include validation annotations/documentation
+//! - No implementation logic — only trait definitions
+
+pub mod dto;
+pub mod factory;
+pub mod service;
+
+pub use dto::*;
+pub use factory::*;
+pub use service::*;

--- a/engine/src/failure_parser/application/service.rs
+++ b/engine/src/failure_parser/application/service.rs
@@ -1,0 +1,117 @@
+//! Service interfaces (use cases) for the Failure Parser bounded context.
+//!
+//! @canonical .pi/architecture/modules/failure-parser.md#service
+//! Implements: Contract Freeze — FailureParserService trait
+//! Issue: #495
+//!
+//! These traits define the application-level operations that can be performed
+//! for failure parsing and suggested fix generation. All methods are
+//! async and return domain error types.
+//!
+//! # Contract (Frozen)
+//! - Every use case has a corresponding trait method
+//! - Input/output types are DTOs defined in `dto/`
+//! - All methods are async (use `async-trait` for trait object safety)
+//! - No implementation — only contract signatures
+
+use async_trait::async_trait;
+
+use crate::failure_parser::domain::{
+    TemplateFailure, SourceContext, FailureParserError, ParserRegistry,
+};
+
+use super::dto::{
+    FormatForLlmInput, FormatForLlmOutput, ParseOutputInput, ParseOutputResult,
+    RegisterParserInput, RegisterParserResult, SuggestFixInput, SuggestFixOutput,
+};
+
+/// Application service for parsing compiler/test output into structured failures.
+///
+/// The service orchestrates the parser registry to find the right parser
+/// for the tool, delegates to it, and then generates suggested fixes
+/// using the available source context.
+///
+/// # Flow
+/// 1. Find appropriate parser in the ParserRegistry
+/// 2. Parse raw output into ParsedFailure
+/// 3. Generate suggested fixes for each failure using SourceContext
+/// 4. Format results for LLM consumption
+#[async_trait]
+pub trait FailureParserService: Send + Sync {
+    /// Parse raw compiler/test output into structured failures.
+    ///
+    /// Accepts the raw stdout/stderr from a tool execution and produces
+    /// typed `TemplateFailure` values. Returns an empty vec if no failures
+    /// are detected.
+    ///
+    /// # Arguments
+    /// * `tool` - The tool that produced the output (e.g., "tsc", "jest", "rustc", "pytest")
+    /// * `output` - The raw stdout/stderr
+    /// * `source_context` - Available symbols and source code for suggestion generation
+    async fn parse(
+        &self,
+        input: ParseOutputInput,
+    ) -> Result<ParseOutputResult, FailureParserError>;
+
+    /// Generate a human-readable summary suitable for LLM context.
+    ///
+    /// Produces a string like:
+    /// ```text
+    /// FAILURE ANALYSIS: 1 error found.
+    ///  - TS2339 at tests/tasklist.test.ts:3:10: Property 'addTask' not found.
+    ///    Available methods on TaskList: add, list, complete, count, activeCount.
+    ///    Suggested fix: use 'add' instead of 'addTask'.
+    /// ```
+    async fn format_for_llm(
+        &self,
+        input: FormatForLlmInput,
+    ) -> Result<FormatForLlmOutput, FailureParserError>;
+
+    /// Generate a suggested fix for a single failure.
+    ///
+    /// Uses the source context to find similar symbols, check type signatures,
+    /// and generate actionable fix suggestions.
+    async fn suggest_fix(
+        &self,
+        input: SuggestFixInput,
+    ) -> Result<SuggestFixOutput, FailureParserError>;
+
+    /// Register a new parser in the parser registry.
+    ///
+    /// Allows runtime registration of custom parsers for new tools/languages.
+    async fn register_parser(
+        &self,
+        input: RegisterParserInput,
+    ) -> Result<RegisterParserResult, FailureParserError>;
+
+    /// Get the underlying parser registry for inspection.
+    fn parser_registry(&self) -> &ParserRegistry;
+}
+
+/// Trait for components that generate suggested fixes for failures.
+///
+/// This is the "Suggested Fix Generation" component referenced in the
+/// epic. It can be implemented as a standalone service or integrated
+/// into the FailureParserService.
+#[async_trait]
+pub trait FixSuggestionService: Send + Sync {
+    /// Generate a suggested fix for a single TemplateFailure.
+    ///
+    /// Cross-references the failure against the available source context
+    /// to produce actionable guidance.
+    async fn suggest_fix(
+        &self,
+        failure: &TemplateFailure,
+        source_context: &SourceContext,
+    ) -> Result<Option<String>, FailureParserError>;
+
+    /// Generate fixes for multiple failures at once (batched).
+    ///
+    /// More efficient than calling suggest_fix() individually when
+    /// there are many failures, as it can cache symbol lookups.
+    async fn suggest_fixes_batch(
+        &self,
+        failures: &[TemplateFailure],
+        source_context: &SourceContext,
+    ) -> Result<Vec<(usize, Option<String>)>, FailureParserError>;
+}

--- a/engine/src/failure_parser/domain/detail.rs
+++ b/engine/src/failure_parser/domain/detail.rs
@@ -1,0 +1,189 @@
+//! FailureDetail — individual error with location and suggestion.
+//!
+//! @canonical .pi/architecture/modules/failure-parser.md#detail
+//! Implements: Contract Freeze — FailureDetail struct
+//! Issue: #495
+//!
+//! # Contract (Frozen)
+//! - Pairs a TemplateFailure with a structured FailureDetail
+//! - Carries the suggested fix, severity, and classification metadata
+//! - Serialization support for eventing and API responses
+
+use serde::{Deserialize, Serialize};
+
+use super::failure::{SourceLocation, TemplateFailure};
+
+/// Individual parsed failure with full context.
+///
+/// Wraps a `TemplateFailure` with the suggested fix, severity
+/// classification, and raw error text for traceability.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FailureDetail {
+    /// The typed failure classification.
+    pub failure: TemplateFailure,
+
+    /// Human-readable suggested fix, if one could be determined.
+    /// This is the actionable guidance for LLM self-correction.
+    pub suggested_fix: Option<String>,
+
+    /// Severity classification of this failure.
+    pub severity: FailureSeverity,
+
+    /// The raw error line from the compiler/test output.
+    pub raw_line: String,
+
+    /// The source tool that produced this error (e.g., "tsc", "jest", "rustc").
+    pub source_tool: String,
+
+    /// Confidence that this parsing is correct (0.0–1.0).
+    pub confidence: f64,
+}
+
+impl FailureDetail {
+    /// Create a new FailureDetail.
+    pub fn new(
+        failure: TemplateFailure,
+        suggested_fix: Option<String>,
+        severity: FailureSeverity,
+        raw_line: String,
+        source_tool: impl Into<String>,
+        confidence: f64,
+    ) -> Self {
+        Self {
+            failure,
+            suggested_fix,
+            severity,
+            raw_line,
+            source_tool: source_tool.into(),
+            confidence,
+        }
+    }
+
+    /// Returns the source location from the underlying failure, if available.
+    pub fn location(&self) -> Option<SourceLocation> {
+        match &self.failure {
+            TemplateFailure::MissingSymbol { location, .. } => Some(location.clone()),
+            TemplateFailure::WrongArgCount { location, .. } => Some(location.clone()),
+            TemplateFailure::TypeMismatch { location, .. } => Some(location.clone()),
+            TemplateFailure::CompileError { location, .. } => Some(location.clone()),
+            TemplateFailure::AssertionFailure { location, .. } => Some(location.clone()),
+            TemplateFailure::TestFailure { location, .. } => location.clone(),
+        }
+    }
+
+    /// Returns a compact one-line representation for logging.
+    pub fn to_log_line(&self) -> String {
+        let loc = self.location();
+        let loc_str = loc
+            .as_ref()
+            .map(|l| l.to_compact())
+            .unwrap_or_default();
+        let fix = self
+            .suggested_fix
+            .as_deref()
+            .unwrap_or("no suggestion");
+        format!(
+            "[{}] {} (severity={:?}, confidence={:.2}) — fix: {}",
+            self.source_tool,
+            loc_str,
+            self.severity,
+            self.confidence,
+            fix
+        )
+    }
+}
+
+/// Severity classification for a parsed failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FailureSeverity {
+    /// Compile errors — template is syntactically invalid.
+    CompileBlock,
+    /// Test failures — template compiled but logic is wrong.
+    TestBlock,
+    /// Warnings — template works but has issues.
+    Warning,
+}
+
+impl FailureSeverity {
+    /// Returns the canonical snake_case name.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            FailureSeverity::CompileBlock => "compile_block",
+            FailureSeverity::TestBlock => "test_block",
+            FailureSeverity::Warning => "warning",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_failure_detail_new() {
+        let failure = TemplateFailure::MissingSymbol {
+            symbol: "addTask".into(),
+            available: vec!["add".into()],
+            suggestion: Some("Use 'add'".into()),
+            location: SourceLocation::new("test.ts", 3, Some(10)),
+        };
+        let detail = FailureDetail::new(
+            failure.clone(),
+            Some("Use 'add' instead".into()),
+            FailureSeverity::CompileBlock,
+            "error TS2339: Property 'addTask' does not exist".into(),
+            "tsc",
+            0.95,
+        );
+        assert_eq!(detail.failure, failure);
+        assert_eq!(detail.source_tool, "tsc");
+        assert_eq!(detail.severity, FailureSeverity::CompileBlock);
+    }
+
+    #[test]
+    fn test_failure_detail_location() {
+        let failure = TemplateFailure::MissingSymbol {
+            symbol: "x".into(),
+            available: vec![],
+            suggestion: None,
+            location: SourceLocation::new("test.ts", 1, None),
+        };
+        let detail = FailureDetail::new(
+            failure,
+            None,
+            FailureSeverity::CompileBlock,
+            "error".into(),
+            "tsc",
+            1.0,
+        );
+        assert_eq!(
+            detail.location(),
+            Some(SourceLocation::new("test.ts", 1, None))
+        );
+    }
+
+    #[test]
+    fn test_failure_detail_test_failure_location() {
+        let failure = TemplateFailure::TestFailure {
+            test_name: "test".into(),
+            message: "failed".into(),
+            location: None,
+        };
+        let detail = FailureDetail::new(
+            failure,
+            None,
+            FailureSeverity::TestBlock,
+            "FAIL".into(),
+            "jest",
+            1.0,
+        );
+        assert_eq!(detail.location(), None);
+    }
+
+    #[test]
+    fn test_severity_as_str() {
+        assert_eq!(FailureSeverity::CompileBlock.as_str(), "compile_block");
+        assert_eq!(FailureSeverity::TestBlock.as_str(), "test_block");
+        assert_eq!(FailureSeverity::Warning.as_str(), "warning");
+    }
+}

--- a/engine/src/failure_parser/domain/error.rs
+++ b/engine/src/failure_parser/domain/error.rs
@@ -1,0 +1,80 @@
+//! Failure parser error types.
+//!
+//! @canonical .pi/architecture/modules/failure-parser.md
+//! Implements: Contract Freeze — FailureParserError enum
+//! Issue: #495
+//!
+//! All errors use `thiserror` derive macros. No `anyhow` in library code.
+//!
+//! # Contract (Frozen)
+//! - `FailureParserError` is the single error type for this module
+//! - Each variant carries structured context for error reporting
+//! - Implements `std::error::Error` for library compatibility
+//! - Converted to `CoreOrchestratorError` via `#[from]` at the orchestrator level
+
+use thiserror::Error;
+
+/// Errors that can occur during failure parsing.
+#[derive(Debug, Error)]
+pub enum FailureParserError {
+    /// The raw output could not be parsed as expected (no matching patterns).
+    #[error("Parse failed for tool '{tool}': {reason}")]
+    ParseError {
+        /// The tool whose output failed to parse (e.g., "tsc", "jest").
+        tool: String,
+        /// Why parsing failed.
+        reason: String,
+        /// A snippet of the raw output that could not be parsed.
+        output_snippet: Option<String>,
+    },
+
+    /// The input format is not supported or could not be recognized.
+    #[error("Unrecognized output format: {detail}")]
+    UnrecognizedFormat {
+        /// Details about why the format is unrecognized.
+        detail: String,
+        /// The tool that produced the output.
+        tool: String,
+    },
+
+    /// The language/tool parser is not registered in the parser registry.
+    #[error("No parser registered for tool: {tool}")]
+    UnsupportedTool {
+        /// The tool name that has no registered parser.
+        tool: String,
+        /// List of available parsers.
+        available: Vec<String>,
+    },
+
+    /// Missing or empty output — nothing to parse.
+    #[error("No output to parse for tool '{tool}'")]
+    EmptyOutput {
+        /// The tool that produced empty output.
+        tool: String,
+    },
+
+    /// The source context could not be built (symbol extraction failed).
+    #[error("Source context error: {detail}")]
+    SourceContextError {
+        /// Details about the source context error.
+        detail: String,
+    },
+
+    /// A suggestion could not be generated.
+    #[error("Suggestion generation failed: {detail}")]
+    SuggestionFailed {
+        /// Details about why suggestion generation failed.
+        detail: String,
+    },
+}
+
+impl FailureParserError {
+    /// Returns `true` if this error is transient and the operation may succeed on retry.
+    pub fn is_retriable(&self) -> bool {
+        matches!(
+            self,
+            FailureParserError::ParseError { .. }
+                | FailureParserError::SourceContextError { .. }
+        )
+    }
+}

--- a/engine/src/failure_parser/domain/event/mod.rs
+++ b/engine/src/failure_parser/domain/event/mod.rs
@@ -1,0 +1,76 @@
+//! Event payload schemas for the Failure Parser bounded context.
+//!
+//! @canonical .pi/architecture/modules/failure-parser.md
+//! Implements: Contract Freeze — FailureParserEvent payload schemas
+//! Issue: #495
+//!
+//! These events are emitted on the `EventBus` whenever failures are parsed,
+//! suggestions are generated, or parsing errors occur. Consumers
+//! (audit, console printer, TUI) subscribe to these event types.
+//!
+//! # Contract (Frozen)
+//! - Each event carries the full context needed by consumers
+//! - No internal implementation details exposed
+//! - `sequence` is populated by EventBus at emission time
+
+use serde::{Deserialize, Serialize};
+
+use crate::failure_parser::domain::{ParsedFailure, TemplateFailure};
+
+/// Events emitted by the Failure Parser module.
+///
+/// Wrapped in `ExecutionEvent::FailureParser(...)` at the orchestration layer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum FailureParserEvent {
+    /// Raw compiler/test output was successfully parsed into structured failures.
+    OutputParsed {
+        /// The tool that produced the output (e.g., "tsc", "jest", "rustc").
+        tool: String,
+        /// The complete parsed result.
+        parsed: ParsedFailure,
+        /// Brief human-readable summary of the parse result.
+        summary: String,
+    },
+
+    /// The parser could not parse the output for a specific tool.
+    ParseFailed {
+        /// The tool that produced the output.
+        tool: String,
+        /// Why parsing failed.
+        reason: String,
+        /// Whether the parser fell back to a generic classification.
+        fell_back_to_default: bool,
+    },
+
+    /// A suggested fix was generated for a failure.
+    FixGenerated {
+        /// The failure the fix was generated for.
+        failure: TemplateFailure,
+        /// The generated fix suggestion.
+        suggestion: String,
+        /// The source tool.
+        tool: String,
+        /// Confidence in the fix suggestion (0.0–1.0).
+        confidence: f64,
+    },
+
+    /// Source context was built for suggestion generation.
+    SourceContextBuilt {
+        /// The tool being parsed.
+        tool: String,
+        /// Number of files scanned.
+        files_scanned: usize,
+        /// Number of symbols extracted.
+        symbols_found: usize,
+        /// Whether the context was truncated for performance.
+        truncated: bool,
+    },
+
+    /// A new parser was registered in the parser registry.
+    ParserRegistered {
+        /// The tool name the parser handles.
+        tool: String,
+        /// Number of parsers now in the registry.
+        total_parsers: usize,
+    },
+}

--- a/engine/src/failure_parser/domain/failure.rs
+++ b/engine/src/failure_parser/domain/failure.rs
@@ -1,0 +1,400 @@
+//! TemplateFailure — typed classification of template execution failures.
+//!
+//! @canonical .pi/architecture/modules/failure-parser.md#failure
+//! Implements: Contract Freeze — TemplateFailure enum, SourceLocation
+//! Issue: #495
+//!
+//! # Contract (Frozen)
+//! - Six mutually exclusive failure categories
+//! - Each variant carries structured context for LLM self-correction
+//! - Implements `Clone`, `Debug`, `PartialEq`, `Eq` for testability
+//! - Serialization support for eventing and API responses
+//! - SourceLocation is the canonical location type used throughout
+
+use serde::{Deserialize, Serialize};
+
+/// Typed classification of why a template execution failed.
+///
+/// Each variant carries structured context suitable for feeding back
+/// to the LLM for self-correction. Produced by `FailureParserService`
+/// implementations (TypeScriptParser, JestParser, RustcParser, etc.).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum TemplateFailure {
+    /// A symbol (function, method, class, variable) was referenced but doesn't exist.
+    MissingSymbol {
+        /// The symbol that was referenced but not found.
+        symbol: String,
+        /// Available symbols in the same scope, if determinable.
+        available: Vec<String>,
+        /// Suggested replacement, if one closely matches.
+        suggestion: Option<String>,
+        /// Where the error occurred.
+        location: SourceLocation,
+    },
+
+    /// Wrong number or type of arguments passed to a function/method.
+    WrongArgCount {
+        /// The function/method name.
+        function: String,
+        /// Expected number of arguments.
+        expected: usize,
+        /// Actual number of arguments provided.
+        actual: usize,
+        /// The call site.
+        location: SourceLocation,
+    },
+
+    /// A type mismatch error.
+    TypeMismatch {
+        /// Expected type.
+        expected: String,
+        /// Actual type.
+        actual: String,
+        /// Where the error occurred.
+        location: SourceLocation,
+    },
+
+    /// A compilation error that doesn't fit into more specific categories.
+    CompileError {
+        /// The compiler error code (e.g., TS2339, E0308).
+        code: String,
+        /// The error message.
+        message: String,
+        /// Where the error occurred.
+        location: SourceLocation,
+    },
+
+    /// A test assertion failure.
+    AssertionFailure {
+        /// The test name.
+        test_name: String,
+        /// Expected value.
+        expected: String,
+        /// Received value.
+        received: String,
+        /// Where the error occurred.
+        location: SourceLocation,
+    },
+
+    /// A generic test failure (test threw, timeout, etc.).
+    TestFailure {
+        /// The test name.
+        test_name: String,
+        /// The error message.
+        message: String,
+        /// Where the error occurred (may be None if location is unknown).
+        location: Option<SourceLocation>,
+    },
+}
+
+impl TemplateFailure {
+    /// Returns the canonical snake_case type name for this failure variant.
+    ///
+    /// Used for serialization tags, logging, and event payloads.
+    pub fn variant_name(&self) -> &'static str {
+        match self {
+            TemplateFailure::MissingSymbol { .. } => "missing_symbol",
+            TemplateFailure::WrongArgCount { .. } => "wrong_arg_count",
+            TemplateFailure::TypeMismatch { .. } => "type_mismatch",
+            TemplateFailure::CompileError { .. } => "compile_error",
+            TemplateFailure::AssertionFailure { .. } => "assertion_failure",
+            TemplateFailure::TestFailure { .. } => "test_failure",
+        }
+    }
+
+    /// Returns a human-readable one-line summary of this failure.
+    ///
+    /// Used for logging and LLM context summaries.
+    pub fn summary(&self) -> String {
+        match self {
+            TemplateFailure::MissingSymbol {
+                symbol, location, ..
+            } => {
+                format!(
+                    "MissingSymbol '{}' at {}:{}",
+                    symbol, location.file, location.line
+                )
+            }
+            TemplateFailure::WrongArgCount {
+                function,
+                expected,
+                actual,
+                location,
+            } => {
+                format!(
+                    "WrongArgCount '{}' at {}:{}: expected {} args, got {}",
+                    function, location.file, location.line, expected, actual
+                )
+            }
+            TemplateFailure::TypeMismatch {
+                expected,
+                actual,
+                location,
+            } => {
+                format!(
+                    "TypeMismatch at {}:{}: expected '{}', got '{}'",
+                    location.file, location.line, expected, actual
+                )
+            }
+            TemplateFailure::CompileError {
+                code, message, ..
+            } => {
+                format!("CompileError {}: {}", code, message)
+            }
+            TemplateFailure::AssertionFailure {
+                test_name,
+                expected,
+                received,
+                ..
+            } => {
+                format!(
+                    "AssertionFailure '{}': expected '{}', received '{}'",
+                    test_name, expected, received
+                )
+            }
+            TemplateFailure::TestFailure {
+                test_name, message, ..
+            } => {
+                format!("TestFailure '{}': {}", test_name, message)
+            }
+        }
+    }
+
+    /// Returns `true` if this failure type is eligible for automatic retry
+    /// after applying the suggested fix.
+    ///
+    /// MissingSymbol, WrongArgCount, and TypeMismatch are fixable.
+    /// CompileError may be fixable depending on context.
+    /// AssertionFailure and TestFailure typically require replanning.
+    pub fn is_fixable(&self) -> bool {
+        matches!(
+            self,
+            TemplateFailure::MissingSymbol { .. }
+                | TemplateFailure::WrongArgCount { .. }
+                | TemplateFailure::TypeMismatch { .. }
+        )
+    }
+}
+
+/// Location in source code where a failure occurred.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SourceLocation {
+    /// File path relative to project root.
+    pub file: String,
+    /// Line number (1-indexed).
+    pub line: usize,
+    /// Column number (1-indexed, optional for non-column-specific errors).
+    pub column: Option<usize>,
+}
+
+impl SourceLocation {
+    /// Create a new SourceLocation.
+    pub fn new(file: impl Into<String>, line: usize, column: Option<usize>) -> Self {
+        Self {
+            file: file.into(),
+            line,
+            column,
+        }
+    }
+
+    /// Format as `file:line:column` (or `file:line` if column is None).
+    pub fn to_compact(&self) -> String {
+        match self.column {
+            Some(col) => format!("{}:{}:{}", self.file, self.line, col),
+            None => format!("{}:{}", self.file, self.line),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_missing_symbol_variant_name() {
+        let f = TemplateFailure::MissingSymbol {
+            symbol: "addTask".into(),
+            available: vec!["add".into()],
+            suggestion: Some("Use 'add' instead of 'addTask'".into()),
+            location: SourceLocation::new("test.ts", 3, Some(10)),
+        };
+        assert_eq!(f.variant_name(), "missing_symbol");
+    }
+
+    #[test]
+    fn test_wrong_arg_count_variant_name() {
+        let f = TemplateFailure::WrongArgCount {
+            function: "add".into(),
+            expected: 2,
+            actual: 3,
+            location: SourceLocation::new("test.ts", 5, None),
+        };
+        assert_eq!(f.variant_name(), "wrong_arg_count");
+    }
+
+    #[test]
+    fn test_type_mismatch_variant_name() {
+        let f = TemplateFailure::TypeMismatch {
+            expected: "string".into(),
+            actual: "number".into(),
+            location: SourceLocation::new("test.ts", 10, Some(5)),
+        };
+        assert_eq!(f.variant_name(), "type_mismatch");
+    }
+
+    #[test]
+    fn test_compile_error_variant_name() {
+        let f = TemplateFailure::CompileError {
+            code: "TS2339".into(),
+            message: "Property does not exist".into(),
+            location: SourceLocation::new("test.ts", 3, Some(10)),
+        };
+        assert_eq!(f.variant_name(), "compile_error");
+    }
+
+    #[test]
+    fn test_assertion_failure_variant_name() {
+        let f = TemplateFailure::AssertionFailure {
+            test_name: "should add task".into(),
+            expected: "true".into(),
+            received: "false".into(),
+            location: SourceLocation::new("test.ts", 20, Some(1)),
+        };
+        assert_eq!(f.variant_name(), "assertion_failure");
+    }
+
+    #[test]
+    fn test_test_failure_variant_name() {
+        let f = TemplateFailure::TestFailure {
+            test_name: "should compile".into(),
+            message: "timeout".into(),
+            location: None,
+        };
+        assert_eq!(f.variant_name(), "test_failure");
+    }
+
+    #[test]
+    fn test_source_location_compact_with_column() {
+        let loc = SourceLocation::new("src/lib.ts", 42, Some(7));
+        assert_eq!(loc.to_compact(), "src/lib.ts:42:7");
+    }
+
+    #[test]
+    fn test_source_location_compact_without_column() {
+        let loc = SourceLocation::new("src/lib.ts", 42, None);
+        assert_eq!(loc.to_compact(), "src/lib.ts:42");
+    }
+
+    #[test]
+    fn test_is_fixable_missing_symbol() {
+        let f = TemplateFailure::MissingSymbol {
+            symbol: "x".into(),
+            available: vec![],
+            suggestion: None,
+            location: SourceLocation::new("test.ts", 1, None),
+        };
+        assert!(f.is_fixable());
+    }
+
+    #[test]
+    fn test_is_fixable_wrong_arg_count() {
+        let f = TemplateFailure::WrongArgCount {
+            function: "f".into(),
+            expected: 1,
+            actual: 2,
+            location: SourceLocation::new("test.ts", 1, None),
+        };
+        assert!(f.is_fixable());
+    }
+
+    #[test]
+    fn test_is_fixable_type_mismatch() {
+        let f = TemplateFailure::TypeMismatch {
+            expected: "string".into(),
+            actual: "number".into(),
+            location: SourceLocation::new("test.ts", 1, None),
+        };
+        assert!(f.is_fixable());
+    }
+
+    #[test]
+    fn test_is_fixable_compile_error() {
+        let f = TemplateFailure::CompileError {
+            code: "TS1005".into(),
+            message: "';' expected".into(),
+            location: SourceLocation::new("test.ts", 1, None),
+        };
+        assert!(!f.is_fixable());
+    }
+
+    #[test]
+    fn test_is_fixable_assertion_failure() {
+        let f = TemplateFailure::AssertionFailure {
+            test_name: "test".into(),
+            expected: "true".into(),
+            received: "false".into(),
+            location: SourceLocation::new("test.ts", 1, None),
+        };
+        assert!(!f.is_fixable());
+    }
+
+    #[test]
+    fn test_summary_missing_symbol() {
+        let f = TemplateFailure::MissingSymbol {
+            symbol: "addTask".into(),
+            available: vec!["add".into()],
+            suggestion: Some("Use 'add'".into()),
+            location: SourceLocation::new("src/test.ts", 3, Some(10)),
+        };
+        let s = f.summary();
+        assert!(s.contains("MissingSymbol"));
+        assert!(s.contains("addTask"));
+        assert!(s.contains("src/test.ts:3"));
+    }
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        let failures = vec![
+            TemplateFailure::MissingSymbol {
+                symbol: "x".into(),
+                available: vec![],
+                suggestion: None,
+                location: SourceLocation::new("test.ts", 1, None),
+            },
+            TemplateFailure::WrongArgCount {
+                function: "f".into(),
+                expected: 1,
+                actual: 2,
+                location: SourceLocation::new("test.ts", 2, Some(5)),
+            },
+            TemplateFailure::TypeMismatch {
+                expected: "string".into(),
+                actual: "number".into(),
+                location: SourceLocation::new("test.ts", 3, Some(1)),
+            },
+            TemplateFailure::CompileError {
+                code: "TS2339".into(),
+                message: "not found".into(),
+                location: SourceLocation::new("test.ts", 4, None),
+            },
+            TemplateFailure::AssertionFailure {
+                test_name: "t".into(),
+                expected: "a".into(),
+                received: "b".into(),
+                location: SourceLocation::new("test.ts", 5, Some(1)),
+            },
+            TemplateFailure::TestFailure {
+                test_name: "t".into(),
+                message: "timeout".into(),
+                location: None,
+            },
+        ];
+
+        for failure in &failures {
+            let json = serde_json::to_string(failure).unwrap();
+            let deserialized: TemplateFailure = serde_json::from_str(&json).unwrap();
+            assert_eq!(*failure, deserialized);
+        }
+    }
+}

--- a/engine/src/failure_parser/domain/input.rs
+++ b/engine/src/failure_parser/domain/input.rs
@@ -1,0 +1,115 @@
+//! CompilerOutput — raw compiler/test output wrapper.
+//!
+//! @canonical .pi/architecture/modules/failure-parser.md#input
+//! Implements: Contract Freeze — CompilerOutput struct
+//! Issue: #495
+//!
+//! # Contract (Frozen)
+//! - Wraps the raw stdout/stderr from a tool execution
+//! - Carries exit code and tool metadata for context-aware parsing
+//! - Serialization support for eventing and API responses
+
+use serde::{Deserialize, Serialize};
+
+/// Raw compiler or test runner output to be parsed.
+///
+/// This is the input to `FailureParserService::parse()`. It wraps
+/// the raw stdout/stderr along with metadata about the execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompilerOutput {
+    /// The raw stdout from the tool execution.
+    pub stdout: String,
+
+    /// The raw stderr from the tool execution (may be empty).
+    pub stderr: String,
+
+    /// The process exit code.
+    pub exit_code: i32,
+
+    /// The tool that produced this output (e.g., "tsc", "jest", "rustc", "pytest").
+    pub tool: String,
+
+    /// Working directory where the tool was executed (for resolving relative paths).
+    pub working_directory: String,
+}
+
+impl CompilerOutput {
+    /// Create a new CompilerOutput.
+    pub fn new(
+        stdout: impl Into<String>,
+        stderr: impl Into<String>,
+        exit_code: i32,
+        tool: impl Into<String>,
+        working_directory: impl Into<String>,
+    ) -> Self {
+        Self {
+            stdout: stdout.into(),
+            stderr: stderr.into(),
+            exit_code,
+            tool: tool.into(),
+            working_directory: working_directory.into(),
+        }
+    }
+
+    /// Returns `true` if the exit code indicates failure (non-zero).
+    pub fn is_failure(&self) -> bool {
+        self.exit_code != 0
+    }
+
+    /// Returns the combined stdout + stderr output.
+    pub fn combined(&self) -> String {
+        if self.stderr.is_empty() {
+            self.stdout.clone()
+        } else if self.stdout.is_empty() {
+            self.stderr.clone()
+        } else {
+            format!("{}\n{}", self.stdout, self.stderr)
+        }
+    }
+
+    /// Returns `true` if both stdout and stderr are empty.
+    pub fn is_empty(&self) -> bool {
+        self.stdout.is_empty() && self.stderr.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compiler_output_is_failure() {
+        let output = CompilerOutput::new("ok", "", 0, "tsc", "/project");
+        assert!(!output.is_failure());
+
+        let output = CompilerOutput::new("", "error", 1, "tsc", "/project");
+        assert!(output.is_failure());
+    }
+
+    #[test]
+    fn test_compiler_output_combined() {
+        let output = CompilerOutput::new("stdout", "stderr", 1, "tsc", "/project");
+        assert_eq!(output.combined(), "stdout\nstderr");
+    }
+
+    #[test]
+    fn test_compiler_output_combined_stdout_only() {
+        let output = CompilerOutput::new("stdout", "", 0, "tsc", "/project");
+        assert_eq!(output.combined(), "stdout");
+    }
+
+    #[test]
+    fn test_compiler_output_combined_stderr_only() {
+        let output = CompilerOutput::new("", "stderr", 1, "tsc", "/project");
+        assert_eq!(output.combined(), "stderr");
+    }
+
+    #[test]
+    fn test_compiler_output_is_empty() {
+        let output = CompilerOutput::new("", "", 0, "tsc", "/project");
+        assert!(output.is_empty());
+
+        let output = CompilerOutput::new("x", "", 0, "tsc", "/project");
+        assert!(!output.is_empty());
+    }
+}

--- a/engine/src/failure_parser/domain/mod.rs
+++ b/engine/src/failure_parser/domain/mod.rs
@@ -1,0 +1,34 @@
+//! Domain entities and interfaces for the Failure Parser bounded context.
+//!
+//! @canonical .pi/architecture/modules/failure-parser.md
+//! Implements: Contract Freeze — TemplateFailure, FailureDetail, CompilerOutput,
+//!              ParsedFailure, FailureParserError, FailureParserEvent, ParserRegistry
+//! Issue: #495
+//!
+//! This module defines the core domain types — `TemplateFailure`, `FailureDetail`,
+//! `CompilerOutput`, `ParsedFailure`, `FailureParserError`, and the `LanguageParser`
+//! trait for parser registry. These are pure domain objects with no framework
+//! dependencies. They serve as the frozen contract that all implementations
+//! must satisfy.
+//!
+//! # Contract Freeze
+//! - No implementation logic beyond enum variants, accessors, and constructors
+//! - All parsing orchestration logic must happen in the application layer
+//! - All persistence must happen behind repository interfaces
+//! - The TemplateFailure ↔ error code mapping is the core domain invariant
+
+pub mod detail;
+pub mod error;
+pub mod event;
+pub mod failure;
+pub mod input;
+pub mod output;
+pub mod registry;
+
+pub use detail::*;
+pub use error::FailureParserError;
+pub use event::*;
+pub use failure::*;
+pub use input::*;
+pub use output::*;
+pub use registry::*;

--- a/engine/src/failure_parser/domain/output.rs
+++ b/engine/src/failure_parser/domain/output.rs
@@ -1,0 +1,238 @@
+//! ParsedFailure — parsed result with all failures.
+//!
+//! @canonical .pi/architecture/modules/failure-parser.md#output
+//! Implements: Contract Freeze — ParsedFailure, SourceContext structs
+//! Issue: #495
+//!
+//! # Contract (Frozen)
+//! - Output container for the complete parse result
+//! - Carries the list of parsed failures and overall severity
+//! - SourceContext provides symbol information for suggestion generation
+//! - Serialization support for eventing and API responses
+
+use serde::{Deserialize, Serialize};
+
+use super::detail::{FailureDetail, FailureSeverity};
+
+/// The complete result of parsing compiler/test output.
+///
+/// Returned by `FailureParserService::parse()`. Contains the list of
+/// parsed failure details and an overall severity classification.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ParsedFailure {
+    /// Individual parsed failure details.
+    pub failures: Vec<FailureDetail>,
+
+    /// Overall severity of the entire failure set.
+    pub overall_severity: FailureSeverity,
+
+    /// Total number of failures found.
+    pub total_count: usize,
+
+    /// Number of fixable failures (where a suggestion was generated).
+    pub fixable_count: usize,
+
+    /// The source tool that produced the original output.
+    pub source_tool: String,
+}
+
+impl ParsedFailure {
+    /// Create a new ParsedFailure from a list of FailureDetail items.
+    ///
+    /// Automatically computes overall_severity, total_count, and fixable_count.
+    pub fn from_failures(failures: Vec<FailureDetail>, source_tool: impl Into<String>) -> Self {
+        let total_count = failures.len();
+        let fixable_count = failures
+            .iter()
+            .filter(|d| d.suggested_fix.is_some())
+            .count();
+        let overall_severity = Self::compute_overall_severity(&failures);
+
+        Self {
+            failures,
+            overall_severity,
+            total_count,
+            fixable_count,
+            source_tool: source_tool.into(),
+        }
+    }
+
+    /// Returns `true` if there are no failures.
+    pub fn is_clean(&self) -> bool {
+        self.failures.is_empty()
+    }
+
+    /// Returns true if all failures have suggested fixes.
+    pub fn all_fixable(&self) -> bool {
+        self.fixable_count == self.total_count && self.total_count > 0
+    }
+
+    /// Compute the overall severity from a list of failure details.
+    ///
+    /// CompileBlock > TestBlock > Warning.
+    fn compute_overall_severity(failures: &[FailureDetail]) -> FailureSeverity {
+        for detail in failures {
+            if detail.severity == FailureSeverity::CompileBlock {
+                return FailureSeverity::CompileBlock;
+            }
+        }
+        for detail in failures {
+            if detail.severity == FailureSeverity::TestBlock {
+                return FailureSeverity::TestBlock;
+            }
+        }
+        if failures.is_empty() {
+            FailureSeverity::Warning
+        } else {
+            FailureSeverity::Warning
+        }
+    }
+}
+
+/// Context about the source code available for suggestion generation.
+///
+/// Provided to parsers so they can cross-reference error symbols
+/// against the actual source code to generate meaningful fix suggestions.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SourceContext {
+    /// Available symbols keyed by file path (relative to project root).
+    /// The map value is a list of symbol names (function names, method names, type names).
+    pub symbols_by_file: std::collections::HashMap<String, Vec<String>>,
+
+    /// Full source content keyed by file path, for context-aware suggestions.
+    /// Limited to files in the immediate error scope for performance.
+    pub source_by_file: std::collections::HashMap<String, String>,
+}
+
+impl SourceContext {
+    /// Create a new empty SourceContext.
+    pub fn empty() -> Self {
+        Self {
+            symbols_by_file: std::collections::HashMap::new(),
+            source_by_file: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Get symbols available in a specific file.
+    pub fn symbols_in_file(&self, file: &str) -> Vec<String> {
+        self.symbols_by_file
+            .get(file)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Get source content for a specific file.
+    pub fn source_for_file(&self, file: &str) -> Option<&str> {
+        self.source_by_file.get(file).map(|s| s.as_str())
+    }
+
+    /// Returns `true` if this context has any symbols or source content.
+    pub fn has_content(&self) -> bool {
+        !self.symbols_by_file.is_empty() || !self.source_by_file.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::failure_parser::domain::failure::{SourceLocation, TemplateFailure};
+
+    fn make_detail(suggestion: Option<&str>, severity: FailureSeverity) -> FailureDetail {
+        FailureDetail::new(
+            TemplateFailure::MissingSymbol {
+                symbol: "x".into(),
+                available: vec![],
+                suggestion: None,
+                location: SourceLocation::new("test.ts", 1, None),
+            },
+            suggestion.map(|s| s.to_string()),
+            severity,
+            "error".into(),
+            "tsc",
+            1.0,
+        )
+    }
+
+    #[test]
+    fn test_parsed_failure_empty() {
+        let parsed = ParsedFailure::from_failures(vec![], "tsc");
+        assert!(parsed.is_clean());
+        assert_eq!(parsed.total_count, 0);
+        assert_eq!(parsed.fixable_count, 0);
+    }
+
+    #[test]
+    fn test_parsed_failure_with_failures() {
+        let failures = vec![
+            make_detail(Some("fix 1"), FailureSeverity::CompileBlock),
+            make_detail(None, FailureSeverity::TestBlock),
+            make_detail(Some("fix 2"), FailureSeverity::Warning),
+        ];
+        let parsed = ParsedFailure::from_failures(failures, "tsc");
+        assert!(!parsed.is_clean());
+        assert_eq!(parsed.total_count, 3);
+        assert_eq!(parsed.fixable_count, 2);
+        assert_eq!(parsed.overall_severity, FailureSeverity::CompileBlock);
+    }
+
+    #[test]
+    fn test_parsed_failure_overall_severity_compile_block_wins() {
+        let failures = vec![
+            make_detail(None, FailureSeverity::Warning),
+            make_detail(None, FailureSeverity::CompileBlock),
+            make_detail(None, FailureSeverity::TestBlock),
+        ];
+        let parsed = ParsedFailure::from_failures(failures, "tsc");
+        assert_eq!(parsed.overall_severity, FailureSeverity::CompileBlock);
+    }
+
+    #[test]
+    fn test_parsed_failure_overall_severity_test_block() {
+        let failures = vec![
+            make_detail(None, FailureSeverity::Warning),
+            make_detail(None, FailureSeverity::TestBlock),
+        ];
+        let parsed = ParsedFailure::from_failures(failures, "jest");
+        assert_eq!(parsed.overall_severity, FailureSeverity::TestBlock);
+    }
+
+    #[test]
+    fn test_source_context_empty() {
+        let ctx = SourceContext::empty();
+        assert!(!ctx.has_content());
+        assert!(ctx.symbols_in_file("test.ts").is_empty());
+    }
+
+    #[test]
+    fn test_source_context_with_symbols() {
+        let mut ctx = SourceContext::empty();
+        ctx.symbols_by_file
+            .insert("test.ts".into(), vec!["add".into(), "remove".into()]);
+        ctx.source_by_file
+            .insert("test.ts".into(), "content".into());
+
+        assert!(ctx.has_content());
+        assert_eq!(ctx.symbols_in_file("test.ts"), vec!["add", "remove"]);
+        assert_eq!(ctx.source_for_file("test.ts"), Some("content"));
+    }
+
+    #[test]
+    fn test_all_fixable() {
+        let failures = vec![
+            make_detail(Some("fix"), FailureSeverity::CompileBlock),
+            make_detail(Some("fix"), FailureSeverity::TestBlock),
+        ];
+        let parsed = ParsedFailure::from_failures(failures, "tsc");
+        assert!(parsed.all_fixable());
+    }
+
+    #[test]
+    fn test_not_all_fixable() {
+        let failures = vec![
+            make_detail(Some("fix"), FailureSeverity::CompileBlock),
+            make_detail(None, FailureSeverity::TestBlock),
+        ];
+        let parsed = ParsedFailure::from_failures(failures, "tsc");
+        assert!(!parsed.all_fixable());
+    }
+}

--- a/engine/src/failure_parser/domain/registry.rs
+++ b/engine/src/failure_parser/domain/registry.rs
@@ -1,0 +1,181 @@
+//! ParserRegistry — extensible parser registry for failure parsing.
+//!
+//! @canonical .pi/architecture/modules/failure-parser.md#registry
+//! Implements: Contract Freeze — LanguageParser trait, ParserRegistry struct
+//! Issue: #495
+//!
+//! # Contract (Frozen)
+//! - LanguageParser trait is the parser interface for all language/tool parsers
+//! - ParserRegistry manages a dynamic registry of parsers by tool name
+//! - Built-in parsers: TypeScriptParser, JestParser, RustcParser, PytestParser
+//! - Custom parsers can be registered at runtime
+
+use async_trait::async_trait;
+
+use crate::failure_parser::domain::{FailureParserError, ParsedFailure, SourceContext};
+
+/// Trait for language/tool-specific parsers.
+///
+/// Each parser implementation handles one specific tool's output format
+/// and converts it into structured `TemplateFailure` values.
+///
+/// Built-in implementations:
+/// - `TypeScriptParser` → tool name "tsc"
+/// - `JestParser` → tool name "jest"
+/// - `RustcParser` → tool name "rustc"
+/// - `PytestParser` → tool name "pytest"
+#[async_trait]
+pub trait LanguageParser: Send + Sync {
+    /// The name of the tool this parser handles (e.g., "tsc", "jest", "rustc", "pytest").
+    fn tool_name(&self) -> &str;
+
+    /// Parse the raw output and return structured failures.
+    ///
+    /// If the output is clean (no failures), returns an empty `ParsedFailure`.
+    /// If the output format is unrecognized, returns a `FailureParserError`.
+    async fn parse(
+        &self,
+        output: &str,
+        source_context: &SourceContext,
+    ) -> Result<ParsedFailure, FailureParserError>;
+
+    /// Returns `true` if this parser can handle the given tool name.
+    fn supports_tool(&self, tool: &str) -> bool {
+        self.tool_name() == tool
+    }
+}
+
+/// Registry of language/tool parsers.
+///
+/// Maintains a mapping of tool names to parser implementations.
+/// New parsers can be registered at runtime using `register()`.
+///
+/// Built-in parsers are registered at startup:
+/// - TypeScriptParser → "tsc"
+/// - JestParser → "jest"
+/// - RustcParser → "rustc"
+/// - PytestParser → "pytest"
+pub struct ParserRegistry {
+    /// Registered parsers keyed by tool name.
+    parsers: std::collections::HashMap<String, Box<dyn LanguageParser>>,
+}
+
+impl ParserRegistry {
+    /// Create a new empty ParserRegistry.
+    pub fn new() -> Self {
+        Self {
+            parsers: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Register a parser for a specific tool.
+    ///
+    /// If a parser is already registered for this tool, it is replaced.
+    /// Emits `FailureParserEvent::ParserRegistered` if event bus is available.
+    pub fn register(&mut self, parser: Box<dyn LanguageParser>) {
+        let tool = parser.tool_name().to_string();
+        self.parsers.insert(tool, parser);
+    }
+
+    /// Get the parser for a specific tool.
+    ///
+    /// Returns `None` if no parser is registered for this tool.
+    pub fn get(&self, tool: &str) -> Option<&dyn LanguageParser> {
+        self.parsers.get(tool).map(|p| p.as_ref())
+    }
+
+    /// Returns `true` if a parser is registered for the given tool.
+    pub fn has_parser(&self, tool: &str) -> bool {
+        self.parsers.contains_key(tool)
+    }
+
+    /// Returns the list of all registered tool names.
+    pub fn available_tools(&self) -> Vec<String> {
+        let mut tools: Vec<String> = self.parsers.keys().cloned().collect();
+        tools.sort();
+        tools
+    }
+
+    /// Returns the number of registered parsers.
+    pub fn len(&self) -> usize {
+        self.parsers.len()
+    }
+
+    /// Returns `true` if no parsers are registered.
+    pub fn is_empty(&self) -> bool {
+        self.parsers.is_empty()
+    }
+}
+
+impl Default for ParserRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A mock parser for testing.
+    struct MockParser {
+        tool: String,
+    }
+
+    #[async_trait]
+    impl LanguageParser for MockParser {
+        fn tool_name(&self) -> &str {
+            &self.tool
+        }
+
+        async fn parse(
+            &self,
+            _output: &str,
+            _source_context: &SourceContext,
+        ) -> Result<ParsedFailure, FailureParserError> {
+            Ok(ParsedFailure::from_failures(vec![], &self.tool))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_parser_registry_register_and_get() {
+        let mut registry = ParserRegistry::new();
+        let parser = MockParser {
+            tool: "tsc".to_string(),
+        };
+        registry.register(Box::new(parser));
+        assert!(registry.has_parser("tsc"));
+        assert!(!registry.has_parser("jest"));
+    }
+
+    #[tokio::test]
+    async fn test_parser_registry_available_tools() {
+        let mut registry = ParserRegistry::new();
+        registry.register(Box::new(MockParser {
+            tool: "rustc".to_string(),
+        }));
+        registry.register(Box::new(MockParser {
+            tool: "tsc".to_string(),
+        }));
+        let tools = registry.available_tools();
+        assert_eq!(tools.len(), 2);
+        assert!(tools.contains(&"tsc".to_string()));
+        assert!(tools.contains(&"rustc".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_parser_registry_empty() {
+        let registry = ParserRegistry::new();
+        assert!(registry.is_empty());
+        assert_eq!(registry.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_parser_supports_tool() {
+        let parser = MockParser {
+            tool: "jest".to_string(),
+        };
+        assert!(parser.supports_tool("jest"));
+        assert!(!parser.supports_tool("tsc"));
+    }
+}

--- a/engine/src/failure_parser/infrastructure/mod.rs
+++ b/engine/src/failure_parser/infrastructure/mod.rs
@@ -1,0 +1,13 @@
+//! Infrastructure layer for the Failure Parser bounded context.
+//!
+//! @canonical .pi/architecture/modules/failure-parser.md
+//! Implements: Contract Freeze — repository interfaces
+//! Issue: #495
+//!
+//! # Contract (Frozen)
+//! - All repository methods are async
+//! - All methods return domain error types
+//! - No framework-specific annotations on trait definitions
+//! - Implementations are hidden behind these interfaces
+
+pub mod repository;

--- a/engine/src/failure_parser/infrastructure/repository/mod.rs
+++ b/engine/src/failure_parser/infrastructure/repository/mod.rs
@@ -1,0 +1,92 @@
+//! Repository interfaces for the Failure Parser bounded context.
+//!
+//! @canonical .pi/architecture/modules/failure-parser.md
+//! Implements: Contract Freeze — ParserConfigRepository, FailureLogRepository traits
+//! Issue: #495
+//!
+//! Repositories abstract data access behind interfaces, allowing
+//! implementations to use filesystem, environment, or mock storage
+//! without coupling domain logic to infrastructure.
+//!
+//! # Contract (Frozen)
+//! - All repository methods are async
+//! - All methods return domain error types
+//! - No framework-specific annotations on trait definitions
+//! - Implementations are hidden behind these interfaces
+
+use async_trait::async_trait;
+
+use crate::failure_parser::domain::{FailureParserError, TemplateFailure};
+
+/// Repository for storing and retrieving parser configuration.
+///
+/// Supports custom parser registrations and tool-specific settings
+/// that persist across sessions.
+#[async_trait]
+pub trait ParserConfigRepository: Send + Sync {
+    /// Store a custom tool-to-parser mapping.
+    ///
+    /// Allows users to register custom parsers for tools that are not
+    /// natively supported.
+    async fn store_custom_parser(
+        &self,
+        tool: &str,
+        parser_type: &str,
+    ) -> Result<(), FailureParserError>;
+
+    /// Retrieve the parser type for a given tool.
+    ///
+    /// Returns `None` if no custom parser is configured for this tool.
+    async fn get_custom_parser(
+        &self,
+        tool: &str,
+    ) -> Result<Option<String>, FailureParserError>;
+
+    /// Retrieve all custom parser registrations.
+    ///
+    /// Returns a map of tool → parser_type.
+    async fn get_all_custom_parsers(
+        &self,
+    ) -> Result<std::collections::HashMap<String, String>, FailureParserError>;
+
+    /// Remove a custom parser registration.
+    async fn remove_custom_parser(&self, tool: &str) -> Result<bool, FailureParserError>;
+}
+
+/// Repository for persisting parse results (for audit/replay).
+///
+/// Optional — only needed if parsing traceability is required
+/// for debugging and quality monitoring.
+#[async_trait]
+pub trait FailureLogRepository: Send + Sync {
+    /// Record a parsed failure for audit.
+    async fn record_failure(
+        &self,
+        tool: &str,
+        failure: &TemplateFailure,
+    ) -> Result<(), FailureParserError>;
+
+    /// Record a batch of parsed failures.
+    async fn record_failures_batch(
+        &self,
+        tool: &str,
+        failures: &[TemplateFailure],
+    ) -> Result<(), FailureParserError>;
+
+    /// Get recent failure history for a given tool.
+    ///
+    /// Returns the most recent `limit` entries.
+    async fn get_recent_failures(
+        &self,
+        tool: &str,
+        limit: usize,
+    ) -> Result<Vec<(String, TemplateFailure)>, FailureParserError>;
+
+    /// Get failure frequency statistics for a tool.
+    ///
+    /// Returns a map of failure variant name → count.
+    async fn get_failure_stats(
+        &self,
+        tool: &str,
+    ) -> Result<std::collections::HashMap<String, usize>, FailureParserError>;
+}

--- a/engine/src/failure_parser/interfaces/http/mod.rs
+++ b/engine/src/failure_parser/interfaces/http/mod.rs
@@ -1,0 +1,443 @@
+//! HTTP API contracts for Failure Parser endpoints.
+//!
+//! @canonical .pi/architecture/modules/failure-parser.md
+//! Implements: Contract Freeze — HTTP endpoint contracts and error formats
+//! Issue: #495
+//!
+//! Defines endpoint paths, methods, request/response schemas, and error
+//! response formats. These contracts are framework-agnostic — they describe
+//! the API surface that any HTTP server implementation must satisfy.
+//!
+//! # Contract (Frozen)
+//! - All endpoints documented with method, path, request, and response types
+//! - Error responses follow a unified format
+//! - No framework-specific annotations (axum/actix/warp annotations added by implementation)
+
+use serde::{Deserialize, Serialize};
+
+use crate::failure_parser::application::dto::{
+    ClassifySeverityInput, ClassifySeverityOutput, FormatForLlmInput, FormatForLlmOutput,
+    ListParsersResult, ParseOutputInput, ParseOutputResult, ParserMetadata, RegisterParserInput,
+    RegisterParserResult, SuggestFixInput, SuggestFixOutput,
+};
+
+use crate::failure_parser::domain::{
+    FailureDetail,
+    TemplateFailure,
+    SourceContext,
+};
+
+// ---------------------------------------------------------------------------
+// API Base Path
+// ---------------------------------------------------------------------------
+
+/// All failure parser endpoints are served under this base path.
+pub const API_BASE_PATH: &str = "/api/v1/failure-parser";
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/failure-parser/parse
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/failure-parser/parse
+///
+/// Parse raw compiler/test output into structured failures.
+///
+/// **Request:** `ParseRequest`
+/// **Response:** `200 OK` with `ParseResponse`
+pub const PARSE_PATH: &str = "/api/v1/failure-parser/parse";
+pub const PARSE_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/failure-parser/parse.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParseRequest {
+    /// The tool that produced the output (e.g., "tsc", "jest", "rustc", "pytest").
+    pub tool: String,
+    /// The raw stdout from the tool execution.
+    pub stdout: String,
+    /// The raw stderr from the tool execution.
+    pub stderr: String,
+    /// The process exit code.
+    pub exit_code: i32,
+    /// Available source context for suggestion generation.
+    pub source_context: SourceContext,
+    /// Working directory where the tool was executed.
+    pub working_directory: String,
+}
+
+impl From<ParseRequest> for ParseOutputInput {
+    fn from(req: ParseRequest) -> Self {
+        Self {
+            tool: req.tool,
+            stdout: req.stdout,
+            stderr: req.stderr,
+            exit_code: req.exit_code,
+            source_context: req.source_context,
+            working_directory: req.working_directory,
+        }
+    }
+}
+
+/// Response body for POST /api/v1/failure-parser/parse.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParseResponse {
+    pub success: bool,
+    pub parsed: ParseOutputResult,
+}
+
+impl From<ParseOutputResult> for ParseResponse {
+    fn from(result: ParseOutputResult) -> Self {
+        Self {
+            success: result.success,
+            parsed: result,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/failure-parser/suggest-fix
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/failure-parser/suggest-fix
+///
+/// Generate a suggested fix for a specific failure.
+///
+/// **Request:** `SuggestFixRequest`
+/// **Response:** `200 OK` with `SuggestFixResponse`
+pub const SUGGEST_FIX_PATH: &str = "/api/v1/failure-parser/suggest-fix";
+pub const SUGGEST_FIX_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/failure-parser/suggest-fix.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SuggestFixRequest {
+    /// The failure to generate a fix for (as JSON with type tag).
+    pub failure: TemplateFailure,
+    /// Available source context.
+    pub source_context: SourceContext,
+    /// Minimum confidence threshold.
+    #[serde(default = "default_min_confidence")]
+    pub min_confidence: f64,
+}
+
+fn default_min_confidence() -> f64 {
+    0.5
+}
+
+impl From<SuggestFixRequest> for SuggestFixInput {
+    fn from(req: SuggestFixRequest) -> Self {
+        Self {
+            failure: req.failure,
+            source_context: req.source_context,
+            min_confidence: req.min_confidence,
+        }
+    }
+}
+
+/// Response body for POST /api/v1/failure-parser/suggest-fix.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SuggestFixResponse {
+    pub success: bool,
+    pub suggestion: Option<String>,
+    pub confidence: f64,
+    pub rationale: Option<String>,
+}
+
+impl From<SuggestFixOutput> for SuggestFixResponse {
+    fn from(output: SuggestFixOutput) -> Self {
+        Self {
+            success: output.suggestion.is_some(),
+            suggestion: output.suggestion,
+            confidence: output.confidence,
+            rationale: output.rationale,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: GET /api/v1/failure-parser/parsers
+// ---------------------------------------------------------------------------
+
+/// GET /api/v1/failure-parser/parsers
+///
+/// List all registered parsers.
+///
+/// **Response:** `200 OK` with `ListParsersResponse`
+pub const LIST_PARSERS_PATH: &str = "/api/v1/failure-parser/parsers";
+pub const LIST_PARSERS_METHOD: &str = "GET";
+
+/// Response body for GET /api/v1/failure-parser/parsers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListParsersResponse {
+    pub parsers: Vec<ParserMetadata>,
+    pub total: usize,
+}
+
+impl From<ListParsersResult> for ListParsersResponse {
+    fn from(result: ListParsersResult) -> Self {
+        Self {
+            parsers: result.parsers,
+            total: result.total,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/failure-parser/register-parser
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/failure-parser/register-parser
+///
+/// Register a new parser for a tool.
+///
+/// **Request:** `RegisterParserRequest`
+/// **Response:** `200 OK` with `RegisterParserResponse`
+pub const REGISTER_PARSER_PATH: &str = "/api/v1/failure-parser/register-parser";
+pub const REGISTER_PARSER_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/failure-parser/register-parser.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegisterParserRequest {
+    /// The tool name this parser handles.
+    pub tool: String,
+    /// Human-readable description.
+    pub description: String,
+}
+
+impl From<RegisterParserRequest> for RegisterParserInput {
+    fn from(req: RegisterParserRequest) -> Self {
+        Self {
+            tool: req.tool,
+            description: req.description,
+        }
+    }
+}
+
+/// Response body for POST /api/v1/failure-parser/register-parser.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegisterParserResponse {
+    pub success: bool,
+    pub total_parsers: usize,
+    pub message: String,
+}
+
+impl From<RegisterParserResult> for RegisterParserResponse {
+    fn from(result: RegisterParserResult) -> Self {
+        Self {
+            success: result.success,
+            total_parsers: result.total_parsers,
+            message: result.message,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/failure-parser/format-for-llm
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/failure-parser/format-for-llm
+///
+/// Format failures into a human-readable summary for LLM consumption.
+///
+/// **Request:** `FormatForLlmRequest`
+/// **Response:** `200 OK` with `FormatForLlmResponse`
+pub const FORMAT_FOR_LLM_PATH: &str = "/api/v1/failure-parser/format-for-llm";
+pub const FORMAT_FOR_LLM_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/failure-parser/format-for-llm.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FormatForLlmRequest {
+    /// The failures to format.
+    pub failures: Vec<TemplateFailure>,
+    /// Optional title.
+    pub title: Option<String>,
+}
+
+impl From<FormatForLlmRequest> for FormatForLlmInput {
+    fn from(req: FormatForLlmRequest) -> Self {
+        Self {
+            failures: req.failures,
+            title: req.title,
+        }
+    }
+}
+
+/// Response body for POST /api/v1/failure-parser/format-for-llm.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FormatForLlmResponse {
+    pub formatted: String,
+    pub count: usize,
+}
+
+impl From<FormatForLlmOutput> for FormatForLlmResponse {
+    fn from(output: FormatForLlmOutput) -> Self {
+        Self {
+            formatted: output.formatted,
+            count: output.count,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/failure-parser/classify-severity
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/failure-parser/classify-severity
+///
+/// Classify the overall severity of a set of failures.
+///
+/// **Request:** `ClassifySeverityRequest`
+/// **Response:** `200 OK` with `ClassifySeverityResponse`
+pub const CLASSIFY_SEVERITY_PATH: &str = "/api/v1/failure-parser/classify-severity";
+pub const CLASSIFY_SEVERITY_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/failure-parser/classify-severity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClassifySeverityRequest {
+    /// The failure details to classify.
+    pub failures: Vec<FailureDetail>,
+}
+
+impl From<ClassifySeverityRequest> for ClassifySeverityInput {
+    fn from(req: ClassifySeverityRequest) -> Self {
+        Self { failures: req.failures }
+    }
+}
+
+/// Response body for POST /api/v1/failure-parser/classify-severity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClassifySeverityResponse {
+    pub overall_severity: String,
+    pub compile_blocks: usize,
+    pub test_blocks: usize,
+    pub warnings: usize,
+}
+
+impl From<ClassifySeverityOutput> for ClassifySeverityResponse {
+    fn from(output: ClassifySeverityOutput) -> Self {
+        Self {
+            overall_severity: output.overall_severity,
+            compile_blocks: output.compile_blocks,
+            test_blocks: output.test_blocks,
+            warnings: output.warnings,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unified Error Response Format
+// ---------------------------------------------------------------------------
+
+/// Standard error response for all Failure Parser API endpoints.
+///
+/// All 4xx/5xx responses use this format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiErrorResponse {
+    /// HTTP status code.
+    pub status: u16,
+    /// Machine-readable error code.
+    pub code: String,
+    /// Human-readable error message.
+    pub message: String,
+    /// Detailed error context (optional, may include field-level errors).
+    pub details: Option<serde_json::Value>,
+    /// Request ID for tracing (if available).
+    pub request_id: Option<String>,
+}
+
+/// Standardized error codes for Failure Parser API.
+pub mod error_codes {
+    /// Parsing failed — no matching patterns found.
+    pub const PARSE_ERROR: &str = "PARSE_ERROR";
+    /// The output format was not recognized.
+    pub const UNRECOGNIZED_FORMAT: &str = "UNRECOGNIZED_FORMAT";
+    /// No parser registered for the given tool.
+    pub const UNSUPPORTED_TOOL: &str = "UNSUPPORTED_TOOL";
+    /// Empty output provided.
+    pub const EMPTY_OUTPUT: &str = "EMPTY_OUTPUT";
+    /// Source context could not be built.
+    pub const SOURCE_CONTEXT_ERROR: &str = "SOURCE_CONTEXT_ERROR";
+    /// Suggestion generation failed.
+    pub const SUGGESTION_FAILED: &str = "SUGGESTION_FAILED";
+    /// Internal server error.
+    pub const INTERNAL_ERROR: &str = "INTERNAL_ERROR";
+}
+
+/// HTTP status code mappings for Failure Parser errors.
+pub mod status_codes {
+    pub const PARSE_ERROR: u16 = 422;
+    pub const UNRECOGNIZED_FORMAT: u16 = 422;
+    pub const UNSUPPORTED_TOOL: u16 = 400;
+    pub const EMPTY_OUTPUT: u16 = 400;
+    pub const SOURCE_CONTEXT_ERROR: u16 = 500;
+    pub const SUGGESTION_FAILED: u16 = 500;
+    pub const INTERNAL_ERROR: u16 = 500;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::failure_parser::domain::SourceLocation;
+
+    #[test]
+    fn test_parse_request_roundtrip() {
+        let req = ParseRequest {
+            tool: "tsc".into(),
+            stdout: "error TS2339".into(),
+            stderr: String::new(),
+            exit_code: 2,
+            source_context: SourceContext::empty(),
+            working_directory: "/project".into(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let deserialized: ParseRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.tool, "tsc");
+        assert_eq!(deserialized.exit_code, 2);
+    }
+
+    #[test]
+    fn test_parse_request_to_input() {
+        let req = ParseRequest {
+            tool: "tsc".into(),
+            stdout: "output".into(),
+            stderr: String::new(),
+            exit_code: 2,
+            source_context: SourceContext::empty(),
+            working_directory: "/project".into(),
+        };
+        let input: ParseOutputInput = req.into();
+        assert_eq!(input.tool, "tsc");
+        assert_eq!(input.exit_code, 2);
+    }
+
+    #[test]
+    fn test_api_error_response() {
+        let err = ApiErrorResponse {
+            status: 422,
+            code: "PARSE_ERROR".into(),
+            message: "Could not parse output".into(),
+            details: None,
+            request_id: Some("req-123".into()),
+        };
+        let json = serde_json::to_string(&err).unwrap();
+        let deserialized: ApiErrorResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.status, 422);
+        assert_eq!(deserialized.code, "PARSE_ERROR");
+        assert_eq!(deserialized.request_id, Some("req-123".into()));
+    }
+
+    #[test]
+    fn test_suggest_fix_request_default_confidence() {
+        let req = SuggestFixRequest {
+            failure: TemplateFailure::MissingSymbol {
+                symbol: "x".into(),
+                available: vec![],
+                suggestion: None,
+                location: SourceLocation::new("test.ts", 1, None),
+            },
+            source_context: SourceContext::empty(),
+            min_confidence: 0.5,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let deserialized: SuggestFixRequest = serde_json::from_str(&json).unwrap();
+        assert!((deserialized.min_confidence - 0.5).abs() < 1e-10);
+    }
+}

--- a/engine/src/failure_parser/interfaces/mod.rs
+++ b/engine/src/failure_parser/interfaces/mod.rs
@@ -1,0 +1,10 @@
+//! Interface adapters for the Failure Parser bounded context.
+//!
+//! @canonical .pi/architecture/modules/failure-parser.md
+//! Implements: Contract Freeze — HTTP API contracts
+//! Issue: #495
+//!
+//! Defines framework-agnostic API contracts that describe the
+//! external interface surface of the failure parser module.
+
+pub mod http;

--- a/engine/src/failure_parser/mod.rs
+++ b/engine/src/failure_parser/mod.rs
@@ -1,0 +1,49 @@
+//! Failure Parser bounded context.
+//!
+//! @canonical .pi/architecture/modules/failure-parser.md
+//! Implements: Contract Freeze — failure-parser
+//! Issue: #495 (#494 epic)
+//!
+//! This module parses raw compiler, test runner, and linter output into
+//! structured, typed `TemplateFailure` values. Each failure carries precise
+//! location context (file, line, column), a machine-readable error code, and
+//! a suggested fix derived from the available source code context.
+//!
+//! This is the bridge between "something failed" and "here's exactly what to
+//! change." The parser enables the validation loop to feed actionable feedback
+//! back to the LLM for self-correction.
+//!
+//! # Architecture
+//!
+//! ```text
+//! failure_parser/
+//! ├── domain/                # Domain entities (TemplateFailure, FailureDetail, etc.), errors, events
+//! │   ├── failure.rs         # TemplateFailure enum (6 categories)
+//! │   ├── detail.rs          # FailureDetail with location, suggestion, severity
+//! │   ├── input.rs           # CompilerOutput — raw stdout/stderr wrapper
+//! │   ├── output.rs          # ParsedFailure, SourceContext
+//! │   ├── error.rs           # FailureParserError enum
+//! │   ├── registry.rs        # LanguageParser trait + ParserRegistry
+//! │   └── event/             # FailureParserEvent payload schemas
+//! ├── application/           # Service traits, DTOs, factory interfaces
+//! │   ├── service.rs         # FailureParserService, FixSuggestionService traits
+//! │   ├── factory.rs         # ParserFactory, FailureParserServiceFactory, FixSuggestionServiceFactory traits
+//! │   └── dto/               # Input/Output DTOs with validation docs
+//! ├── infrastructure/        # Repository interfaces
+//! │   └── repository/        # ParserConfigRepository, FailureLogRepository traits
+//! └── interfaces/            # API contracts
+//!     └── http/              # REST endpoint contracts with request/response schemas
+//! ```
+//!
+//! # Contract Freeze Notice
+//!
+//! ALL files in this module are frozen contracts.
+//! - No implementation changes without explicit contract change approval
+//! - Implementation PRs MUST reference these interfaces
+//! - DTO schemas serve as the canonical data contract
+//! - Tests verify contract assertions (serialization, naming, accessors)
+
+pub mod application;
+pub mod domain;
+pub mod infrastructure;
+pub mod interfaces;

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -36,6 +36,7 @@ pub mod error;
 pub mod event_system;
 pub mod execution_engine;
 pub mod failure_classification;
+pub mod failure_parser;
 pub mod hooks;
 pub mod llm_step;
 pub mod observability;


### PR DESCRIPTION
## Contract Freeze: failure-parser

Define and freeze all public interfaces, contracts, and schemas for the failure-parser epic.

### What's Included

**TemplateFailure** — 6 typed failure variants (MissingSymbol, WrongArgCount, TypeMismatch, CompileError, AssertionFailure, TestFailure) with structured LLM-readable context.

**FailureParserService** — Core service trait for parsing compiler/test/lint output into structured failures and formatting for LLM consumption.

**TypeScript Parser** — LanguageParser trait + extensible ParserRegistry supporting tsc, jest, rustc, pytest.

**Suggested Fix Generation** — FixSuggestionService trait that cross-references source context to generate actionable fix suggestions.

### Architecture (Clean Architecture)
- `domain/` — TemplateFailure, FailureDetail, CompilerOutput, ParsedFailure, SourceContext, FailureParserError, FailureParserEvent, LanguageParser, ParserRegistry
- `application/` — FailureParserService, FixSuggestionService, ParserFactory, FailureParserServiceFactory + DTOs
- `infrastructure/` — ParserConfigRepository, FailureLogRepository
- `interfaces/http/` — 6 REST endpoint contracts with unified error format

### Acceptance
- ✅ 43 contract tests pass (serialization, variant assertions, severity classification, registry operations)
- ✅ Build succeeds with zero new warnings
- ✅ All interfaces frozen — no implementation included