### PR TITLE
feat: implement TemplateFailure domain model and service (#496)

### DIFF
--- a/engine/.pi/.guardian-pipeline-state.json
+++ b/engine/.pi/.guardian-pipeline-state.json
@@ -51,12 +51,49 @@
       }
     }
   ],
-  "currentItemIndex": 0,
+  "currentItemIndex": 1,
   "currentStepIndex": 0,
   "status": "running",
   "retryCount": 0,
-  "results": [],
+  "results": [
+    {
+      "item": "issue-contract-freeze",
+      "status": "done",
+      "stepResults": [
+        {
+          "step": "implement",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "implement",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "validate",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "validate",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "create-mr",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "merge",
+          "status": "passed",
+          "reason": ""
+        }
+      ]
+    }
+  ],
   "mergeOnValid": true,
   "createdAt": "2026-06-19T18:53:34.644Z",
-  "updatedAt": "2026-06-19T18:53:34.644Z"
+  "updatedAt": "2026-06-19T19:01:37.744Z"
 }

--- a/engine/src/failure_parser/domain/mod.rs
+++ b/engine/src/failure_parser/domain/mod.rs
@@ -24,6 +24,7 @@ pub mod failure;
 pub mod input;
 pub mod output;
 pub mod registry;
+pub mod template_service;
 
 pub use detail::*;
 pub use error::FailureParserError;
@@ -32,3 +33,4 @@ pub use failure::*;
 pub use input::*;
 pub use output::*;
 pub use registry::*;
+pub use template_service::TemplateFailureService;

