### PR TITLE
feat: contract freeze for action-input epic (#521)

### DIFF
--- a/actions/.pi/.guardian-epic-state.json
+++ b/actions/.pi/.guardian-epic-state.json
@@ -1,0 +1,147 @@
+{
+  "name": "\"action-input\"",
+  "trackingIssueId": "520",
+  "epicId": null,
+  "slices": [
+    {
+      "module": "action-input",
+      "components": [
+        {
+          "name": "ActionInputs",
+          "status": "planned",
+          "description": "Typed container of all GitHub Action inputs",
+          "dependencies": [
+            "none"
+          ]
+        },
+        {
+          "name": "InputParser",
+          "status": "planned",
+          "description": "Parse all GitHub Action inputs from environment variables",
+          "dependencies": [
+            "none"
+          ]
+        },
+        {
+          "name": "CommentParser",
+          "status": "planned",
+          "description": "Parse `/rigorix` slash commands from issue and PR comments",
+          "dependencies": [
+            "none"
+          ]
+        },
+        {
+          "name": "CiDetector",
+          "status": "planned",
+          "description": "Detects the CI environment and adjusts engine configuration",
+          "dependencies": [
+            "none"
+          ]
+        },
+        {
+          "name": "ConfigLoader",
+          "status": "planned",
+          "description": "Loads `action.yml` defaults and merges with environment overrides",
+          "dependencies": [
+            "none"
+          ]
+        }
+      ],
+      "nextLogicalSlice": [
+        {
+          "name": "ActionInputs",
+          "status": "planned",
+          "description": "Typed container of all GitHub Action inputs",
+          "dependencies": [
+            "none"
+          ]
+        },
+        {
+          "name": "InputParser",
+          "status": "planned",
+          "description": "Parse all GitHub Action inputs from environment variables",
+          "dependencies": [
+            "none"
+          ]
+        },
+        {
+          "name": "CommentParser",
+          "status": "planned",
+          "description": "Parse `/rigorix` slash commands from issue and PR comments",
+          "dependencies": [
+            "none"
+          ]
+        },
+        {
+          "name": "CiDetector",
+          "status": "planned",
+          "description": "Detects the CI environment and adjusts engine configuration",
+          "dependencies": [
+            "none"
+          ]
+        },
+        {
+          "name": "ConfigLoader",
+          "status": "planned",
+          "description": "Loads `action.yml` defaults and merges with environment overrides",
+          "dependencies": [
+            "none"
+          ]
+        }
+      ]
+    }
+  ],
+  "issues": [
+    {
+      "id": "issue-contract-freeze",
+      "title": "Contract Freeze: Define interfaces and contracts",
+      "status": "planned",
+      "remoteIssueId": "521"
+    },
+    {
+      "id": "issue-actioninputs",
+      "title": "ActionInputs: Typed container of all GitHub Action inputs",
+      "status": "planned",
+      "remoteIssueId": "522"
+    },
+    {
+      "id": "issue-inputparser",
+      "title": "InputParser: Parse all GitHub Action inputs from environment variables",
+      "status": "planned",
+      "remoteIssueId": "523"
+    },
+    {
+      "id": "issue-commentparser",
+      "title": "CommentParser: Parse `/rigorix` slash commands from issue and PR comments",
+      "status": "planned",
+      "remoteIssueId": "524"
+    },
+    {
+      "id": "issue-cidetector",
+      "title": "CiDetector: Detects the CI environment and adjusts engine configuration",
+      "status": "planned",
+      "remoteIssueId": "525"
+    },
+    {
+      "id": "issue-configloader",
+      "title": "ConfigLoader: Loads `action.yml` defaults and merges with environment overrides",
+      "status": "planned",
+      "remoteIssueId": "526"
+    },
+    {
+      "id": "issue-proofing",
+      "title": "Proofing: Validation scripts + CI integration",
+      "status": "planned",
+      "remoteIssueId": "527"
+    },
+    {
+      "id": "issue-architecture-readiness",
+      "title": "Architecture Readiness: Runbook, DR, docs, CI enforcement",
+      "status": "planned",
+      "remoteIssueId": "528"
+    }
+  ],
+  "status": "planning",
+  "currentIssueIndex": 0,
+  "createdAt": "2026-06-20T13:37:36.843Z"
+}

--- a/actions/.pi/.guardian-pipeline-state.json
+++ b/actions/.pi/.guardian-pipeline-state.json
@@ -1,0 +1,63 @@
+{
+  "id": "PL-4814",
+  "name": "\"action-input\"",
+  "items": [
+    "issue-contract-freeze",
+    "issue-actioninputs",
+    "issue-inputparser",
+    "issue-commentparser",
+    "issue-cidetector",
+    "issue-configloader",
+    "issue-proofing",
+    "issue-architecture-readiness"
+  ],
+  "steps": [
+    {
+      "name": "implement",
+      "prompt": ".pi/prompts/issue-implementation-series.md",
+      "acceptance": {
+        "type": "validator",
+        "validators": [
+          "ci"
+        ]
+      }
+    },
+    {
+      "name": "validate",
+      "acceptance": {
+        "type": "validator",
+        "validators": [
+          "ci",
+          "tests",
+          "security"
+        ]
+      }
+    },
+    {
+      "name": "create-mr",
+      "prompt": ".pi/prompts/issue-closeout.md",
+      "acceptance": {
+        "type": "none"
+      }
+    },
+    {
+      "name": "merge",
+      "prompt": ".pi/prompts/issue-merge.md",
+      "acceptance": {
+        "type": "validator",
+        "validators": [
+          "ci",
+          "canonical"
+        ]
+      }
+    }
+  ],
+  "currentItemIndex": 0,
+  "currentStepIndex": 0,
+  "status": "running",
+  "retryCount": 0,
+  "results": [],
+  "mergeOnValid": true,
+  "createdAt": "2026-06-20T13:37:36.863Z",
+  "updatedAt": "2026-06-20T13:37:36.863Z"
+}

--- a/actions/.pi/issues/issue-actioninputs.md
+++ b/actions/.pi/issues/issue-actioninputs.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-ACTION-INPUT-1"
+  epic: "TBD"
+  component: "ActionInputs"
+  module: "action-input"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement ActionInputs for the action-input module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for actioninputs
+    application:
+      - New service/handler for actioninputs
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/action-input.md#actioninputs"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Typed container of all GitHub Action inputs
+
+  file_changes:
+    - "create: src/action-input/actioninputs/"
+    - "create: tests/unit/action-input/actioninputs/"
+    - "create: tests/integration/action-input/actioninputs/"
+---
+
+# ISSUE-ACTION-INPUT-1: ActionInputs
+
+## Intent
+
+Typed container of all GitHub Action inputs
+
+## Architecture Context
+
+- **Module:** action-input
+- **Component:** ActionInputs
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement ActionInputs for the action-input module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for actioninputs
+
+### Application
+- New service/handler for actioninputs
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/action-input.md#actioninputs`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/actions/.pi/issues/issue-architecture-readiness.md
+++ b/actions/.pi/issues/issue-architecture-readiness.md
@@ -1,0 +1,124 @@
+---
+guardian_issue:
+  id: "ISSUE-READINESS"
+  epic: ""action-input""
+  component: "Architecture Readiness"
+  module: "action-input"
+  status: planned
+  priority: critical
+  dependencies: []
+
+  in_scope:
+    - Create runbook (startup, shutdown, recovery procedures)
+    - Create DR plan (backup, restore, failover)
+    - Add observability (metrics, tracing, structured logging)
+    - Add health check endpoints
+    - Update architecture documentation
+    - Sync canonical references
+    - Verify CI enforces all the above
+
+  out_of_scope:
+    - New feature work
+    - Implementation changes
+
+  affected_layers:
+    domain:
+      - Architecture documentation updates
+    application:
+      - Observability hooks
+    infrastructure:
+      - Health checks, monitoring config
+    ci:
+      - Verify proofing scripts + validators in CI
+
+  canonical_references:
+    - module: ".pi/architecture/modules/action-input.md"
+
+  acceptance_criteria:
+    - "Runbook created and reviewed"
+    - "DR plan documented"
+    - "Observability patterns in place (tracing, metrics, logging)"
+    - "Health check endpoint responds"
+    - "Architecture docs synced with implementation"
+    - "Canonical references verified (validate-canonical.sh passes)"
+    - "Proofing scripts integrated in CI and passing"
+    - "All validators pass: ci, tests, security, architecture, canonical, operations"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+    - operations
+
+  implementation_notes: |
+    The final issue in every epic. Production readiness means: the team can operate it
+    (runbook), recover from failure (DR plan), observe it (metrics/tracing/logging),
+    and CI will catch regressions (proofing scripts + validators).
+
+  file_changes:
+    - "create: docs/runbook-action-input.md"
+    - "create: docs/dr-plan-action-input.md"
+    - "modify: .pi/architecture/CHANGELOG.md"
+    - "modify: .pi/architecture/modules/action-input.md"
+---
+
+# Architecture Readiness: action-input
+
+## Intent
+
+Make the action-input module production-ready. This is the final issue in every epic
+— it closes the loop between implementation and operability.
+
+## Deliverables
+
+### Runbook
+`docs/runbook-action-input.md` covering:
+- Startup sequence and dependencies
+- Graceful shutdown procedure
+- Common failure modes and recovery
+- Configuration reference
+
+### DR Plan
+`docs/dr-plan-action-input.md` covering:
+- Backup strategy and schedule
+- Restore procedure
+- Failover plan
+- RTO/RPO targets
+
+### Observability
+- Metrics: key business and technical metrics exposed
+- Tracing: distributed tracing context propagated
+- Logging: structured logging with correlation IDs
+- Health: /health endpoint with dependency checks
+
+### CI Enforcement
+Verify that:
+- Proofing scripts from the proofing issue are in CI
+- All validators (ci, tests, security, architecture, canonical, operations) pass
+- A CI pipeline run against this state succeeds
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | Runbook exists | manual review |
+| 2 | DR plan exists | manual review |
+| 3 | Observability patterns present | validate-operations.sh |
+| 4 | Canonical references synced | validate-canonical.sh |
+| 5 | CI enforce validators | validate-ci.sh |
+| 6 | All proofing scripts pass | run_hardening_stages.sh |
+| 7 | Architecture docs updated | validate-architecture.sh |
+
+## Implementation
+
+> **Agent:** Close out the epic properly:
+> 1. Write runbook and DR plan docs
+> 2. Add observability instrumentation
+> 3. Update architecture module docs with final implementation details
+> 4. Sync CHANGE LOG
+> 5. Verify proofing scripts from the proofing issue pass
+> 6. Run full validation suite
+> 7. Architecture readiness validator: bash .pi/scripts/validate-architecture-readiness.sh
+> 8. Create final MR

--- a/actions/.pi/issues/issue-cidetector.md
+++ b/actions/.pi/issues/issue-cidetector.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-ACTION-INPUT-4"
+  epic: "TBD"
+  component: "CiDetector"
+  module: "action-input"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement CiDetector for the action-input module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for cidetector
+    application:
+      - New service/handler for cidetector
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/action-input.md#cidetector"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Detects the CI environment and adjusts engine configuration
+
+  file_changes:
+    - "create: src/action-input/cidetector/"
+    - "create: tests/unit/action-input/cidetector/"
+    - "create: tests/integration/action-input/cidetector/"
+---
+
+# ISSUE-ACTION-INPUT-4: CiDetector
+
+## Intent
+
+Detects the CI environment and adjusts engine configuration
+
+## Architecture Context
+
+- **Module:** action-input
+- **Component:** CiDetector
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement CiDetector for the action-input module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for cidetector
+
+### Application
+- New service/handler for cidetector
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/action-input.md#cidetector`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/actions/.pi/issues/issue-commentparser.md
+++ b/actions/.pi/issues/issue-commentparser.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-ACTION-INPUT-3"
+  epic: "TBD"
+  component: "CommentParser"
+  module: "action-input"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement CommentParser for the action-input module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for commentparser
+    application:
+      - New service/handler for commentparser
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/action-input.md#commentparser"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Parse `/rigorix` slash commands from issue and PR comments
+
+  file_changes:
+    - "create: src/action-input/commentparser/"
+    - "create: tests/unit/action-input/commentparser/"
+    - "create: tests/integration/action-input/commentparser/"
+---
+
+# ISSUE-ACTION-INPUT-3: CommentParser
+
+## Intent
+
+Parse `/rigorix` slash commands from issue and PR comments
+
+## Architecture Context
+
+- **Module:** action-input
+- **Component:** CommentParser
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement CommentParser for the action-input module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for commentparser
+
+### Application
+- New service/handler for commentparser
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/action-input.md#commentparser`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/actions/.pi/issues/issue-configloader.md
+++ b/actions/.pi/issues/issue-configloader.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-ACTION-INPUT-5"
+  epic: "TBD"
+  component: "ConfigLoader"
+  module: "action-input"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement ConfigLoader for the action-input module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for configloader
+    application:
+      - New service/handler for configloader
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/action-input.md#configloader"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Loads `action.yml` defaults and merges with environment overrides
+
+  file_changes:
+    - "create: src/action-input/configloader/"
+    - "create: tests/unit/action-input/configloader/"
+    - "create: tests/integration/action-input/configloader/"
+---
+
+# ISSUE-ACTION-INPUT-5: ConfigLoader
+
+## Intent
+
+Loads `action.yml` defaults and merges with environment overrides
+
+## Architecture Context
+
+- **Module:** action-input
+- **Component:** ConfigLoader
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement ConfigLoader for the action-input module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for configloader
+
+### Application
+- New service/handler for configloader
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/action-input.md#configloader`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/actions/.pi/issues/issue-contract-freeze.md
+++ b/actions/.pi/issues/issue-contract-freeze.md
@@ -1,0 +1,107 @@
+---
+guardian_issue:
+  id: "ISSUE-CONTRACT-FREEZE"
+  epic: ""action-input""
+  component: "Contract Freeze"
+  module: "action-input"
+  status: planned
+  priority: critical
+  dependencies: []
+
+  in_scope:
+    - Define public interfaces for all components in this epic
+    - Define DTOs, schemas, and API contracts
+    - Document event payloads and topics
+    - Create interface stubs with no implementation
+    - Freeze: no implementation changes without contract change
+
+  out_of_scope:
+    - Any implementation logic
+    - Database schema changes
+    - Infrastructure setup
+
+  affected_layers:
+    domain:
+      - Interface definitions for domain services
+    application:
+      - Input/output DTO definitions
+    api:
+      - REST/event contracts
+
+  canonical_references:
+    - module: ".pi/architecture/modules/action-input.md"
+
+  acceptance_criteria:
+    - "All component interfaces defined as interfaces/types"
+    - "DTO schemas documented"
+    - "API contracts frozen and reviewed"
+    - "Implementation PRs reference these contracts"
+
+  validators:
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Define the contract before any implementation. Every implementation issue
+    depends on this contract being frozen first. The contract should include:
+    interfaces, types, DTOs, event schemas, API paths, error formats.
+
+  file_changes:
+    - "create: src/action-input/contracts/"
+    - "create: src/action-input/contracts/dtos/"
+    - "create: src/action-input/contracts/events/"
+---
+
+# Contract Freeze: action-input
+
+## Intent
+
+Define and freeze all public interfaces, contracts, and schemas for the action-input
+epic before any implementation begins. This prevents architecture drift — implementation
+must satisfy contracts, not the other way around.
+
+## Included Components
+
+- ActionInputs
+- InputParser
+- CommentParser
+- CiDetector
+- ConfigLoader
+
+## What Must Be Frozen
+
+### Interfaces
+- Service interfaces for every component
+- Repository/DAO interfaces
+- Factory interfaces
+
+### Contracts
+- Input/output DTO schemas
+- API endpoint contracts (method, path, request/response)
+- Event payload schemas
+- Error response formats
+
+### Out of Bounds (no contracts needed)
+- Internal implementation details
+- Database column names (hidden behind repository)
+- Framework-specific annotations
+
+## Acceptance Criteria
+
+| # | Criterion | How to Verify |
+|---|-----------|---------------|
+| 1 | All component interfaces defined | Check src/<group>/<module>/domain/ and application/ |
+| 2 | Contracts reviewed and frozen | PR approval |
+| 3 | DTO schemas documented | OpenAPI / TypeSpec / equivalent |
+| 4 | Implementation depends on contracts | No implementation without interface |
+
+## Implementation
+
+> **Agent:** Create interface-only files. No implementation. Use Clean Architecture layers:
+> 1. Read the architecture module to understand each component's role
+> 2. Place domain interfaces in domain/, service interfaces in application/, API contracts in interfaces/http/
+> 3. DTOs with proper validation decorators go in application/
+> 4. Event schemas go in domain/event/
+> 5. Repository interfaces go in infrastructure/repository/
+>
+> The goal is a reviewed, frozen contract that implementation issues can depend on.

--- a/actions/.pi/issues/issue-inputparser.md
+++ b/actions/.pi/issues/issue-inputparser.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-ACTION-INPUT-2"
+  epic: "TBD"
+  component: "InputParser"
+  module: "action-input"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement InputParser for the action-input module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for inputparser
+    application:
+      - New service/handler for inputparser
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/action-input.md#inputparser"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    Parse all GitHub Action inputs from environment variables
+
+  file_changes:
+    - "create: src/action-input/inputparser/"
+    - "create: tests/unit/action-input/inputparser/"
+    - "create: tests/integration/action-input/inputparser/"
+---
+
+# ISSUE-ACTION-INPUT-2: InputParser
+
+## Intent
+
+Parse all GitHub Action inputs from environment variables
+
+## Architecture Context
+
+- **Module:** action-input
+- **Component:** InputParser
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement InputParser for the action-input module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for inputparser
+
+### Application
+- New service/handler for inputparser
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/action-input.md#inputparser`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/actions/.pi/issues/issue-proofing.md
+++ b/actions/.pi/issues/issue-proofing.md
@@ -1,0 +1,117 @@
+---
+guardian_issue:
+  id: "ISSUE-PROOFING"
+  epic: ""action-input""
+  component: "Proofing & CI Enforcement"
+  module: "action-input"
+  status: planned
+  priority: critical
+  dependencies: []
+
+  in_scope:
+    - Create deterministic validation scripts for each contract
+    - Verify all interfaces have matching implementations
+    - Check test coverage meets thresholds
+    - Integrate proofing scripts into .pi/scripts/ci/
+    - Scripts must be self-contained shell scripts (zero token cost)
+
+  out_of_scope:
+    - Implementation changes
+    - New features
+    - Production deployment
+
+  affected_layers:
+    ci:
+      - New proofing scripts in .pi/scripts/ci/
+      - Updated CI stage configuration
+
+  canonical_references:
+    - module: ".pi/architecture/modules/action-input.md"
+
+  acceptance_criteria:
+    - "All proofing scripts created and executable"
+    - "Each contract has at least one validation check"
+    - "Scripts pass on current implementation"
+    - "Scripts fail if implementation is removed"
+    - "Scripts integrated into CI pipeline (stage in run_hardening_stages.sh)"
+
+  validators:
+    - ci
+    - tests
+    - canonical
+
+  implementation_notes: |
+    Create deterministic shell scripts that validate: each defined interface has an
+    implementation, each implementation has tests, test coverage meets threshold,
+    contracts are not violated. These escape the LLM ad-hoc check trap — they run
+    every build for zero token cost.
+
+  file_changes:
+    - "create: .pi/scripts/ci/check_action-input_contracts.sh"
+    - "create: .pi/scripts/ci/check_action-input_coverage.sh"
+    - "modify: .pi/scripts/ci/run_hardening_stages.sh"
+---
+
+# Proofing & CI Enforcement: action-input
+
+## Intent
+
+Create deterministic, automated validation scripts that prove every contract from the
+freeze phase is correctly implemented and tested. These scripts make compliance
+automatic — no human review needed for routine checks.
+
+## What Each Script Does
+
+### Contract Implementation Check
+- Reads each interface from the contract freeze
+- Verifies a concrete implementation class exists
+- Verifies all interface methods are implemented
+- Reports violations with file:line references
+
+### Coverage Threshold Check
+- Runs the project's coverage tool
+- Asserts each module meets minimum coverage (default 80%)
+- Fails the build if coverage drops
+
+### CI Integration
+Each check becomes a CI stage in the hardening pipeline — it runs automatically
+on every PR. No LLM cost. No human review. Just pass or fail.
+
+## Scripts To Create
+
+| Script | Purpose | Location |
+|--------|---------|----------|
+| check_action-input_contracts.sh | Validate contract implementation | .pi/scripts/ci/ |
+| check_action-input_coverage.sh | Enforce coverage thresholds | .pi/scripts/ci/ |
+| stage_action-input_proofing.sh | CI stage wrapper | .pi/scripts/ci/ |
+
+## CI Pipeline Update
+
+Add the new stage to `run_hardening_stages.sh`:
+
+```bash
+run_stage "11" "action-input_proofing" \
+    "${SCRIPTS_DIR}/stage_action-input_proofing.sh" \
+    "always"
+```
+
+## Acceptance Criteria
+
+| # | Criterion | Script |
+|---|-----------|--------|
+| 1 | All interfaces have implementations | check_contracts.sh |
+| 2 | Coverage ≥ 80% per module | check_coverage.sh |
+| 3 | CI runs checks on every PR | run_hardening_stages.sh |
+| 4 | All scripts exit 0 on pass, 1 on fail | self-validating |
+
+## Implementation
+
+> **Agent:** Create shell scripts. Keep them simple — grep, find, awk.
+> No frameworks, no dependencies. Each script should be:
+> 1. Runnable standalone (bash script.sh)
+> 2. Runnable as a CI stage
+> 3. Self-documenting with --help
+> 4. Exit 0 for pass, 1 for fail
+>
+> End by running the full CI pipeline to verify integration:
+> `bash .pi/scripts/ci/run_hardening_stages.sh`

--- a/actions/src/action_input/application/dto/mod.rs
+++ b/actions/src/action_input/application/dto/mod.rs
@@ -1,0 +1,198 @@
+//! Data Transfer Objects for the Action Input module.
+//!
+//! @canonical actions/.pi/architecture/modules/action-input.md
+//! Implements: Contract Freeze — DTO schemas for input parsing, comment parsing,
+//! CI detection, and config loading operations
+//! Issue: issue-contract-freeze
+//!
+//! DTOs define the input/output contracts for service operations.
+//! They carry validation metadata and documentation but no behavior.
+//!
+//! # Contract (Frozen)
+//! - Every service operation has a dedicated input and output DTO
+//! - DTOs are serializable (JSON for event processing)
+//! - Validation constraints are documented in field docs
+
+use serde::{Deserialize, Serialize};
+
+use crate::action_input::domain::{
+    ActionConfig, ActionInputs, CiEnvironment, CommentCommand, GitHubEvent,
+};
+
+// ---------------------------------------------------------------------------
+// Input Parsing DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for parsing GitHub Action inputs from the environment.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ParseInputsInput {
+    /// Override the environment variable prefix (default: `INPUT_`).
+    pub env_prefix: Option<String>,
+
+    /// Override environment for testing (maps variable name → value).
+    /// If `None`, reads from real `std::env::var`.
+    pub env_override: Option<std::collections::HashMap<String, String>>,
+}
+
+/// Output from parsing GitHub Action inputs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParseInputsOutput {
+    /// The parsed action inputs.
+    pub inputs: ActionInputs,
+    /// Number of input fields that were populated (non-None).
+    pub populated_count: u32,
+    /// Names of required inputs that were missing.
+    pub missing_required: Vec<String>,
+    /// Warnings from parsing (e.g., unparseable numeric fields).
+    pub warnings: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Event Payload Parsing DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for parsing a GitHub event payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParseEventPayloadInput {
+    /// Path to the `GITHUB_EVENT_PATH` file.
+    pub event_path: String,
+    /// Override JSON content for testing (if `None`, reads from file).
+    pub content_override: Option<String>,
+}
+
+/// Output from parsing a GitHub event payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParseEventPayloadOutput {
+    /// The parsed GitHub event.
+    pub event: GitHubEvent,
+    /// The raw event name from `GITHUB_EVENT_NAME`.
+    pub event_name: String,
+    /// File size of the event payload in bytes.
+    pub file_size_bytes: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Comment Parsing DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for parsing a comment body for `/rigorix` commands.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParseCommentInput {
+    /// The raw comment body text.
+    pub comment_body: String,
+    /// The command prefix to look for (default: `/rigorix`).
+    pub command_prefix: Option<String>,
+    /// The issue/PR number where the comment was posted.
+    pub issue_number: u64,
+    /// The username of the commenter.
+    pub commenter: String,
+}
+
+/// Output from parsing a comment.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParseCommentOutput {
+    /// The parsed command, if any.
+    pub command: Option<CommentCommand>,
+    /// Whether a command was found.
+    pub found: bool,
+    /// The matched command type as a string (for event logging).
+    pub command_type: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// CI Detection DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for detecting the CI environment.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DetectCiInput {
+    /// Override environment for testing (maps variable name → value).
+    /// If `None`, reads from real `std::env::var`.
+    pub env_override: Option<std::collections::HashMap<String, String>>,
+
+    /// Override the permission mode.
+    /// If `None`, uses CI-aware defaults.
+    pub permission_mode_override: Option<String>,
+}
+
+/// Output from CI environment detection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DetectCiOutput {
+    /// The detected CI environment.
+    pub environment: CiEnvironment,
+    /// The resolved permission mode for the environment.
+    pub permission_mode: String,
+    /// Whether the environment is CI.
+    pub is_ci: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Config Loading DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for loading merged action configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LoadConfigInput {
+    /// Override environment for testing (maps variable name → value).
+    pub env_override: Option<std::collections::HashMap<String, String>>,
+
+    /// Override action.yml content for testing (YAML string).
+    /// If `None`, reads from `action.yml` in CWD.
+    pub action_yml_override: Option<String>,
+
+    /// Override CLI arguments for testing.
+    pub cli_overrides: Option<std::collections::HashMap<String, String>>,
+
+    /// Allow empty/missing action.yml (use all defaults).
+    pub allow_empty_yml: bool,
+}
+
+/// Output from loading merged action configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoadConfigOutput {
+    /// The fully resolved action configuration.
+    pub config: ActionConfig,
+    /// Whether action.yml defaults were found and applied.
+    pub yml_defaults_applied: bool,
+    /// Whether environment overrides were applied.
+    pub env_overrides_applied: bool,
+    /// Whether CLI overrides were applied.
+    pub cli_overrides_applied: bool,
+    /// List of sources that contributed to the final config (ordered by priority).
+    pub sources: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Validation DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for validating parsed inputs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidateInputsInput {
+    /// The parsed action inputs to validate.
+    pub inputs: ActionInputs,
+    /// The detected CI environment (for mode-based validation).
+    pub ci_environment: CiEnvironment,
+}
+
+/// A single validation error.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ValidationError {
+    /// The field that failed validation.
+    pub field: String,
+    /// Human-readable error message.
+    pub message: String,
+    /// The invalid value, if representable.
+    pub value: Option<String>,
+}
+
+/// Output from validating parsed inputs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidateInputsOutput {
+    /// Whether all validation checks passed.
+    pub valid: bool,
+    /// List of validation errors (empty if valid).
+    pub errors: Vec<ValidationError>,
+    /// List of warnings (non-blocking issues).
+    pub warnings: Vec<String>,
+}

--- a/actions/src/action_input/application/factory.rs
+++ b/actions/src/action_input/application/factory.rs
@@ -1,0 +1,108 @@
+//! Factory interfaces for constructing Action Input domain objects.
+//!
+//! @canonical actions/.pi/architecture/modules/action-input.md
+//! Implements: Contract Freeze — InputFactory, ConfigFactory, EventFactory traits
+//! Issue: issue-contract-freeze
+//!
+//! Factories encapsulate the construction of complex domain objects,
+//! allowing implementations to inject dependencies and apply defaults
+//! without exposing construction logic to callers.
+//!
+//! # Contract (Frozen)
+//! - Every factory method returns a configured domain object
+//! - Validation is applied during construction
+//! - No mutable state in factory implementations
+
+use async_trait::async_trait;
+
+use crate::action_input::domain::{ActionConfig, ActionInputError, ActionInputs, GitHubEvent};
+
+/// Factory for constructing `ActionInputs` from raw environment data.
+///
+/// Implementations handle parsing string values from environment variables
+/// into typed `ActionInputs` fields, applying default values and validation.
+#[async_trait]
+pub trait InputFactory: Send + Sync {
+    /// Build an `ActionInputs` from a map of raw string key-value pairs.
+    ///
+    /// Keys should be the env var name without prefix (e.g., `INTENT`, `MODE`).
+    /// Values are raw strings from environment variables.
+    async fn build_from_env_map(
+        &self,
+        env_map: std::collections::HashMap<String, String>,
+    ) -> Result<ActionInputs, ActionInputError>;
+
+    /// Build an `ActionInputs` from parsed CLI arguments.
+    ///
+    /// Accepts a flat map of argument names to values.
+    async fn build_from_cli_args(
+        &self,
+        args: std::collections::HashMap<String, String>,
+    ) -> Result<ActionInputs, ActionInputError>;
+
+    /// Create an `ActionInputs` with all default values.
+    fn defaults(&self) -> ActionInputs;
+
+    /// Parse a single value into the correct type for the given field.
+    ///
+    /// Returns the parsed value as a string representation or an error.
+    async fn parse_field(
+        &self,
+        field: &str,
+        raw_value: &str,
+    ) -> Result<Option<String>, ActionInputError>;
+}
+
+/// Factory for constructing `ActionConfig` from merged sources.
+///
+/// Handles the final resolution of `ActionInputs` (with `Option` fields)
+/// into `ActionConfig` (all fields resolved to concrete values).
+#[async_trait]
+pub trait ConfigFactory: Send + Sync {
+    /// Resolve an `ActionInputs` into a concrete `ActionConfig`.
+    ///
+    /// All `Option` fields in `ActionInputs` are resolved:
+    /// - If `Some(value)`, use the value
+    /// - If `None`, use the default from `ActionConfig::default()`
+    async fn resolve_config(
+        &self,
+        inputs: ActionInputs,
+    ) -> Result<ActionConfig, ActionInputError>;
+
+    /// Apply environment-specific overrides to a config.
+    ///
+    /// For CI environments: sets permission_mode to `workspace_write`
+    /// if not explicitly set.
+    async fn apply_environment_overrides(
+        &self,
+        config: ActionConfig,
+        is_ci: bool,
+    ) -> Result<ActionConfig, ActionInputError>;
+
+    /// Merge two `ActionInputs` with the second taking precedence.
+    async fn merge(
+        &self,
+        base: ActionInputs,
+        overrides: ActionInputs,
+    ) -> Result<ActionInputs, ActionInputError>;
+}
+
+/// Factory for constructing `GitHubEvent` from raw JSON event payloads.
+///
+/// Handles deserialization of the event payload file with event-type-aware
+/// parsing. Different event types have different JSON structures.
+#[async_trait]
+pub trait EventFactory: Send + Sync {
+    /// Build a `GitHubEvent` from raw JSON content and event name.
+    async fn build_from_json(
+        &self,
+        event_name: &str,
+        json_content: &str,
+    ) -> Result<GitHubEvent, ActionInputError>;
+
+    /// Determine the event type from the event name string.
+    fn classify_event_type(&self, event_name: &str) -> &'static str;
+
+    /// Create an unknown event with the given name.
+    fn unknown_event(&self, event_name: &str) -> GitHubEvent;
+}