--- a/engine/src/failure_parser/domain/template_service.rs
+++ b/engine/src/failure_parser/domain/template_service.rs
@@ -1,0 +1,370 @@
+//! TemplateFailureService — domain service for TemplateFailure operations.
+//!
+//! @canonical .pi/architecture/modules/failure-parser.md#failure
+//! Implements: TemplateFailureService — utility operations on TemplateFailure collections
+//! Issue: #496
+//!
+//! Provides operations on collections of TemplateFailure instances:
+//! grouping, filtering, summarizing, and severity analysis.
+
+use crate::failure_parser::domain::{
+    detail::FailureSeverity,
+    failure::TemplateFailure,
+    output::ParsedFailure,
+};
+
+/// Domain service for TemplateFailure operations.
+///
+/// Provides utility functions for working with TemplateFailure collections.
+/// This is stateless — all operations are pure functions over data.
+pub struct TemplateFailureService;
+
+impl TemplateFailureService {
+    /// Group failures by their variant type.
+    ///
+    /// Returns a map of variant name → list of failures.
+    pub fn group_by_variant(failures: &[TemplateFailure]) -> std::collections::HashMap<&'static str, Vec<&TemplateFailure>> {
+        let mut groups: std::collections::HashMap<&'static str, Vec<&TemplateFailure>> = std::collections::HashMap::new();
+        for f in failures {
+            groups.entry(f.variant_name()).or_default().push(f);
+        }
+        groups
+    }
+
+    /// Filter failures that have suggested fixes (is_fixable() returns true).
+    pub fn fixable(failures: &[TemplateFailure]) -> Vec<&TemplateFailure> {
+        failures.iter().filter(|f| f.is_fixable()).collect()
+    }
+
+    /// Filter failures that are NOT fixable.
+    pub fn non_fixable(failures: &[TemplateFailure]) -> Vec<&TemplateFailure> {
+        failures.iter().filter(|f| !f.is_fixable()).collect()
+    }
+
+    /// Compute overall severity from a list of failures.
+    ///
+    /// CompileBlock > TestBlock > Warning.
+    pub fn classify_severity(failures: &[TemplateFailure]) -> FailureSeverity {
+        // Check if any failure has a compile/location that suggests compile block
+        // Heuristic: CompileError, MissingSymbol, WrongArgCount, TypeMismatch are compile blocks
+        for f in failures {
+            match f {
+                TemplateFailure::CompileError { .. }
+                | TemplateFailure::MissingSymbol { .. }
+                | TemplateFailure::WrongArgCount { .. }
+                | TemplateFailure::TypeMismatch { .. } => return FailureSeverity::CompileBlock,
+                _ => {}
+            }
+        }
+        // Test failures
+        for f in failures {
+            match f {
+                TemplateFailure::AssertionFailure { .. }
+                | TemplateFailure::TestFailure { .. } => return FailureSeverity::TestBlock,
+                _ => {}
+            }
+        }
+        FailureSeverity::Warning
+    }
+
+    /// Generate a summary string for a list of failures.
+    ///
+    /// Returns a string like:
+    /// "FAILURE ANALYSIS: 3 errors found (2 fixable, 1 non-fixable)"
+    pub fn summary(failures: &[TemplateFailure]) -> String {
+        let total = failures.len();
+        let fixable = Self::fixable(failures).len();
+        let non_fixable = total - fixable;
+        let severity = Self::classify_severity(failures);
+
+        format!(
+            "FAILURE ANALYSIS: {} {} found ({} fixable, {} non-fixable, severity: {:?})",
+            total,
+            if total == 1 { "error" } else { "errors" },
+            fixable,
+            non_fixable,
+            severity,
+        )
+    }
+
+    /// Get unique error codes from CompileError failures.
+    pub fn error_codes(failures: &[TemplateFailure]) -> std::collections::BTreeSet<String> {
+        failures
+            .iter()
+            .filter_map(|f| {
+                if let TemplateFailure::CompileError { code, .. } = f {
+                    Some(code.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Get unique test names from test failures.
+    pub fn test_names(failures: &[TemplateFailure]) -> std::collections::BTreeSet<String> {
+        failures
+            .iter()
+            .filter_map(|f| match f {
+                TemplateFailure::AssertionFailure { test_name, .. } => Some(test_name.clone()),
+                TemplateFailure::TestFailure { test_name, .. } => Some(test_name.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Create a ParsedFailure from a list of TemplateFailures and a source tool name.
+    pub fn to_parsed(failures: Vec<TemplateFailure>, source_tool: impl Into<String>) -> ParsedFailure {
+        let tool_str: String = source_tool.into();
+        let details: Vec<_> = failures
+            .into_iter()
+            .map(|f| {
+                let severity = match &f {
+                    TemplateFailure::CompileError { .. }
+                    | TemplateFailure::MissingSymbol { .. }
+                    | TemplateFailure::WrongArgCount { .. }
+                    | TemplateFailure::TypeMismatch { .. } => FailureSeverity::CompileBlock,
+                    TemplateFailure::AssertionFailure { .. }
+                    | TemplateFailure::TestFailure { .. } => FailureSeverity::TestBlock,
+                };
+                let raw = f.summary();
+                crate::failure_parser::domain::detail::FailureDetail::new(
+                    f,
+                    None,
+                    severity,
+                    raw,
+                    tool_str.clone(),
+                    1.0,
+                )
+            })
+            .collect();
+
+        ParsedFailure::from_failures(details, tool_str)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::failure_parser::domain::failure::SourceLocation;
+
+    fn make_missing_symbol(symbol: &str) -> TemplateFailure {
+        TemplateFailure::MissingSymbol {
+            symbol: symbol.to_string(),
+            available: vec!["add".into(), "remove".into()],
+            suggestion: Some(format!("Use 'add' instead of '{}'", symbol)),
+            location: SourceLocation::new("test.ts", 3, Some(10)),
+        }
+    }
+
+    fn make_compile_error(code: &str) -> TemplateFailure {
+        TemplateFailure::CompileError {
+            code: code.to_string(),
+            message: "Some compile error".into(),
+            location: SourceLocation::new("test.ts", 5, None),
+        }
+    }
+
+    fn make_test_failure(name: &str) -> TemplateFailure {
+        TemplateFailure::TestFailure {
+            test_name: name.to_string(),
+            message: "Assertion failed".into(),
+            location: None,
+        }
+    }
+
+    fn make_assertion_failure(name: &str) -> TemplateFailure {
+        TemplateFailure::AssertionFailure {
+            test_name: name.to_string(),
+            expected: "true".into(),
+            received: "false".into(),
+            location: SourceLocation::new("test.ts", 10, Some(1)),
+        }
+    }
+
+    fn make_type_mismatch() -> TemplateFailure {
+        TemplateFailure::TypeMismatch {
+            expected: "string".into(),
+            actual: "number".into(),
+            location: SourceLocation::new("test.ts", 15, None),
+        }
+    }
+
+    fn make_wrong_arg_count() -> TemplateFailure {
+        TemplateFailure::WrongArgCount {
+            function: "add".into(),
+            expected: 2,
+            actual: 3,
+            location: SourceLocation::new("test.ts", 20, None),
+        }
+    }
+
+    #[test]
+    fn test_group_by_variant() {
+        let failures = vec![
+            make_missing_symbol("addTask"),
+            make_compile_error("TS2339"),
+            make_test_failure("test1"),
+            make_missing_symbol("removeItem"),
+        ];
+        let groups = TemplateFailureService::group_by_variant(&failures);
+        assert_eq!(groups.len(), 3);
+        assert_eq!(groups.get("missing_symbol").unwrap().len(), 2);
+        assert_eq!(groups.get("compile_error").unwrap().len(), 1);
+        assert_eq!(groups.get("test_failure").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_fixable_filter() {
+        let failures = vec![
+            make_missing_symbol("x"),
+            make_compile_error("E001"),
+            make_test_failure("t1"),
+        ];
+        let fixable = TemplateFailureService::fixable(&failures);
+        assert_eq!(fixable.len(), 1);
+        assert_eq!(fixable[0].variant_name(), "missing_symbol");
+    }
+
+    #[test]
+    fn test_non_fixable_filter() {
+        let failures = vec![
+            make_missing_symbol("x"),
+            make_compile_error("E001"),
+            make_test_failure("t1"),
+        ];
+        let non_fixable = TemplateFailureService::non_fixable(&failures);
+        assert_eq!(non_fixable.len(), 2);
+    }
+
+    #[test]
+    fn test_classify_severity_compile_block_wins() {
+        let failures = vec![
+            make_test_failure("t1"),
+            make_compile_error("E001"),
+        ];
+        assert_eq!(
+            TemplateFailureService::classify_severity(&failures),
+            FailureSeverity::CompileBlock
+        );
+    }
+
+    #[test]
+    fn test_classify_severity_test_block() {
+        let failures = vec![
+            make_test_failure("t1"),
+            make_assertion_failure("t2"),
+        ];
+        assert_eq!(
+            TemplateFailureService::classify_severity(&failures),
+            FailureSeverity::TestBlock
+        );
+    }
+
+    #[test]
+    fn test_classify_severity_warning() {
+        // No failures means warning
+        let failures: Vec<TemplateFailure> = vec![];
+        assert_eq!(
+            TemplateFailureService::classify_severity(&failures),
+            FailureSeverity::Warning
+        );
+    }
+
+    #[test]
+    fn test_classify_severity_compile_types() {
+        let failures = vec![
+            make_type_mismatch(),
+            make_wrong_arg_count(),
+        ];
+        assert_eq!(
+            TemplateFailureService::classify_severity(&failures),
+            FailureSeverity::CompileBlock
+        );
+    }
+
+    #[test]
+    fn test_summary_single() {
+        let failures = vec![make_missing_symbol("x")];
+        let s = TemplateFailureService::summary(&failures);
+        assert!(s.contains("1 error"));
+        assert!(s.contains("1 fixable"));
+    }
+
+    #[test]
+    fn test_summary_multiple() {
+        let failures = vec![
+            make_missing_symbol("x"),
+            make_compile_error("E001"),
+            make_test_failure("t1"),
+        ];
+        let s = TemplateFailureService::summary(&failures);
+        assert!(s.contains("3 errors"));
+        assert!(s.contains("1 fixable"));
+    }
+
+    #[test]
+    fn test_summary_empty() {
+        let failures: Vec<TemplateFailure> = vec![];
+        let s = TemplateFailureService::summary(&failures);
+        assert!(s.contains("0 errors"));
+    }
+
+    #[test]
+    fn test_error_codes() {
+        let failures = vec![
+            make_compile_error("TS2339"),
+            make_compile_error("TS2554"),
+            make_missing_symbol("x"),
+            make_compile_error("TS2339"),
+        ];
+        let codes = TemplateFailureService::error_codes(&failures);
+        assert_eq!(codes.len(), 2);
+        assert!(codes.contains("TS2339"));
+        assert!(codes.contains("TS2554"));
+    }
+
+    #[test]
+    fn test_test_names() {
+        let failures = vec![
+            make_test_failure("should_add_task"),
+            make_assertion_failure("should_remove_task"),
+            make_compile_error("E001"),
+        ];
+        let names = TemplateFailureService::test_names(&failures);
+        assert_eq!(names.len(), 2);
+        assert!(names.contains("should_add_task"));
+        assert!(names.contains("should_remove_task"));
+    }
+
+    #[test]
+    fn test_to_parsed() {
+        let failures = vec![
+            make_missing_symbol("x"),
+            make_test_failure("t1"),
+        ];
+        let parsed = TemplateFailureService::to_parsed(failures, "tsc");
+        assert_eq!(parsed.total_count, 2);
+        assert_eq!(parsed.source_tool, "tsc");
+        assert!(!parsed.is_clean());
+    }
+
+    #[test]
+    fn test_to_parsed_empty() {
+        let parsed = TemplateFailureService::to_parsed(vec![], "jest");
+        assert!(parsed.is_clean());
+        assert_eq!(parsed.total_count, 0);
+    }
+
+    #[test]
+    fn test_group_by_variant_empty() {
+        let groups = TemplateFailureService::group_by_variant(&[]);
+        assert!(groups.is_empty());
+    }
+
+    #[test]
+    fn test_error_codes_empty() {
+        let codes = TemplateFailureService::error_codes(&[]);
+        assert!(codes.is_empty());
+    }
+}

--- a/engine/tests/failure_parser_template_integration.rs
+++ b/engine/tests/failure_parser_template_integration.rs
@@ -1,0 +1,394 @@
+//! Integration tests for TemplateFailure — typed classification of execution failures.
+//!
+//! @canonical .pi/architecture/modules/failure-parser.md#failure
+//! Implements: TemplateFailure integration tests
+//! Issue: #496
+//!
+//! Tests the full lifecycle of TemplateFailure:
+//! - Construction from error scenarios
+//! - Serialization/deserialization roundtrips
+//! - SourceLocation formatting
+//! - FailureDetail creation
+//! - ParsedFailure aggregation
+//! - TemplateFailureService operations
+//!
+//! These are integration tests that exercise the public API surface
+//! as consumers would use it.
+
+use rigorix_engine::failure_parser::domain::{
+    FailureDetail, FailureSeverity, ParsedFailure, SourceContext,
+    SourceLocation, TemplateFailure, TemplateFailureService,
+};
+
+// ---------------------------------------------------------------------------
+// Helper: create a sample MissingSymbol failure like tsc TS2339
+// ---------------------------------------------------------------------------
+
+fn sample_missing_symbol_failure() -> TemplateFailure {
+    TemplateFailure::MissingSymbol {
+        symbol: "addTask".to_string(),
+        available: vec![
+            "add".to_string(),
+            "list".to_string(),
+            "complete".to_string(),
+        ],
+        suggestion: Some("Use 'add' instead of 'addTask'".to_string()),
+        location: SourceLocation::new("tests/tasklist.test.ts", 3, Some(10)),
+    }
+}
+
+fn sample_wrong_arg_count_failure() -> TemplateFailure {
+    TemplateFailure::WrongArgCount {
+        function: "add".to_string(),
+        expected: 2,
+        actual: 3,
+        location: SourceLocation::new("tests/tasklist.test.ts", 15, Some(5)),
+    }
+}
+
+fn sample_type_mismatch_failure() -> TemplateFailure {
+    TemplateFailure::TypeMismatch {
+        expected: "Task".to_string(),
+        actual: "string".to_string(),
+        location: SourceLocation::new("tests/tasklist.test.ts", 20, Some(1)),
+    }
+}
+
+fn sample_compile_error_failure() -> TemplateFailure {
+    TemplateFailure::CompileError {
+        code: "TS2339".to_string(),
+        message: "Property 'addTask' does not exist on type 'TaskList'.".to_string(),
+        location: SourceLocation::new("tests/tasklist.test.ts", 3, Some(10)),
+    }
+}
+
+fn sample_assertion_failure() -> TemplateFailure {
+    TemplateFailure::AssertionFailure {
+        test_name: "should add a new task".to_string(),
+        expected: "5".to_string(),
+        received: "3".to_string(),
+        location: SourceLocation::new("tests/tasklist.test.ts", 42, Some(1)),
+    }
+}
+
+fn sample_test_failure() -> TemplateFailure {
+    TemplateFailure::TestFailure {
+        test_name: "should complete task".to_string(),
+        message: "TimeoutError: test exceeded 5000ms".to_string(),
+        location: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: TemplateFailure Construction & Accessors
+// ---------------------------------------------------------------------------
+
+#[test]
+fn integration_template_failure_all_variants() {
+    let failures = vec![
+        sample_missing_symbol_failure(),
+        sample_wrong_arg_count_failure(),
+        sample_type_mismatch_failure(),
+        sample_compile_error_failure(),
+        sample_assertion_failure(),
+        sample_test_failure(),
+    ];
+
+    assert_eq!(failures.len(), 6);
+    assert_eq!(failures[0].variant_name(), "missing_symbol");
+    assert_eq!(failures[1].variant_name(), "wrong_arg_count");
+    assert_eq!(failures[2].variant_name(), "type_mismatch");
+    assert_eq!(failures[3].variant_name(), "compile_error");
+    assert_eq!(failures[4].variant_name(), "assertion_failure");
+    assert_eq!(failures[5].variant_name(), "test_failure");
+}
+
+#[test]
+fn integration_template_failure_summary_formats() {
+    let f = sample_missing_symbol_failure();
+    let s = f.summary();
+    assert!(s.contains("MissingSymbol"), "Summary should contain variant name: {}", s);
+    assert!(s.contains("addTask"), "Summary should contain symbol: {}", s);
+    assert!(s.contains("tests/tasklist.test.ts"), "Summary should contain file: {}", s);
+}
+
+#[test]
+fn integration_template_failure_fixable_categories() {
+    assert!(sample_missing_symbol_failure().is_fixable());
+    assert!(sample_wrong_arg_count_failure().is_fixable());
+    assert!(sample_type_mismatch_failure().is_fixable());
+    assert!(!sample_compile_error_failure().is_fixable());
+    assert!(!sample_assertion_failure().is_fixable());
+    assert!(!sample_test_failure().is_fixable());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Serialization Roundtrips
+// ---------------------------------------------------------------------------
+
+#[test]
+fn integration_serialization_json_roundtrip_all_variants() {
+    let variants = vec![
+        sample_missing_symbol_failure(),
+        sample_wrong_arg_count_failure(),
+        sample_type_mismatch_failure(),
+        sample_compile_error_failure(),
+        sample_assertion_failure(),
+        sample_test_failure(),
+    ];
+
+    for (i, variant) in variants.iter().enumerate() {
+        let json = serde_json::to_string_pretty(variant)
+            .unwrap_or_else(|e| panic!("Variant {}: serialization failed: {}", i, e));
+        let deserialized: TemplateFailure = serde_json::from_str(&json)
+            .unwrap_or_else(|e| panic!("Variant {}: deserialization failed: {} from JSON: {}", i, e, &json[..200]));
+        assert_eq!(*variant, deserialized, "Variant {}: roundtrip equality failed", i);
+    }
+}
+
+#[test]
+fn integration_serialization_json_serde_tag() {
+    // Verify that serde tag works and variant names are correct
+    let f = sample_missing_symbol_failure();
+    let json = serde_json::to_value(&f).unwrap();
+    assert_eq!(json["type"], "missing_symbol");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: SourceLocation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn integration_source_location_compact() {
+    let loc = SourceLocation::new("src/lib.ts", 10, Some(3));
+    assert_eq!(loc.to_compact(), "src/lib.ts:10:3");
+
+    let loc = SourceLocation::new("src/lib.ts", 10, None);
+    assert_eq!(loc.to_compact(), "src/lib.ts:10");
+}
+
+#[test]
+fn integration_source_location_new() {
+    let loc = SourceLocation::new("test.ts", 1, Some(1));
+    assert_eq!(loc.file, "test.ts");
+    assert_eq!(loc.line, 1);
+    assert_eq!(loc.column, Some(1));
+}
+
+// ---------------------------------------------------------------------------
+// Tests: FailureDetail
+// ---------------------------------------------------------------------------
+
+#[test]
+fn integration_failure_detail_location_extraction() {
+    let detail = FailureDetail::new(
+        sample_missing_symbol_failure(),
+        Some("Use 'add'".to_string()),
+        FailureSeverity::CompileBlock,
+        "error TS2339: Property 'addTask' does not exist".to_string(),
+        "tsc",
+        0.95,
+    );
+    assert_eq!(detail.source_tool, "tsc");
+    assert_eq!(detail.severity, FailureSeverity::CompileBlock);
+    assert_eq!(detail.suggested_fix, Some("Use 'add'".to_string()));
+    assert!((detail.confidence - 0.95).abs() < 1e-10);
+
+    let loc = detail.location().unwrap();
+    assert_eq!(loc.file, "tests/tasklist.test.ts");
+    assert_eq!(loc.line, 3);
+}
+
+#[test]
+fn integration_failure_detail_test_failure_no_location() {
+    let detail = FailureDetail::new(
+        sample_test_failure(),
+        None,
+        FailureSeverity::TestBlock,
+        "FAIL should complete task".to_string(),
+        "jest",
+        1.0,
+    );
+    assert_eq!(detail.location(), None);
+}
+
+#[test]
+fn integration_failure_detail_to_log_line() {
+    let detail = FailureDetail::new(
+        sample_missing_symbol_failure(),
+        Some("Use 'add'".to_string()),
+        FailureSeverity::CompileBlock,
+        "error: TS2339".to_string(),
+        "tsc",
+        0.95,
+    );
+    let log = detail.to_log_line();
+    assert!(log.contains("tsc"), "Log should contain tool name");
+    assert!(log.contains("tests/tasklist.test.ts:3:10"), "Log should contain location");
+    assert!(log.contains("Use 'add'"), "Log should contain fix suggestion");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: ParsedFailure
+// ---------------------------------------------------------------------------
+
+#[test]
+fn integration_parsed_failure_from_details() {
+    let failures = vec![
+        FailureDetail::new(
+            sample_missing_symbol_failure(),
+            Some("Use 'add'".to_string()),
+            FailureSeverity::CompileBlock,
+            "error: TS2339".to_string(),
+            "tsc",
+            0.95,
+        ),
+        FailureDetail::new(
+            sample_test_failure(),
+            None,
+            FailureSeverity::TestBlock,
+            "FAIL".to_string(),
+            "jest",
+            1.0,
+        ),
+    ];
+
+    let parsed = ParsedFailure::from_failures(failures, "tsc");
+    assert_eq!(parsed.total_count, 2);
+    assert_eq!(parsed.fixable_count, 1);
+    assert_eq!(parsed.source_tool, "tsc");
+    assert!(!parsed.is_clean());
+    assert_eq!(parsed.overall_severity, FailureSeverity::CompileBlock);
+}
+
+#[test]
+fn integration_parsed_failure_empty() {
+    let parsed = ParsedFailure::from_failures(vec![], "tsc");
+    assert!(parsed.is_clean());
+    // all_fixable requires total_count > 0, so empty returns false
+    assert!(!parsed.all_fixable());
+    assert_eq!(parsed.total_count, 0);
+    assert_eq!(parsed.fixable_count, 0);
+}
+
+#[test]
+fn integration_parsed_failure_all_fixable() {
+    let failures = vec![
+        FailureDetail::new(
+            sample_missing_symbol_failure(),
+            Some("Fix 1".to_string()),
+            FailureSeverity::CompileBlock,
+            "e1".to_string(),
+            "tsc",
+            1.0,
+        ),
+        FailureDetail::new(
+            sample_wrong_arg_count_failure(),
+            Some("Fix 2".to_string()),
+            FailureSeverity::CompileBlock,
+            "e2".to_string(),
+            "tsc",
+            1.0,
+        ),
+    ];
+    let parsed = ParsedFailure::from_failures(failures, "tsc");
+    assert!(parsed.all_fixable());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: SourceContext
+// ---------------------------------------------------------------------------
+
+#[test]
+fn integration_source_context_with_multiple_files() {
+    let mut ctx = SourceContext::empty();
+    ctx.symbols_by_file.insert(
+        "src/tasklist.ts".to_string(),
+        vec!["add".to_string(), "remove".to_string(), "list".to_string()],
+    );
+    ctx.source_by_file
+        .insert("src/tasklist.ts".to_string(), "export class TaskList { ... }".to_string());
+
+    assert!(ctx.has_content());
+    let symbols = ctx.symbols_in_file("src/tasklist.ts");
+    assert_eq!(symbols.len(), 3);
+    assert!(symbols.contains(&"add".to_string()));
+    assert_eq!(ctx.source_for_file("src/tasklist.ts"), Some("export class TaskList { ... }"));
+}
+
+// ---------------------------------------------------------------------------
+// Tests: TemplateFailureService
+// ---------------------------------------------------------------------------
+
+#[test]
+fn integration_service_group_by_variant() {
+    let failures = vec![
+        sample_missing_symbol_failure(),
+        sample_compile_error_failure(),
+        sample_missing_symbol_failure(),
+    ];
+    let groups = TemplateFailureService::group_by_variant(&failures);
+    assert_eq!(groups.len(), 2);
+    assert_eq!(groups.get("missing_symbol").unwrap().len(), 2);
+    assert_eq!(groups.get("compile_error").unwrap().len(), 1);
+}
+
+#[test]
+fn integration_service_to_parsed_full_flow() {
+    let failures = vec![
+        sample_missing_symbol_failure(),
+        sample_test_failure(),
+    ];
+
+    let parsed = TemplateFailureService::to_parsed(failures, "tsc");
+    assert_eq!(parsed.total_count, 2);
+    assert!(!parsed.is_clean());
+
+    // Verify the details have proper severity
+    // First is compile block (missing symbol), second is test block
+    assert_eq!(parsed.failures[0].severity, FailureSeverity::CompileBlock);
+    assert_eq!(parsed.failures[1].severity, FailureSeverity::TestBlock);
+}
+
+#[test]
+fn integration_service_summary_multiple_types() {
+    let failures = vec![
+        sample_missing_symbol_failure(),
+        sample_compile_error_failure(),
+        sample_assertion_failure(),
+        sample_test_failure(),
+    ];
+    let summary = TemplateFailureService::summary(&failures);
+    assert!(summary.contains("4 errors"));
+    assert!(summary.contains("1 fixable"));
+    assert!(summary.contains("3 non-fixable"));
+}
+
+#[test]
+fn integration_service_error_codes() {
+    let failures = vec![
+        sample_compile_error_failure(),
+        TemplateFailure::CompileError {
+            code: "TS2554".to_string(),
+            message: "Expected 2 arguments".to_string(),
+            location: SourceLocation::new("test.ts", 1, None),
+        },
+        sample_missing_symbol_failure(),
+    ];
+    let codes = TemplateFailureService::error_codes(&failures);
+    assert_eq!(codes.len(), 2);
+    assert!(codes.contains("TS2339"));
+    assert!(codes.contains("TS2554"));
+}
+
+#[test]
+fn integration_service_test_names() {
+    let failures = vec![
+        sample_assertion_failure(),
+        sample_test_failure(),
+    ];
+    let names = TemplateFailureService::test_names(&failures);
+    assert_eq!(names.len(), 2);
+    assert!(names.contains("should add a new task"));
+    assert!(names.contains("should complete task"));
+}


### PR DESCRIPTION
## TemplateFailure Implementation

Implement the TemplateFailure component for the failure-parser epic.

### What's Included

- **TemplateFailureService** — Domain service with grouping, filtering, severity classification, and summary operations for TemplateFailure collections
- **Integration tests** — 19 integration tests covering:
  - All 6 TemplateFailure variant construction and accessors
  - JSON serialization/deserialization roundtrips
  - SourceLocation formatting (with/without column)
  - FailureDetail creation and location extraction
  - ParsedFailure aggregation (empty, partial, all-fixable)
  - SourceContext with multiple files
  - TemplateFailureService operations (group, filter, classify, summarize)

### Verification
- ✅ 78 tests pass (59 unit + 19 integration)
- ✅ Build succeeds with zero new warnings