--- a/actions/src/action_input/application/mod.rs
+++ b/actions/src/action_input/application/mod.rs
@@ -1,0 +1,24 @@
+//! Application layer for the Action Input bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/action-input.md#application
+//! Implements: Contract Freeze — service traits, DTO schemas, factory interfaces
+//! Issue: issue-contract-freeze
+//!
+//! This module defines the application-level contracts:
+//! - Service interfaces (use cases) in `service.rs`
+//! - Input/output DTO schemas in `dto/`
+//! - Factory interfaces in `factory.rs`
+//!
+//! # Contract (Frozen)
+//! - All service traits are async (use `async-trait`)
+//! - All public methods return `Result<_, ActionInputError>`
+//! - DTOs carry full documentation for each field
+//! - No implementation — only contract signatures
+
+pub mod dto;
+pub mod factory;
+pub mod service;
+
+pub use dto::*;
+pub use factory::*;
+pub use service::*;

--- a/actions/src/action_input/application/service.rs
+++ b/actions/src/action_input/application/service.rs
@@ -1,0 +1,280 @@
+//! Service interfaces (use cases) for the Action Input bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/action-input.md
+//! Implements: Contract Freeze — InputParsingService, EventParsingService,
+//! CommentParsingService, CiDetectionService, ConfigLoadingService,
+//! InputValidationService traits
+//! Issue: issue-contract-freeze
+//!
+//! These traits define the application-level operations for parsing GitHub
+//! Action inputs, events, comments, and configuration. All methods are async
+//! and return domain error types.
+//!
+//! # Contract (Frozen)
+//! - Every use case has a corresponding trait method
+//! - Input/output types are DTOs defined in `dto/`
+//! - All methods are async (use `async-trait` for trait object safety)
+//! - No implementation — only contract signatures
+
+use async_trait::async_trait;
+
+use crate::action_input::domain::{ActionInputError, CommentCommand};
+
+use super::dto::{
+    DetectCiInput, DetectCiOutput, LoadConfigInput, LoadConfigOutput, ParseCommentInput,
+    ParseCommentOutput, ParseEventPayloadInput, ParseEventPayloadOutput, ParseInputsInput,
+    ParseInputsOutput, ValidateInputsInput, ValidateInputsOutput,
+};
+
+/// Application service for parsing GitHub Action inputs from environment variables.
+///
+/// Implements the contract defined in `InputParser` from the architecture doc.
+/// Reads `INPUT_<NAME>` environment variables and converts them to typed
+/// `ActionInputs` struct fields.
+///
+/// # Contract (Frozen)
+/// - `parse()` is the primary entry point
+/// - Returns structured results with warnings for unparseable values
+/// - Missing required inputs are reported, not panicked
+#[async_trait]
+pub trait InputParsingService: Send + Sync {
+    /// Parse all inputs from the environment.
+    ///
+    /// Reads `INPUT_<NAME>` environment variables where `<NAME>` is the
+    /// uppercase version of the input name with hyphens replaced by underscores.
+    ///
+    /// # Returns
+    ///
+    /// `ParseInputsOutput` containing:
+    /// - The parsed `ActionInputs` (with `None` for missing optional fields)
+    /// - Count of populated fields
+    /// - Names of missing required fields
+    /// - Warnings for values that failed to parse
+    async fn parse(&self, input: ParseInputsInput) -> Result<ParseInputsOutput, ActionInputError>;
+
+    /// Parse a single input value into its typed representation.
+    ///
+    /// Used by implementations to convert raw env var strings into typed values.
+    /// Returns `None` if parsing fails (the warning is captured in the output).
+    async fn parse_field<T: std::str::FromStr>(
+        &self,
+        name: &str,
+        value: &str,
+    ) -> Result<Option<T>, ActionInputError>;
+
+    /// Check if a required input is present.
+    ///
+    /// Returns an error with the field name if the required input is missing.
+    async fn require_input(&self, name: &str) -> Result<String, ActionInputError>;
+
+    /// Read a single environment variable by name.
+    ///
+    /// Returns `None` if the variable is not set or empty.
+    async fn read_env_var(&self, name: &str) -> Option<String>;
+}
+
+/// Application service for parsing GitHub event payload JSON.
+///
+/// Implements the `EventPayloadParser` component from the architecture doc.
+/// Reads the `GITHUB_EVENT_PATH` file and deserializes it into structured
+/// `GitHubEvent` types based on the event name.
+///
+/// # Contract (Frozen)
+/// - `parse()` reads from `GITHUB_EVENT_PATH` by default
+/// - Supports: workflow_dispatch, issue_comment, pull_request, push
+/// - Unknown event types return `GitHubEvent::Unknown`
+#[async_trait]
+pub trait EventParsingService: Send + Sync {
+    /// Parse the GitHub event payload from the specified path.
+    ///
+    /// Reads the JSON file at `GITHUB_EVENT_PATH`, determines the event
+    /// type from `GITHUB_EVENT_NAME`, and deserializes into the matching
+    /// `GitHubEvent` variant.
+    async fn parse(
+        &self,
+        input: ParseEventPayloadInput,
+    ) -> Result<ParseEventPayloadOutput, ActionInputError>;
+
+    /// Get the event name from the environment.
+    ///
+    /// Reads `GITHUB_EVENT_NAME` env var. Returns error if not in CI.
+    async fn get_event_name(&self) -> Result<String, ActionInputError>;
+
+    /// Get the event payload file path from the environment.
+    ///
+    /// Reads `GITHUB_EVENT_PATH` env var. Returns error if not in CI.
+    async fn get_event_path(&self) -> Result<String, ActionInputError>;
+}
+
+/// Application service for parsing `/rigorix` slash commands from comments.
+///
+/// Implements the `CommentParser` component from the architecture doc.
+/// Scans issue/PR comment bodies for `/rigorix <command> [args]` patterns.
+///
+/// # Contract (Frozen)
+/// - Commands: run, validate, plan, status, retry
+/// - Returns `None` if no command prefix is found
+/// - Returns `CommentCommand::Help` for unrecognized commands after `/rigorix`
+/// - Case-sensitive matching against `/rigorix` prefix
+#[async_trait]
+pub trait CommentParsingService: Send + Sync {
+    /// Parse a comment body for a `/rigorix` command.
+    ///
+    /// Scans the comment text for lines starting with `/rigorix`.
+    /// Returns the parsed command or `None` if no command is found.
+    async fn parse(
+        &self,
+        input: ParseCommentInput,
+    ) -> Result<ParseCommentOutput, ActionInputError>;
+
+    /// Parse a command and validate its arguments.
+    ///
+    /// Like `parse()`, but also validates that:
+    /// - `run`/`validate`/`plan` commands have non-empty intent
+    /// - `retry` commands have a valid UUID
+    async fn parse_and_validate(
+        &self,
+        input: ParseCommentInput,
+    ) -> Result<ParseCommentOutput, ActionInputError>;
+
+    /// Check if a comment text starts with the command prefix.
+    async fn has_command_prefix(&self, comment: &str) -> bool;
+
+    /// Extract the command arguments string after the prefix and command word.
+    ///
+    /// E.g., for `/rigorix run implement feature X`, returns `"implement feature X"`.
+    async fn extract_args(&self, comment: &str) -> Option<String>;
+
+    /// Validate that the commenter has permission to execute a command.
+    ///
+    /// Checks against allowed actors (repo owner, collaborators, etc.).
+    async fn validate_permission(
+        &self,
+        commenter: &str,
+        command: &CommentCommand,
+    ) -> Result<bool, ActionInputError>;
+}
+
+/// Application service for detecting the CI environment.
+///
+/// Implements the `CiDetector` component from the architecture doc.
+/// Checks for CI-specific environment variables to determine the
+/// runtime context and set appropriate permission modes.
+///
+/// # Contract (Frozen)
+/// - Detects `GITHUB_ACTIONS` → `CiEnvironment::GitHubActions`
+/// - Falls back to `CiEnvironment::Local`
+/// - CI defaults to `workspace_write` permission mode
+/// - Local defaults to `prompt` permission mode
+#[async_trait]
+pub trait CiDetectionService: Send + Sync {
+    /// Detect the CI environment type.
+    ///
+    /// Checks for `GITHUB_ACTIONS` env var to determine if running
+    /// inside GitHub Actions. Returns `CiEnvironment::Local` otherwise.
+    async fn detect(&self, input: DetectCiInput) -> Result<DetectCiOutput, ActionInputError>;
+
+    /// Get the default permission mode for the current environment.
+    ///
+    /// Returns `"workspace_write"` in CI, `"prompt"` locally.
+    async fn default_permission_mode(&self) -> String;
+
+    /// Check if the current environment is CI.
+    async fn is_ci(&self) -> bool;
+
+    /// Get the workspace root path.
+    ///
+    /// Reads `GITHUB_WORKSPACE` in CI, returns current dir locally.
+    async fn workspace_root(&self) -> Result<String, ActionInputError>;
+}
+
+/// Application service for loading and merging action configuration.
+///
+/// Implements the `ConfigLoader` component from the architecture doc.
+/// Merges configuration from multiple sources with proper precedence:
+/// 1. `INPUT_*` env vars (runtime overrides, highest priority)
+/// 2. CLI arguments (if run outside GitHub Actions)
+/// 3. `action.yml` defaults
+/// 4. Engine defaults
+///
+/// # Contract (Frozen)
+/// - `load()` is the primary entry point
+/// - Environment overrides take highest precedence
+/// - Missing `action.yml` is non-fatal (uses defaults)
+/// - Returns structured output indicating which sources contributed
+#[async_trait]
+pub trait ConfigLoadingService: Send + Sync {
+    /// Load and merge configuration from all available sources.
+    ///
+    /// Resolution order (highest priority wins):
+    /// 1. Environment variable overrides (`INPUT_*`)
+    /// 2. CLI argument overrides
+    /// 3. `action.yml` default values
+    /// 4. Compiled-in defaults
+    async fn load(&self, input: LoadConfigInput) -> Result<LoadConfigOutput, ActionInputError>;
+
+    /// Load default values from `action.yml`.
+    ///
+    /// Parses the `action.yml` file in the current working directory
+    /// and extracts the `inputs` section defaults.
+    async fn load_yml_defaults(
+        &self,
+        path_override: Option<String>,
+    ) -> Result<crate::action_input::domain::ActionInputs, ActionInputError>;
+
+    /// Merge environment overrides into the base config.
+    ///
+    /// Applies `INPUT_*` env var values on top of the base config.
+    /// Environment values that are set override the base.
+    async fn apply_env_overrides(
+        &self,
+        base: crate::action_input::domain::ActionInputs,
+    ) -> Result<crate::action_input::domain::ActionInputs, ActionInputError>;
+
+    /// Merge CLI argument overrides into the base config.
+    async fn apply_cli_overrides(
+        &self,
+        base: crate::action_input::domain::ActionInputs,
+        overrides: std::collections::HashMap<String, String>,
+    ) -> Result<crate::action_input::domain::ActionInputs, ActionInputError>;
+
+    /// Resolve a merged `ActionInputs` (with `Option` fields) into a
+    /// concrete `ActionConfig` (all fields resolved to defaults).
+    async fn resolve(
+        &self,
+        merged: crate::action_input::domain::ActionInputs,
+    ) -> Result<crate::action_input::domain::ActionConfig, ActionInputError>;
+}
+
+/// Application service for validating parsed inputs.
+///
+/// Validates that parsed inputs meet semantic constraints before
+/// they are passed to the action router or engine.
+///
+/// # Contract (Frozen)
+/// - Validates required fields based on mode
+/// - Validates numeric fields are within acceptable bounds
+/// - Detects conflicting inputs
+/// - Returns structured validation results
+#[async_trait]
+pub trait InputValidationService: Send + Sync {
+    /// Validate parsed inputs against semantic constraints.
+    ///
+    /// Checks include:
+    /// - Mode-specific required fields (e.g., intent required for `run` mode)
+    /// - Numeric bounds (e.g., max_llm_calls > 0)
+    /// - No conflicting inputs
+    async fn validate(
+        &self,
+        input: ValidateInputsInput,
+    ) -> Result<ValidateInputsOutput, ActionInputError>;
+
+    /// Validate that intent is provided when required.
+    ///
+    /// Intent is required for `run`, `validate`, and `plan` modes.
+    async fn require_intent_for_mode(
+        &self,
+        mode: &str,
+        intent: &Option<String>,
+    ) -> Result<(), ActionInputError>;
+}

--- a/actions/src/action_input/domain/error.rs
+++ b/actions/src/action_input/domain/error.rs
@@ -1,0 +1,116 @@
+//! Error types for the Action Input bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/action-input.md
+//! Implements: Contract Freeze — ActionInputError enum
+//! Issue: issue-contract-freeze
+//!
+//! All errors use `thiserror` derive macros. No `anyhow` in library code.
+//!
+//! # Contract (Frozen)
+//! - `ActionInputError` is the single error type for this module
+//! - Each variant carries structured context for error reporting
+//! - Implements `std::error::Error` for library compatibility
+
+use thiserror::Error;
+
+use crate::shared::github_client::GitHubClientError;
+
+/// Errors that can occur during GitHub Action input parsing.
+#[derive(Debug, Error)]
+pub enum ActionInputError {
+    /// A required input variable was not provided.
+    #[error("Missing required input: {0}")]
+    MissingRequiredInput(String),
+
+    /// An input value could not be parsed into the expected type.
+    #[error("Invalid input value for '{field}': expected {expected_type}, got '{value}'")]
+    InvalidInputValue {
+        /// The input field name (e.g. "INPUT_MAX_LLM_CALLS").
+        field: String,
+        /// The expected Rust type.
+        expected_type: &'static str,
+        /// The raw string value that failed to parse.
+        value: String,
+    },
+
+    /// The `GITHUB_EVENT_PATH` file was not found or unreadable.
+    #[error("GitHub event payload not found at '{path}': {detail}")]
+    EventPayloadNotFound {
+        /// The expected path to the event payload file.
+        path: String,
+        /// Additional details about the failure.
+        detail: String,
+    },
+
+    /// Failed to parse the GitHub event JSON payload.
+    #[error("Failed to parse GitHub event payload: {detail}")]
+    EventPayloadParseError {
+        /// Parse error description.
+        detail: String,
+        /// Source line number if available.
+        line: Option<u32>,
+    },
+
+    /// Unknown or unsupported GitHub event type.
+    #[error("Unknown or unsupported GitHub event type: {event_name}")]
+    UnsupportedEventType {
+        /// The value of `GITHUB_EVENT_NAME`.
+        event_name: String,
+    },
+
+    /// The `action.yml` file was not found or unreadable.
+    #[error("action.yml not found: {detail}")]
+    ActionYmlNotFound {
+        /// Additional details about the failure.
+        detail: String,
+    },
+
+    /// Failed to parse `action.yml`.
+    #[error("Failed to parse action.yml: {detail}")]
+    ActionYmlParseError {
+        /// Parse error description.
+        detail: String,
+    },
+
+    /// IO error (file system, environment).
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// JSON serialization/deserialization error.
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// YAML serialization/deserialization error.
+    #[error("YAML error: {0}")]
+    Yaml(#[from] serde_yaml::Error),
+
+    /// GitHub API client error.
+    #[error("GitHub API error: {0}")]
+    GitHubApi(#[from] GitHubClientError),
+
+    /// Environment variable error (e.g., missing GITHUB_WORKSPACE).
+    #[error("Environment error: {detail}")]
+    EnvironmentError {
+        /// Error description.
+        detail: String,
+    },
+
+    /// Internal invariant violation (should not happen).
+    #[error("Internal error: {detail}")]
+    Internal {
+        /// Error description.
+        detail: String,
+    },
+}
+
+impl ActionInputError {
+    /// Whether the error is retriable.
+    pub fn is_retriable(&self) -> bool {
+        matches!(
+            self,
+            ActionInputError::Io(_)
+                | ActionInputError::GitHubApi(_)
+                | ActionInputError::EventPayloadNotFound { .. }
+        )
+    }
+}

--- a/actions/src/action_input/domain/event/mod.rs
+++ b/actions/src/action_input/domain/event/mod.rs
@@ -1,0 +1,76 @@
+//! Event payload schemas for the Action Input bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/action-input.md
+//! Implements: Contract Freeze — ActionInputEvent payload schemas
+//! Issue: issue-contract-freeze
+//!
+//! These events are emitted on the EventBus whenever inputs are parsed,
+//! commands are detected, or CI environment is resolved. Consumers
+//! (audit, console printer, action-entrypoint) subscribe to these event types.
+//!
+//! # Contract (Frozen)
+//! - Each event carries the full context needed by consumers
+//! - No internal implementation details exposed
+//! - Events are serializable for audit logging
+
+use serde::{Deserialize, Serialize};
+
+/// Events emitted by the Action Input module.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ActionInputEvent {
+    /// Inputs were successfully parsed from the environment.
+    InputsParsed {
+        /// Which mode was resolved (or None if ambiguous).
+        mode: Option<String>,
+        /// Whether intent was provided.
+        has_intent: bool,
+        /// Number of non-default input fields set.
+        inputs_count: u32,
+    },
+
+    /// A `/rigorix` slash command was detected in a comment.
+    CommentCommandDetected {
+        /// The issue or PR number where the comment was posted.
+        issue_number: u64,
+        /// The command type (run, validate, plan, status, retry, help).
+        command_type: String,
+        /// The commenter's username.
+        commenter: String,
+    },
+
+    /// CI environment was detected.
+    CiEnvironmentDetected {
+        /// Whether we're running in CI.
+        is_ci: bool,
+        /// The CI type (GitHubActions or Local).
+        ci_type: String,
+        /// The resolved permission mode.
+        permission_mode: String,
+    },
+
+    /// Configuration was loaded and merged.
+    ConfigLoaded {
+        /// Whether environment overrides were applied.
+        has_env_overrides: bool,
+        /// Whether action.yml defaults were found.
+        has_yml_defaults: bool,
+        /// Whether CLI overrides were applied.
+        has_cli_overrides: bool,
+    },
+
+    /// An input parsing error occurred (non-fatal warning).
+    InputWarning {
+        /// The field that produced the warning.
+        field: String,
+        /// Warning message.
+        message: String,
+    },
+
+    /// GitHub event payload was parsed.
+    EventParsed {
+        /// The event type (workflow_dispatch, issue_comment, pull_request, push, unknown).
+        event_type: String,
+        /// Whether parsing succeeded.
+        success: bool,
+    },
+}

--- a/actions/src/action_input/domain/mod.rs
+++ b/actions/src/action_input/domain/mod.rs
@@ -1,0 +1,26 @@
+//! Domain entities and interfaces for the Action Input bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/action-input.md#domain
+//! Implements: Contract Freeze — domain entities ActionInputs, ActionConfig, CommentCommand,
+//! CiEnvironment, GitHubEvent, ActionInputError, ActionInputEvent
+//! Issue: issue-contract-freeze
+//!
+//! This module defines the core domain types — `ActionInputs`, `ActionConfig`,
+//! `CommentCommand`, `CiEnvironment`, `GitHubEvent`, `ActionInputError`, and
+//! `ActionInputEvent`. These are pure domain objects with no framework
+//! dependencies. They serve as the frozen contract that all implementation
+//! must satisfy.
+//!
+//! # Contract (Frozen)
+//! - No implementation logic beyond constructors and field accessors
+//! - All validation must happen in the application layer (service traits)
+//! - All persistence must happen behind repository interfaces
+//! - All domain types are serializable (Serialize + Deserialize)
+
+pub mod error;
+pub mod event;
+pub mod types;
+
+pub use error::*;
+pub use event::*;
+pub use types::*;

--- a/actions/src/action_input/domain/types.rs
+++ b/actions/src/action_input/domain/types.rs
@@ -1,0 +1,298 @@
+//! Domain types for GitHub Action input parsing.
+//!
+//! @canonical actions/.pi/architecture/modules/action-input.md#types
+//! Implements: Contract Freeze — ActionInputs, ActionConfig, CommentCommand, CiEnvironment
+//! Issue: issue-contract-freeze
+//!
+//! These are the core domain types that represent parsed GitHub Action inputs,
+//! configuration, CI environment detection, and slash command parsing.
+//! They serve as the frozen contract that all implementation must satisfy.
+//!
+//! # Contract (Frozen)
+//! - No implementation logic beyond constructors and field accessors
+//! - All validation must happen in the application layer (service traits)
+//! - All types are serializable (Serialize + Deserialize) where applicable
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// ActionInputs
+// ---------------------------------------------------------------------------
+
+/// All inputs parsed from the GitHub Action environment.
+///
+/// Fields marked `Option` are optional and have sensible defaults
+/// when not provided (applied by `ConfigLoader`).
+///
+/// ## Source
+///
+/// These values originate from the workflow YAML `with:` block and are
+/// passed by GitHub Actions as `INPUT_<NAME>` environment variables
+/// (uppercased, hyphens replaced with underscores).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ActionInputs {
+    /// Natural-language intent for the engine.
+    /// Required for `run`, `plan`, and `validate` modes.
+    pub intent: Option<String>,
+
+    /// Execution mode: auto, governance, run, validate, plan, status.
+    /// Default: "auto" (detect from event context).
+    pub mode: Option<String>,
+
+    /// Permission mode for engine tool execution.
+    /// Default: "workspace_write" (in CI), "prompt" (local).
+    pub permission_mode: Option<String>,
+
+    /// Path to policy.toml for Mode A governance.
+    /// Default: ".rigorix/policy.toml".
+    pub policy_file: Option<String>,
+
+    /// Mode A: fail workflow on policy violations.
+    /// Default: false (warn-only for early adoption).
+    pub fail_on_violation: Option<bool>,
+
+    /// Fail workflow if the action itself encounters an error.
+    /// Default: false (fail-open).
+    pub fail_on_action_error: Option<bool>,
+
+    /// Maximum LLM API calls per execution.
+    pub max_llm_calls: Option<u32>,
+
+    /// Maximum LLM tokens per execution.
+    pub max_llm_tokens: Option<u64>,
+
+    /// Maximum validation loop iterations.
+    /// Default: 3.
+    pub max_validation_iterations: Option<u32>,
+
+    /// Maximum retries for transient API failures.
+    /// Default: 3.
+    pub max_retries: Option<u32>,
+
+    /// Base retry delay in milliseconds (exponential backoff with ±25% jitter).
+    /// Default: 1000.
+    pub retry_delay_ms: Option<u64>,
+
+    /// Whether to post results as a PR comment.
+    pub post_pr_comment: Option<bool>,
+
+    /// Configuration profile to use.
+    pub profile: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// ActionConfig
+// ---------------------------------------------------------------------------
+
+/// Final merged configuration after resolving defaults, YAML, and environment overrides.
+///
+/// Produced by `ConfigLoader` from merging:
+/// 1. `INPUT_*` environment variables (runtime overrides, highest priority)
+/// 2. CLI arguments (if run outside GitHub Actions)
+/// 3. `action.yml` default values
+/// 4. Engine defaults (from rigorix-engine configuration module)
+///
+/// Unlike `ActionInputs` (which preserves `Option` for all fields),
+/// `ActionConfig` has all values resolved to concrete types.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActionConfig {
+    /// Natural-language intent for the engine.
+    pub intent: Option<String>,
+
+    /// Execution mode: auto, governance, run, validate, plan, status.
+    pub mode: String,
+
+    /// Permission mode: read_only, workspace_write, dangerous_full_access.
+    pub permission_mode: String,
+
+    /// Path to policy.toml for Mode A governance.
+    pub policy_file: String,
+
+    /// Mode A: fail workflow on policy violations.
+    pub fail_on_violation: bool,
+
+    /// Fail workflow if the action itself encounters an error.
+    pub fail_on_action_error: bool,
+
+    /// Maximum LLM calls per execution.
+    pub max_llm_calls: u32,
+
+    /// Maximum LLM tokens per execution.
+    pub max_llm_tokens: u64,
+
+    /// Maximum validation loop iterations.
+    pub max_validation_iterations: u32,
+
+    /// Maximum retries for transient API failures.
+    pub max_retries: u32,
+
+    /// Base retry delay in milliseconds.
+    pub retry_delay_ms: u64,
+
+    /// Whether to post results as a PR comment.
+    pub post_pr_comment: bool,
+
+    /// Configuration profile to use.
+    pub profile: Option<String>,
+}
+
+impl Default for ActionConfig {
+    fn default() -> Self {
+        Self {
+            intent: None,
+            mode: "auto".to_string(),
+            permission_mode: "workspace_write".to_string(),
+            policy_file: ".rigorix/policy.toml".to_string(),
+            fail_on_violation: false,
+            fail_on_action_error: false,
+            max_llm_calls: 50,
+            max_llm_tokens: 50000,
+            max_validation_iterations: 3,
+            max_retries: 3,
+            retry_delay_ms: 1000,
+            post_pr_comment: true,
+            profile: None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CommentCommand
+// ---------------------------------------------------------------------------
+
+/// Parsed `/rigorix` slash command from an issue or PR comment.
+///
+/// Supported commands:
+/// - `/rigorix run <intent>` — full execution
+/// - `/rigorix validate <intent>` — validation loop
+/// - `/rigorix plan <intent>` — plan only
+/// - `/rigorix status` — current status
+/// - `/rigorix retry <execution_id>` — retry a failed execution
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum CommentCommand {
+    /// Full Mode B execution: plan → execute → validate → persist.
+    Run {
+        /// Natural-language intent describing the work to be done.
+        intent: String,
+    },
+
+    /// Self-correcting validation loop.
+    Validate {
+        /// Natural-language intent for validation.
+        intent: String,
+    },
+
+    /// Planning phase only — no execution.
+    Plan {
+        /// Natural-language intent for planning.
+        intent: String,
+    },
+
+    /// Show current execution status.
+    Status,
+
+    /// Retry a previously failed execution.
+    Retry {
+        /// The execution ID to retry.
+        execution_id: String,
+    },
+
+    /// Show help/usage information.
+    Help,
+}
+
+// ---------------------------------------------------------------------------
+// CiEnvironment
+// ---------------------------------------------------------------------------
+
+/// Detected CI environment type.
+///
+/// Determines permission defaults and output formatting.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum CiEnvironment {
+    /// Running inside GitHub Actions.
+    GitHubActions {
+        /// Value of `GITHUB_WORKSPACE`.
+        workspace: String,
+        /// Value of `GITHUB_EVENT_NAME`.
+        event_name: String,
+        /// Value of `GITHUB_ACTOR`.
+        actor: String,
+    },
+
+    /// Running locally (not in CI).
+    Local,
+}
+
+impl CiEnvironment {
+    /// Whether the current environment is CI.
+    pub fn is_ci(&self) -> bool {
+        matches!(self, CiEnvironment::GitHubActions { .. })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GitHubEvent
+// ---------------------------------------------------------------------------
+
+/// Parsed GitHub event context from `GITHUB_EVENT_PATH`.
+///
+/// Not all fields are present — the structure depends on the event type
+/// (`GITHUB_EVENT_NAME`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "event_type")]
+pub enum GitHubEvent {
+    /// Triggered by `workflow_dispatch` — manual trigger via UI or API.
+    WorkflowDispatch {
+        /// Branch/tag/ref that was dispatched.
+        ref_name: String,
+        /// Inputs passed to the workflow_dispatch event.
+        inputs: std::collections::HashMap<String, serde_json::Value>,
+    },
+
+    /// Triggered by `issue_comment` on an issue or PR.
+    IssueComment {
+        /// The issue or PR number.
+        issue_number: u64,
+        /// The raw comment body text.
+        comment_body: String,
+        /// The username that posted the comment.
+        commenter: String,
+    },
+
+    /// Triggered by `pull_request` events.
+    PullRequest {
+        /// The PR number.
+        pr_number: u64,
+        /// The PR action (opened, synchronize, closed, labeled, etc.).
+        action: String,
+        /// PR title.
+        title: String,
+        /// PR body text.
+        body: Option<String>,
+        /// Base branch name.
+        base_branch: String,
+        /// Head branch name.
+        head_branch: String,
+        /// Head commit SHA.
+        head_sha: String,
+    },
+
+    /// Triggered by `push` events.
+    Push {
+        /// Branch name.
+        branch: String,
+        /// Commit SHA.
+        sha: String,
+        /// Commit message.
+        message: String,
+        /// Pusher username.
+        pusher: String,
+    },
+
+    /// Unknown or unsupported event type.
+    Unknown {
+        /// The raw event name from `GITHUB_EVENT_NAME`.
+        event_name: String,
+    },
+}

--- a/actions/src/action_input/infrastructure/mod.rs
+++ b/actions/src/action_input/infrastructure/mod.rs
@@ -1,0 +1,18 @@
+//! Infrastructure layer for the Action Input bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/action-input.md#infrastructure
+//! Implements: Contract Freeze — repository interfaces for input, config, and event data access
+//! Issue: issue-contract-freeze
+//!
+//! This module defines the repository interfaces that abstract data access
+//! for the Action Input module. Implementations will read from environment
+//! variables, filesystem (action.yml, event payloads), and CLI arguments.
+//!
+//! # Contract (Frozen)
+//! - All repository methods are async
+//! - All methods return `Result<_, ActionInputError>`
+//! - No dependencies on external frameworks
+
+pub mod repository;
+
+pub use repository::*;

--- a/actions/src/action_input/infrastructure/repository/mod.rs
+++ b/actions/src/action_input/infrastructure/repository/mod.rs
@@ -1,0 +1,117 @@
+//! Repository interfaces for the Action Input bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/action-input.md
+//! Implements: Contract Freeze — InputRepository, ConfigRepository, EventRepository traits
+//! Issue: issue-contract-freeze
+//!
+//! Repositories abstract data access behind interfaces, allowing
+//! implementations to use environment variables, filesystem, or mock
+//! storage without coupling domain logic to infrastructure.
+//!
+//! # Contract (Frozen)
+//! - All repository methods are async
+//! - All methods return domain error types
+//! - No framework-specific annotations on trait definitions
+//! - Implementations are hidden behind these interfaces
+
+use async_trait::async_trait;
+
+use crate::action_input::domain::ActionInputError;
+
+/// Repository for reading environment variables.
+///
+/// Abstracts `std::env::var` / `std::env::vars` behind a trait for
+/// testability. Implementations can use real environment variables
+/// or an in-memory map.
+///
+/// # Security
+/// - Implementations MUST NOT log environment variable values
+/// - Variable names (keys) are safe for logging
+#[async_trait]
+pub trait InputRepository: Send + Sync {
+    /// Read a single environment variable by name.
+    ///
+    /// Returns `Ok(None)` if the variable is not set.
+    async fn read_env_var(&self, name: &str) -> Result<Option<String>, ActionInputError>;
+
+    /// Read all environment variables matching a prefix.
+    ///
+    /// Returns a map of variable names (without prefix) to values.
+    /// E.g., prefix `INPUT_` with `INPUT_MODE=run` returns `{"MODE": "run"}`.
+    async fn read_env_vars(&self, prefix: &str) -> Result<std::collections::HashMap<String, String>, ActionInputError>;
+
+    /// Check if an environment variable is set.
+    async fn has_env_var(&self, name: &str) -> Result<bool, ActionInputError>;
+
+    /// Get the workspace root path.
+    ///
+    /// Reads `GITHUB_WORKSPACE` in CI, falls back to current dir.
+    async fn workspace_root(&self) -> Result<String, ActionInputError>;
+
+    /// Get all CI-related environment variables.
+    ///
+    /// Returns variables like `GITHUB_ACTIONS`, `GITHUB_EVENT_NAME`,
+    /// `GITHUB_EVENT_PATH`, `GITHUB_ACTOR`, etc.
+    async fn read_ci_env_vars(&self) -> Result<std::collections::HashMap<String, String>, ActionInputError>;
+}
+
+/// Repository for reading action configuration sources.
+///
+/// Abstracts filesystem access to `action.yml` and CLI arguments
+/// behind a trait for testability.
+///
+/// # Security
+/// - File paths must be validated against directory traversal
+/// - YAML parsing must not execute arbitrary code
+#[async_trait]
+pub trait ConfigRepository: Send + Sync {
+    /// Read the `action.yml` file content.
+    ///
+    /// Searches CWD for `action.yml` by default.
+    /// Returns `Ok(None)` if the file doesn't exist (non-fatal).
+    async fn read_action_yml(&self, path_override: Option<&str>) -> Result<Option<String>, ActionInputError>;
+
+    /// Parse default input values from `action.yml` content.
+    ///
+    /// Extracts the `inputs` section from the YAML and returns
+    /// a map of input name to default value.
+    async fn parse_yml_defaults(
+        &self,
+        yaml_content: &str,
+    ) -> Result<std::collections::HashMap<String, serde_yaml::Value>, ActionInputError>;
+
+    /// Read CLI argument overrides.
+    ///
+    /// Returns parsed CLI arguments as a flat map of name → value.
+    /// Returns empty map if no CLI args are available.
+    async fn read_cli_args(&self) -> Result<std::collections::HashMap<String, String>, ActionInputError>;
+
+    /// Resolve the full path to `action.yml`.
+    ///
+    /// Returns the absolute path if the file exists.
+    async fn resolve_action_yml_path(&self) -> Result<Option<String>, ActionInputError>;
+}
+
+/// Repository for reading GitHub event payloads.
+///
+/// Abstracts filesystem access to the `GITHUB_EVENT_PATH` JSON file
+/// behind a trait for testability.
+#[async_trait]
+pub trait EventRepository: Send + Sync {
+    /// Read the GitHub event payload file content.
+    ///
+    /// Reads the file at the path specified by `GITHUB_EVENT_PATH`.
+    async fn read_event_payload(&self, path: &str) -> Result<String, ActionInputError>;
+
+    /// Get the `GITHUB_EVENT_PATH` from the environment.
+    async fn get_event_path(&self) -> Result<Option<String>, ActionInputError>;
+
+    /// Get the `GITHUB_EVENT_NAME` from the environment.
+    async fn get_event_name(&self) -> Result<Option<String>, ActionInputError>;
+
+    /// Get the `GITHUB_SHA` from the environment.
+    async fn get_head_sha(&self) -> Result<Option<String>, ActionInputError>;
+
+    /// Get the `GITHUB_REF` from the environment.
+    async fn get_ref(&self) -> Result<Option<String>, ActionInputError>;
+}

--- a/actions/src/action_input/interfaces/http/mod.rs
+++ b/actions/src/action_input/interfaces/http/mod.rs
@@ -1,0 +1,252 @@
+//! HTTP API contracts for Action Input endpoints.
+//!
+//! @canonical actions/.pi/architecture/modules/action-input.md
+//! Implements: Contract Freeze — HTTP endpoint contracts and error formats
+//! Issue: issue-contract-freeze
+//!
+//! Defines endpoint paths, methods, request/response schemas, and error
+//! response formats. These contracts are framework-agnostic — they describe
+//! the API surface that any HTTP server implementation must satisfy.
+//!
+//! Note: In production, the action runs as a GitHub Action, not an HTTP server.
+//! These contracts exist for:
+//! - Local development & debugging endpoints
+//! - Runtime introspection (health checks, status)
+//! - Testing via HTTP mocks
+//!
+//! # Contract (Frozen)
+//! - All endpoints documented with method, path, request, and response types
+//! - Error responses follow a unified format
+//! - No framework-specific annotations (axum/actix/warp annotations added by implementation)
+
+use serde::{Deserialize, Serialize};
+
+use crate::action_input::domain::{ActionConfig, ActionInputs, CiEnvironment, CommentCommand, GitHubEvent};
+
+// ---------------------------------------------------------------------------
+// API Base Path
+// ---------------------------------------------------------------------------
+
+/// All action input endpoints are served under this base path.
+pub const API_BASE_PATH: &str = "/api/v1/action-input";
+
+// ---------------------------------------------------------------------------
+// Endpoint: GET /api/v1/action-input/inputs
+// ---------------------------------------------------------------------------
+
+/// GET /api/v1/action-input/inputs
+///
+/// Retrieve the current parsed action inputs.
+///
+/// **Response:** `200 OK` with `GetInputsResponse`
+pub const GET_INPUTS_PATH: &str = "/api/v1/action-input/inputs";
+pub const GET_INPUTS_METHOD: &str = "GET";
+
+/// Response for GET /api/v1/action-input/inputs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetInputsResponse {
+    /// The parsed action inputs.
+    pub inputs: ActionInputs,
+    /// Number of populated input fields.
+    pub populated_count: u32,
+    /// Environment variables that were checked.
+    pub env_vars_checked: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/action-input/parse
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/action-input/parse
+///
+/// Parse inputs from a provided environment map (for testing/debugging).
+///
+/// **Request:** `ParseInputsRequest`
+/// **Response:** `200 OK` with `ParseInputsResponse`
+pub const PARSE_INPUTS_PATH: &str = "/api/v1/action-input/parse";
+pub const PARSE_INPUTS_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/action-input/parse.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParseInputsRequest {
+    /// Environment variable map (key = var name, value = var value).
+    pub env: std::collections::HashMap<String, String>,
+    /// Optional env prefix (default: `INPUT_`).
+    pub env_prefix: Option<String>,
+}
+
+/// Response body for POST /api/v1/action-input/parse.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParseInputsResponse {
+    pub success: bool,
+    pub inputs: ActionInputs,
+    pub warnings: Vec<String>,
+    pub missing_required: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/action-input/event
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/action-input/event
+///
+/// Parse a GitHub event payload JSON (for testing/debugging).
+///
+/// **Request:** `ParseEventRequest`
+/// **Response:** `200 OK` with `ParseEventResponse`
+pub const PARSE_EVENT_PATH: &str = "/api/v1/action-input/event";
+pub const PARSE_EVENT_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/action-input/event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParseEventRequest {
+    /// The raw event payload JSON.
+    pub payload: serde_json::Value,
+    /// The event name (e.g. "pull_request", "issue_comment").
+    pub event_name: String,
+}
+
+/// Response body for POST /api/v1/action-input/event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParseEventResponse {
+    pub success: bool,
+    pub event: GitHubEvent,
+    pub event_type: String,
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/action-input/comment
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/action-input/comment
+///
+/// Parse a comment for `/rigorix` commands (for testing/debugging).
+///
+/// **Request:** `ParseCommentRequest`
+/// **Response:** `200 OK` with `ParseCommentResponse`
+pub const PARSE_COMMENT_PATH: &str = "/api/v1/action-input/comment";
+pub const PARSE_COMMENT_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/action-input/comment.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParseCommentRequest {
+    /// The raw comment body text.
+    pub body: String,
+    /// The issue/PR number.
+    pub issue_number: u64,
+    /// The commenter's username.
+    pub commenter: String,
+}
+
+/// Response body for POST /api/v1/action-input/comment.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParseCommentResponse {
+    pub found: bool,
+    pub command: Option<CommentCommand>,
+    pub command_type: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: GET /api/v1/action-input/ci
+// ---------------------------------------------------------------------------
+
+/// GET /api/v1/action-input/ci
+///
+/// Detect the CI environment.
+///
+/// **Response:** `200 OK` with `CiDetectionResponse`
+pub const CI_DETECTION_PATH: &str = "/api/v1/action-input/ci";
+pub const CI_DETECTION_METHOD: &str = "GET";
+
+/// Response for GET /api/v1/action-input/ci.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CiDetectionResponse {
+    pub is_ci: bool,
+    pub environment: CiEnvironment,
+    pub permission_mode: String,
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/action-input/config
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/action-input/config
+///
+/// Load and merge action configuration.
+///
+/// **Request:** `LoadConfigRequest`
+/// **Response:** `200 OK` with `LoadConfigResponse`
+pub const LOAD_CONFIG_PATH: &str = "/api/v1/action-input/config";
+pub const LOAD_CONFIG_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/action-input/config.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoadConfigRequest {
+    /// Override action.yml content (YAML string).
+    pub action_yml_override: Option<String>,
+    /// Override environment variables.
+    pub env_override: Option<std::collections::HashMap<String, String>>,
+    /// Allow empty/missing action.yml.
+    pub allow_empty: Option<bool>,
+}
+
+/// Response body for POST /api/v1/action-input/config.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoadConfigResponse {
+    pub success: bool,
+    pub config: ActionConfig,
+    pub sources: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Unified Error Response Format
+// ---------------------------------------------------------------------------
+
+/// Standard error response for all Action Input API endpoints.
+///
+/// All 4xx/5xx responses use this format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiErrorResponse {
+    /// HTTP status code.
+    pub status: u16,
+    /// Machine-readable error code.
+    pub code: String,
+    /// Human-readable error message.
+    pub message: String,
+    /// Detailed error context (optional, may include field-level errors).
+    pub details: Option<serde_json::Value>,
+    /// Request ID for tracing (if available).
+    pub request_id: Option<String>,
+}
+
+/// Standardized error codes for Action Input API.
+pub mod error_codes {
+    /// Missing required input.
+    pub const MISSING_INPUT: &str = "MISSING_REQUIRED_INPUT";
+    /// Input value parse error (e.g., non-numeric string for u32).
+    pub const INVALID_INPUT_VALUE: &str = "INVALID_INPUT_VALUE";
+    /// Event payload file not found.
+    pub const EVENT_NOT_FOUND: &str = "EVENT_PAYLOAD_NOT_FOUND";
+    /// Event payload JSON parse error.
+    pub const EVENT_PARSE_ERROR: &str = "EVENT_PARSE_ERROR";
+    /// Unsupported event type.
+    pub const UNSUPPORTED_EVENT: &str = "UNSUPPORTED_EVENT_TYPE";
+    /// Action YAML file not found.
+    pub const ACTION_YML_NOT_FOUND: &str = "ACTION_YML_NOT_FOUND";
+    /// Action YAML parse error.
+    pub const ACTION_YML_PARSE_ERROR: &str = "ACTION_YML_PARSE_ERROR";
+    /// Internal server error.
+    pub const INTERNAL_ERROR: &str = "INTERNAL_ERROR";
+}
+
+/// HTTP status code mappings for Action Input errors.
+pub mod status_codes {
+    pub const MISSING_INPUT: u16 = 400;
+    pub const INVALID_INPUT_VALUE: u16 = 400;
+    pub const EVENT_NOT_FOUND: u16 = 404;
+    pub const EVENT_PARSE_ERROR: u16 = 400;
+    pub const UNSUPPORTED_EVENT: u16 = 400;
+    pub const ACTION_YML_NOT_FOUND: u16 = 404;
+    pub const ACTION_YML_PARSE_ERROR: u16 = 400;
+    pub const INTERNAL_ERROR: u16 = 500;
+}

--- a/actions/src/action_input/interfaces/mod.rs
+++ b/actions/src/action_input/interfaces/mod.rs
@@ -1,0 +1,18 @@
+//! Interfaces layer for the Action Input bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/action-input.md#interfaces
+//! Implements: Contract Freeze — HTTP API contracts
+//! Issue: issue-contract-freeze
+//!
+//! This module defines the external-facing API contracts for the
+//! Action Input module. HTTP endpoints are framework-agnostic contracts
+//! that any HTTP server implementation must satisfy.
+//!
+//! # Contract (Frozen)
+//! - All endpoint paths, methods, requests, and responses are documented
+//! - Error responses follow a unified format
+//! - No framework-specific annotations
+
+pub mod http;
+
+pub use http::*;

--- a/actions/src/action_input/mod.rs
+++ b/actions/src/action_input/mod.rs
@@ -1,0 +1,64 @@
+//! Action Input — GitHub Action input parsing bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/action-input.md
+//! Implements: Contract Freeze — all component interfaces for action-input epic
+//! Issue: issue-contract-freeze
+//!
+//! This module parses GitHub Actions environment variables, event payloads,
+//! and workflow inputs into typed Rust structs that the engine can consume.
+//! It handles the impedance mismatch between GitHub's string-based `INPUT_*`
+//! environment variables and the engine's structured types.
+//!
+//! # Components
+//!
+//! | Component | Domain | Application | Infrastructure | Interfaces |
+//! |-----------|--------|-------------|----------------|------------|
+//! | ActionInputs | `domain::types::ActionInputs` | `application::dto` | — | `interfaces::http` |
+//! | InputParser | — | `application::service::InputParsingService` | `infrastructure::repository::InputRepository` | — |
+//! | EventPayloadParser | `domain::types::GitHubEvent` | `application::service::EventParsingService` | `infrastructure::repository::EventRepository` | — |
+//! | CommentParser | `domain::types::CommentCommand` | `application::service::CommentParsingService` | — | — |
+//! | CiDetector | `domain::types::CiEnvironment` | `application::service::CiDetectionService` | — | — |
+//! | ConfigLoader | `domain::types::ActionConfig` | `application::service::ConfigLoadingService` | `infrastructure::repository::ConfigRepository` | — |
+//!
+//! # Layer Structure
+//!
+//! ```text
+//! action_input/
+//! ├── mod.rs                          # Module root
+//! ├── domain/                         # Domain entities and interfaces
+//! │   ├── mod.rs
+//! │   ├── types.rs                    # ActionInputs, ActionConfig, CommentCommand, CiEnvironment, GitHubEvent
+//! │   ├── error.rs                    # ActionInputError
+//! │   └── event/
+//! │       └── mod.rs                  # ActionInputEvent payloads
+//! ├── application/                    # Application service interfaces and DTOs
+//! │   ├── mod.rs
+//! │   ├── service.rs                  # Service traits (InputParsingService, CommentParsingService, etc.)
+//! │   ├── dto/
+//! │   │   └── mod.rs                  # Input/output DTO schemas
+//! │   └── factory.rs                  # Factory interfaces
+//! ├── infrastructure/                 # Infrastructure layer
+//! │   ├── mod.rs
+//! │   └── repository/
+//! │       └── mod.rs                  # Repository interfaces (InputRepository, ConfigRepository, EventRepository)
+//! └── interfaces/                     # External interfaces
+//!     ├── mod.rs
+//!     └── http/
+//!         └── mod.rs                  # HTTP API contracts
+//! ```
+//!
+//! # Contract Freeze
+//!
+//! All public interfaces, DTO schemas, and contracts in this module are
+//! frozen. Implementation must satisfy these contracts, not the other way around.
+//! See `actions/.pi/architecture/modules/action-input.md` for the canonical spec.
+//!
+//! # Related Issues
+//!
+//! - Issue #521: Contract Freeze (this issue)
+//! - Issue #520: Epic "action-input"
+
+pub mod application;
+pub mod domain;
+pub mod infrastructure;
+pub mod interfaces;

--- a/actions/src/lib.rs
+++ b/actions/src/lib.rs
@@ -41,8 +41,8 @@
 // ── Phase 1: Scaffold + Shared ──
 pub mod shared;
 
-// ── Future modules (declared for reference, implemented in later phases) ──
-// pub mod action_input;       // Phase 1
+// ── Phase 1: Contract Freeze — interface-only declarations ──
+pub mod action_input;
 // pub mod security_config;    // Phase 2
 // pub mod diff_analyzer;      // Phase 3
 // pub mod policy_evaluator;   // Phase 3


### PR DESCRIPTION
## Contract Freeze: action-input

Define and freeze all public interfaces, contracts, and schemas for the action-input epic.

### Components Frozen
- **ActionInputs** — typed container of all parsed GitHub Action inputs
- **InputParser** — parses `INPUT_*` environment variables
- **CommentParser** — parses `/rigorix` slash commands from comments
- **CiDetector** — detects CI environment, sets permission mode
- **ConfigLoader** — loads action.yml defaults and merges with overrides

### Clean Architecture Layers
- `domain/` — types, error enum, event schemas
- `application/` — service traits, DTOs, factory interfaces
- `infrastructure/repository/` — data access interfaces
- `interfaces/http/` — API endpoint contracts

### Verification
- ✅ `cargo build` — passes
- ✅ `cargo test` — all tests pass
- ✅ `cargo clippy` — no new warnings
- ✅ Interface-only: zero implementation logic

Closes #521
Epic: #520