### PR TITLE
feat: contract freeze for security-config epic (#538)

### DIFF
--- a/actions/.pi/.guardian-epic-state.json
+++ b/actions/.pi/.guardian-epic-state.json
@@ -1,47 +1,47 @@
 {
-  "name": "\"action-input\"",
-  "trackingIssueId": "520",
+  "name": "\"security-config\"",
+  "trackingIssueId": "537",
   "epicId": null,
   "slices": [
     {
-      "module": "action-input",
+      "module": "security-config",
       "components": [
         {
-          "name": "ActionInputs",
+          "name": "ForkDetector",
           "status": "planned",
-          "description": "Typed container of all GitHub Action inputs",
+          "description": "/// Detects whether a PR originates from a forked repository.",
           "dependencies": [
             "none"
           ]
         },
         {
-          "name": "InputParser",
+          "name": "SecretMasker",
           "status": "planned",
-          "description": "Parse all GitHub Action inputs from environment variables",
+          "description": "/// Masks sensitive values from GitHub Actions workflow logs.",
           "dependencies": [
             "none"
           ]
         },
         {
-          "name": "CommentParser",
+          "name": "TokenValidator",
           "status": "planned",
-          "description": "Parse `/rigorix` slash commands from issue and PR comments",
+          "description": "/// Validates that the GitHub token has the required permissions.",
           "dependencies": [
             "none"
           ]
         },
         {
-          "name": "CiDetector",
+          "name": "UrlAllowlist",
           "status": "planned",
-          "description": "Detects the CI environment and adjusts engine configuration",
+          "description": "/// Validates backend URLs against a configured allowlist.",
           "dependencies": [
             "none"
           ]
         },
         {
-          "name": "ConfigLoader",
+          "name": "HmacSigner",
           "status": "planned",
-          "description": "Loads `action.yml` defaults and merges with environment overrides",
+          "description": "/// HMAC-SHA256 signing for audit record integrity.",
           "dependencies": [
             "none"
           ]
@@ -49,41 +49,41 @@
       ],
       "nextLogicalSlice": [
         {
-          "name": "ActionInputs",
+          "name": "ForkDetector",
           "status": "planned",
-          "description": "Typed container of all GitHub Action inputs",
+          "description": "/// Detects whether a PR originates from a forked repository.",
           "dependencies": [
             "none"
           ]
         },
         {
-          "name": "InputParser",
+          "name": "SecretMasker",
           "status": "planned",
-          "description": "Parse all GitHub Action inputs from environment variables",
+          "description": "/// Masks sensitive values from GitHub Actions workflow logs.",
           "dependencies": [
             "none"
           ]
         },
         {
-          "name": "CommentParser",
+          "name": "TokenValidator",
           "status": "planned",
-          "description": "Parse `/rigorix` slash commands from issue and PR comments",
+          "description": "/// Validates that the GitHub token has the required permissions.",
           "dependencies": [
             "none"
           ]
         },
         {
-          "name": "CiDetector",
+          "name": "UrlAllowlist",
           "status": "planned",
-          "description": "Detects the CI environment and adjusts engine configuration",
+          "description": "/// Validates backend URLs against a configured allowlist.",
           "dependencies": [
             "none"
           ]
         },
         {
-          "name": "ConfigLoader",
+          "name": "HmacSigner",
           "status": "planned",
-          "description": "Loads `action.yml` defaults and merges with environment overrides",
+          "description": "/// HMAC-SHA256 signing for audit record integrity.",
           "dependencies": [
             "none"
           ]
@@ -96,52 +96,52 @@
       "id": "issue-contract-freeze",
       "title": "Contract Freeze: Define interfaces and contracts",
       "status": "planned",
-      "remoteIssueId": "521"
+      "remoteIssueId": "538"
     },
     {
-      "id": "issue-actioninputs",
-      "title": "ActionInputs: Typed container of all GitHub Action inputs",
+      "id": "issue-forkdetector",
+      "title": "ForkDetector: /// Detects whether a PR originates from a forked repository.",
       "status": "planned",
-      "remoteIssueId": "522"
+      "remoteIssueId": "539"
     },
     {
-      "id": "issue-inputparser",
-      "title": "InputParser: Parse all GitHub Action inputs from environment variables",
+      "id": "issue-secretmasker",
+      "title": "SecretMasker: /// Masks sensitive values from GitHub Actions workflow logs.",
       "status": "planned",
-      "remoteIssueId": "523"
+      "remoteIssueId": "540"
     },
     {
-      "id": "issue-commentparser",
-      "title": "CommentParser: Parse `/rigorix` slash commands from issue and PR comments",
+      "id": "issue-tokenvalidator",
+      "title": "TokenValidator: /// Validates that the GitHub token has the required permissions.",
       "status": "planned",
-      "remoteIssueId": "524"
+      "remoteIssueId": "541"
     },
     {
-      "id": "issue-cidetector",
-      "title": "CiDetector: Detects the CI environment and adjusts engine configuration",
+      "id": "issue-urlallowlist",
+      "title": "UrlAllowlist: /// Validates backend URLs against a configured allowlist.",
       "status": "planned",
-      "remoteIssueId": "525"
+      "remoteIssueId": "542"
     },
     {
-      "id": "issue-configloader",
-      "title": "ConfigLoader: Loads `action.yml` defaults and merges with environment overrides",
+      "id": "issue-hmacsigner",
+      "title": "HmacSigner: /// HMAC-SHA256 signing for audit record integrity.",
       "status": "planned",
-      "remoteIssueId": "526"
+      "remoteIssueId": "543"
     },
     {
       "id": "issue-proofing",
       "title": "Proofing: Validation scripts + CI integration",
       "status": "planned",
-      "remoteIssueId": "527"
+      "remoteIssueId": "544"
     },
     {
       "id": "issue-architecture-readiness",
       "title": "Architecture Readiness: Runbook, DR, docs, CI enforcement",
       "status": "planned",
-      "remoteIssueId": "528"
+      "remoteIssueId": "545"
     }
   ],
   "status": "planning",
   "currentIssueIndex": 0,
-  "createdAt": "2026-06-20T13:37:36.843Z"
+  "createdAt": "2026-06-20T14:18:46.277Z"
 }

--- a/actions/.pi/.guardian-pipeline-state.json
+++ b/actions/.pi/.guardian-pipeline-state.json
@@ -1,13 +1,13 @@
 {
-  "id": "PL-4814",
-  "name": "\"action-input\"",
+  "id": "PL-5280",
+  "name": "\"security-config\"",
   "items": [
     "issue-contract-freeze",
-    "issue-actioninputs",
-    "issue-inputparser",
-    "issue-commentparser",
-    "issue-cidetector",
-    "issue-configloader",
+    "issue-forkdetector",
+    "issue-secretmasker",
+    "issue-tokenvalidator",
+    "issue-urlallowlist",
+    "issue-hmacsigner",
     "issue-proofing",
     "issue-architecture-readiness"
   ],
@@ -52,195 +52,12 @@
       }
     }
   ],
-  "currentItemIndex": 7,
+  "currentItemIndex": 0,
   "currentStepIndex": 0,
   "status": "running",
   "retryCount": 0,
-  "results": [
-    {
-      "item": "issue-contract-freeze",
-      "status": "done",
-      "stepResults": [
-        {
-          "step": "validate",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "validate",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "create-mr",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "merge",
-          "status": "passed",
-          "reason": ""
-        }
-      ]
-    },
-    {
-      "item": "issue-actioninputs",
-      "status": "done",
-      "stepResults": [
-        {
-          "step": "implement",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "validate",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "create-mr",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "merge",
-          "status": "passed",
-          "reason": ""
-        }
-      ]
-    },
-    {
-      "item": "issue-inputparser",
-      "status": "done",
-      "stepResults": [
-        {
-          "step": "merge",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "validate",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "create-mr",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "merge",
-          "status": "passed",
-          "reason": ""
-        }
-      ]
-    },
-    {
-      "item": "issue-commentparser",
-      "status": "done",
-      "stepResults": [
-        {
-          "step": "merge",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "validate",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "create-mr",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "merge",
-          "status": "passed",
-          "reason": ""
-        }
-      ]
-    },
-    {
-      "item": "issue-cidetector",
-      "status": "done",
-      "stepResults": [
-        {
-          "step": "merge",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "validate",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "create-mr",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "merge",
-          "status": "passed",
-          "reason": ""
-        }
-      ]
-    },
-    {
-      "item": "issue-configloader",
-      "status": "done",
-      "stepResults": [
-        {
-          "step": "merge",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "validate",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "create-mr",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "merge",
-          "status": "passed",
-          "reason": ""
-        }
-      ]
-    },
-    {
-      "item": "issue-proofing",
-      "status": "done",
-      "stepResults": [
-        {
-          "step": "merge",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "validate",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "create-mr",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "merge",
-          "status": "passed",
-          "reason": ""
-        }
-      ]
-    }
-  ],
+  "results": [],
   "mergeOnValid": true,
-  "createdAt": "2026-06-20T13:37:36.863Z",
-  "updatedAt": "2026-06-20T14:14:26.518Z"
+  "createdAt": "2026-06-20T14:18:46.302Z",
+  "updatedAt": "2026-06-20T14:18:46.302Z"
 }

--- a/actions/.pi/issues/issue-architecture-readiness.md
+++ b/actions/.pi/issues/issue-architecture-readiness.md
@@ -1,9 +1,9 @@
 ---
 guardian_issue:
   id: "ISSUE-READINESS"
-  epic: ""action-input""
+  epic: ""security-config""
   component: "Architecture Readiness"
-  module: "action-input"
+  module: "security-config"
   status: planned
   priority: critical
   dependencies: []
@@ -32,7 +32,7 @@ guardian_issue:
       - Verify proofing scripts + validators in CI
 
   canonical_references:
-    - module: ".pi/architecture/modules/action-input.md"
+    - module: ".pi/architecture/modules/security-config.md"
 
   acceptance_criteria:
     - "Runbook created and reviewed"
@@ -58,30 +58,30 @@ guardian_issue:
     and CI will catch regressions (proofing scripts + validators).
 
   file_changes:
-    - "create: docs/runbook-action-input.md"
-    - "create: docs/dr-plan-action-input.md"
+    - "create: docs/runbook-security-config.md"
+    - "create: docs/dr-plan-security-config.md"
     - "modify: .pi/architecture/CHANGELOG.md"
-    - "modify: .pi/architecture/modules/action-input.md"
+    - "modify: .pi/architecture/modules/security-config.md"
 ---
 
-# Architecture Readiness: action-input
+# Architecture Readiness: security-config
 
 ## Intent
 
-Make the action-input module production-ready. This is the final issue in every epic
+Make the security-config module production-ready. This is the final issue in every epic
 — it closes the loop between implementation and operability.
 
 ## Deliverables
 
 ### Runbook
-`docs/runbook-action-input.md` covering:
+`docs/runbook-security-config.md` covering:
 - Startup sequence and dependencies
 - Graceful shutdown procedure
 - Common failure modes and recovery
 - Configuration reference
 
 ### DR Plan
-`docs/dr-plan-action-input.md` covering:
+`docs/dr-plan-security-config.md` covering:
 - Backup strategy and schedule
 - Restore procedure
 - Failover plan

--- a/actions/.pi/issues/issue-contract-freeze.md
+++ b/actions/.pi/issues/issue-contract-freeze.md
@@ -1,9 +1,9 @@
 ---
 guardian_issue:
   id: "ISSUE-CONTRACT-FREEZE"
-  epic: ""action-input""
+  epic: ""security-config""
   component: "Contract Freeze"
-  module: "action-input"
+  module: "security-config"
   status: planned
   priority: critical
   dependencies: []
@@ -29,7 +29,7 @@ guardian_issue:
       - REST/event contracts
 
   canonical_references:
-    - module: ".pi/architecture/modules/action-input.md"
+    - module: ".pi/architecture/modules/security-config.md"
 
   acceptance_criteria:
     - "All component interfaces defined as interfaces/types"
@@ -47,26 +47,26 @@ guardian_issue:
     interfaces, types, DTOs, event schemas, API paths, error formats.
 
   file_changes:
-    - "create: src/action-input/contracts/"
-    - "create: src/action-input/contracts/dtos/"
-    - "create: src/action-input/contracts/events/"
+    - "create: src/security-config/contracts/"
+    - "create: src/security-config/contracts/dtos/"
+    - "create: src/security-config/contracts/events/"
 ---
 
-# Contract Freeze: action-input
+# Contract Freeze: security-config
 
 ## Intent
 
-Define and freeze all public interfaces, contracts, and schemas for the action-input
+Define and freeze all public interfaces, contracts, and schemas for the security-config
 epic before any implementation begins. This prevents architecture drift — implementation
 must satisfy contracts, not the other way around.
 
 ## Included Components
 
-- ActionInputs
-- InputParser
-- CommentParser
-- CiDetector
-- ConfigLoader
+- ForkDetector
+- SecretMasker
+- TokenValidator
+- UrlAllowlist
+- HmacSigner
 
 ## What Must Be Frozen
 

--- a/actions/.pi/issues/issue-forkdetector.md
+++ b/actions/.pi/issues/issue-forkdetector.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-SECURITY-CONFIG-1"
+  epic: "TBD"
+  component: "ForkDetector"
+  module: "security-config"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement ForkDetector for the security-config module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for forkdetector
+    application:
+      - New service/handler for forkdetector
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/security-config.md#forkdetector"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    /// Detects whether a PR originates from a forked repository.
+
+  file_changes:
+    - "create: src/security-config/forkdetector/"
+    - "create: tests/unit/security-config/forkdetector/"
+    - "create: tests/integration/security-config/forkdetector/"
+---
+
+# ISSUE-SECURITY-CONFIG-1: ForkDetector
+
+## Intent
+
+/// Detects whether a PR originates from a forked repository.
+
+## Architecture Context
+
+- **Module:** security-config
+- **Component:** ForkDetector
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement ForkDetector for the security-config module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for forkdetector
+
+### Application
+- New service/handler for forkdetector
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/security-config.md#forkdetector`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/actions/.pi/issues/issue-hmacsigner.md
+++ b/actions/.pi/issues/issue-hmacsigner.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-SECURITY-CONFIG-5"
+  epic: "TBD"
+  component: "HmacSigner"
+  module: "security-config"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement HmacSigner for the security-config module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for hmacsigner
+    application:
+      - New service/handler for hmacsigner
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/security-config.md#hmacsigner"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    /// HMAC-SHA256 signing for audit record integrity.
+
+  file_changes:
+    - "create: src/security-config/hmacsigner/"
+    - "create: tests/unit/security-config/hmacsigner/"
+    - "create: tests/integration/security-config/hmacsigner/"
+---
+
+# ISSUE-SECURITY-CONFIG-5: HmacSigner
+
+## Intent
+
+/// HMAC-SHA256 signing for audit record integrity.
+
+## Architecture Context
+
+- **Module:** security-config
+- **Component:** HmacSigner
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement HmacSigner for the security-config module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for hmacsigner
+
+### Application
+- New service/handler for hmacsigner
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/security-config.md#hmacsigner`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/actions/.pi/issues/issue-proofing.md
+++ b/actions/.pi/issues/issue-proofing.md
@@ -1,9 +1,9 @@
 ---
 guardian_issue:
   id: "ISSUE-PROOFING"
-  epic: ""action-input""
+  epic: ""security-config""
   component: "Proofing & CI Enforcement"
-  module: "action-input"
+  module: "security-config"
   status: planned
   priority: critical
   dependencies: []
@@ -26,7 +26,7 @@ guardian_issue:
       - Updated CI stage configuration
 
   canonical_references:
-    - module: ".pi/architecture/modules/action-input.md"
+    - module: ".pi/architecture/modules/security-config.md"
 
   acceptance_criteria:
     - "All proofing scripts created and executable"
@@ -47,12 +47,12 @@ guardian_issue:
     every build for zero token cost.
 
   file_changes:
-    - "create: .pi/scripts/ci/check_action-input_contracts.sh"
-    - "create: .pi/scripts/ci/check_action-input_coverage.sh"
+    - "create: .pi/scripts/ci/check_security-config_contracts.sh"
+    - "create: .pi/scripts/ci/check_security-config_coverage.sh"
     - "modify: .pi/scripts/ci/run_hardening_stages.sh"
 ---
 
-# Proofing & CI Enforcement: action-input
+# Proofing & CI Enforcement: security-config
 
 ## Intent
 
@@ -81,17 +81,17 @@ on every PR. No LLM cost. No human review. Just pass or fail.
 
 | Script | Purpose | Location |
 |--------|---------|----------|
-| check_action-input_contracts.sh | Validate contract implementation | .pi/scripts/ci/ |
-| check_action-input_coverage.sh | Enforce coverage thresholds | .pi/scripts/ci/ |
-| stage_action-input_proofing.sh | CI stage wrapper | .pi/scripts/ci/ |
+| check_security-config_contracts.sh | Validate contract implementation | .pi/scripts/ci/ |
+| check_security-config_coverage.sh | Enforce coverage thresholds | .pi/scripts/ci/ |
+| stage_security-config_proofing.sh | CI stage wrapper | .pi/scripts/ci/ |
 
 ## CI Pipeline Update
 
 Add the new stage to `run_hardening_stages.sh`:
 
 ```bash
-run_stage "11" "action-input_proofing" \
-    "${SCRIPTS_DIR}/stage_action-input_proofing.sh" \
+run_stage "11" "security-config_proofing" \
+    "${SCRIPTS_DIR}/stage_security-config_proofing.sh" \
     "always"
 ```
 

--- a/actions/.pi/issues/issue-secretmasker.md
+++ b/actions/.pi/issues/issue-secretmasker.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-SECURITY-CONFIG-2"
+  epic: "TBD"
+  component: "SecretMasker"
+  module: "security-config"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement SecretMasker for the security-config module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for secretmasker
+    application:
+      - New service/handler for secretmasker
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/security-config.md#secretmasker"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    /// Masks sensitive values from GitHub Actions workflow logs.
+
+  file_changes:
+    - "create: src/security-config/secretmasker/"
+    - "create: tests/unit/security-config/secretmasker/"
+    - "create: tests/integration/security-config/secretmasker/"
+---
+
+# ISSUE-SECURITY-CONFIG-2: SecretMasker
+
+## Intent
+
+/// Masks sensitive values from GitHub Actions workflow logs.
+
+## Architecture Context
+
+- **Module:** security-config
+- **Component:** SecretMasker
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement SecretMasker for the security-config module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for secretmasker
+
+### Application
+- New service/handler for secretmasker
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/security-config.md#secretmasker`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/actions/.pi/issues/issue-tokenvalidator.md
+++ b/actions/.pi/issues/issue-tokenvalidator.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-SECURITY-CONFIG-3"
+  epic: "TBD"
+  component: "TokenValidator"
+  module: "security-config"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement TokenValidator for the security-config module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for tokenvalidator
+    application:
+      - New service/handler for tokenvalidator
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/security-config.md#tokenvalidator"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    /// Validates that the GitHub token has the required permissions.
+
+  file_changes:
+    - "create: src/security-config/tokenvalidator/"
+    - "create: tests/unit/security-config/tokenvalidator/"
+    - "create: tests/integration/security-config/tokenvalidator/"
+---
+
+# ISSUE-SECURITY-CONFIG-3: TokenValidator
+
+## Intent
+
+/// Validates that the GitHub token has the required permissions.
+
+## Architecture Context
+
+- **Module:** security-config
+- **Component:** TokenValidator
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement TokenValidator for the security-config module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for tokenvalidator
+
+### Application
+- New service/handler for tokenvalidator
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/security-config.md#tokenvalidator`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/actions/.pi/issues/issue-urlallowlist.md
+++ b/actions/.pi/issues/issue-urlallowlist.md
@@ -1,0 +1,135 @@
+---
+guardian_issue:
+  id: "ISSUE-SECURITY-CONFIG-4"
+  epic: "TBD"
+  component: "UrlAllowlist"
+  module: "security-config"
+  status: planned
+  priority: high
+  dependencies:
+    - "none"
+
+  in_scope:
+    - Implement UrlAllowlist for the security-config module
+    - Write unit tests for all public interfaces
+    - Add integration tests with upstream/downstream components
+    - Create API documentation
+
+  out_of_scope:
+    - Changes to upstream components (none)
+    - UI/frontend changes
+    - Deployment pipeline configuration
+
+  affected_layers:
+    domain:
+      - New domain models for urlallowlist
+    application:
+      - New service/handler for urlallowlist
+    infrastructure:
+      - New database tables or external service connections
+    api:
+      - New endpoints or event handlers
+
+  canonical_references:
+    - module: ".pi/architecture/modules/security-config.md#urlallowlist"
+
+  acceptance_criteria:
+    - "CI pipeline passes (validate-ci.sh)"
+    - "All unit tests pass with ≥ 90% coverage"
+    - "Integration tests pass with upstream/downstream components"
+    - "validate-security.sh passes"
+    - "validate-architecture.sh passes"
+    - "validate-canonical.sh passes"
+
+  validators:
+    - ci
+    - tests
+    - security
+    - architecture
+    - canonical
+
+  implementation_notes: |
+    /// Validates backend URLs against a configured allowlist.
+
+  file_changes:
+    - "create: src/security-config/urlallowlist/"
+    - "create: tests/unit/security-config/urlallowlist/"
+    - "create: tests/integration/security-config/urlallowlist/"
+---
+
+# ISSUE-SECURITY-CONFIG-4: UrlAllowlist
+
+## Intent
+
+/// Validates backend URLs against a configured allowlist.
+
+## Architecture Context
+
+- **Module:** security-config
+- **Component:** UrlAllowlist
+- **Status:** planned
+- **Dependencies:** none
+
+## Dependencies
+
+```
+  └── none
+```
+
+## In Scope
+
+- Implement UrlAllowlist for the security-config module
+- Write unit tests for all public interfaces
+- Add integration tests with upstream/downstream components
+- Create API documentation
+
+## Out of Scope
+
+- Changes to upstream components
+- UI/frontend changes
+- Deployment pipeline configuration
+
+## Affected Layers
+
+### Domain
+- New domain models for urlallowlist
+
+### Application
+- New service/handler for urlallowlist
+
+### Infrastructure
+- New database tables or external service connections
+
+### API
+- New endpoints or event handlers
+
+## Canonical References
+
+- **Module:** `.pi/architecture/modules/security-config.md#urlallowlist`
+
+## Acceptance Criteria
+
+| # | Criterion | Validator |
+|---|-----------|-----------|
+| 1 | CI pipeline passes | `validate-ci.sh` |
+| 2 | All unit tests pass with ≥ 90% coverage | `validate-tests.sh` |
+| 3 | Integration tests pass | `validate-integration.sh` |
+| 4 | Security checks pass | `validate-security.sh` |
+| 5 | Architecture compliance | `validate-architecture.sh` |
+| 6 | Canonical references valid | `validate-canonical.sh` |
+
+## Implementation
+
+> **Agent:** This is your complete session context. All information you need is above.
+> Start by reading the canonical reference files, then implement following the layer structure.
+
+### Steps
+
+1. Read canonical architecture references
+2. Create domain entities and interfaces
+3. Implement application service/handler
+4. Add infrastructure connections
+5. Write unit tests (≥ 90% coverage)
+6. Write integration tests
+7. Run all validators
+8. Create MR

--- a/actions/src/lib.rs
+++ b/actions/src/lib.rs
@@ -43,6 +43,7 @@ pub mod shared;
 
 // ── Phase 1: Contract Freeze — interface-only declarations ──
 pub mod action_input;
+pub mod security_config;
 // pub mod security_config;    // Phase 2
 // pub mod diff_analyzer;      // Phase 3
 // pub mod policy_evaluator;   // Phase 3

--- a/actions/src/security_config/application/dto/mod.rs
+++ b/actions/src/security_config/application/dto/mod.rs
@@ -1,0 +1,238 @@
+//! Data Transfer Objects for the Security Configuration module.
+//!
+//! @canonical actions/.pi/architecture/modules/security-config.md
+//! Implements: Contract Freeze — DTO schemas for security validation, fork detection,
+//! secret masking, token validation, URL allowlisting, and HMAC signing operations
+//! Issue: issue-contract-freeze
+//!
+//! DTOs define the input/output contracts for service operations.
+//! They carry validation metadata and documentation but no behavior.
+//!
+//! # Contract (Frozen)
+//! - Every service operation has a dedicated input and output DTO
+//! - DTOs are serializable (JSON for API, TOML for config)
+//! - Validation constraints are documented in field docs
+
+use serde::{Deserialize, Serialize};
+
+use crate::security_config::domain::{
+    ActionMode, HmacKey, SecurityContext, SecurityLevel, SecurityPolicy,
+};
+
+// ---------------------------------------------------------------------------
+// Security Validation DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for running pre-flight security validation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidateSecurityInput {
+    /// The GitHub token to validate.
+    pub github_token: String,
+
+    /// Optional API key to mask (e.g., ANTHROPIC_API_KEY, OPENAI_API_KEY).
+    pub api_key: Option<String>,
+
+    /// Path to the policy file (for tamper detection).
+    pub policy_path: String,
+
+    /// Backend audit URL to validate.
+    pub backend_url: Option<String>,
+
+    /// The action mode to check permissions against.
+    pub mode: ActionMode,
+}
+
+/// Output from running pre-flight security validation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidateSecurityOutput {
+    /// The complete security context with all check results.
+    pub context: SecurityContext,
+
+    /// Whether all checks passed.
+    pub valid: bool,
+
+    /// List of validation warnings (non-blocking).
+    pub warnings: Vec<String>,
+
+    /// Duration of validation in milliseconds.
+    pub duration_ms: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Fork Detection DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for detecting fork PRs.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DetectForkInput {
+    /// Override environment for testing (maps variable name → value).
+    /// If `None`, reads from real `std::env::var`.
+    pub env_override: Option<std::collections::HashMap<String, String>>,
+}
+
+/// Output from fork detection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DetectForkOutput {
+    /// Whether this is a fork PR.
+    pub is_fork: bool,
+    /// Head repository full name (e.g., "user/repo").
+    pub head_repo: Option<String>,
+    /// Base repository full name (e.g., "org/repo").
+    pub base_repo: Option<String>,
+    /// Fork owner username (if fork).
+    pub fork_owner: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Secret Masking DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for masking secrets.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MaskSecretsInput {
+    /// List of secrets to mask.
+    pub secrets: Vec<String>,
+}
+
+/// Output from masking secrets.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MaskSecretsOutput {
+    /// Number of secrets masked.
+    pub masked_count: u32,
+    /// Hints about which secrets were masked (not the values).
+    pub masked_hints: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Token Validation DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for validating the GitHub token.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidateTokenInput {
+    /// The GitHub token to validate.
+    pub token: String,
+    /// The action mode to check required permissions for.
+    pub mode: ActionMode,
+}
+
+/// Output from token validation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidateTokenOutput {
+    /// Whether the token is valid (responds to API calls).
+    pub valid: bool,
+    /// Whether the token has the required permissions for the mode.
+    pub has_required_permissions: bool,
+    /// List of permissions the token has.
+    pub available_scopes: Vec<String>,
+    /// List of required permissions the token is missing.
+    pub missing_scopes: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// URL Allowlist DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for validating a URL against the allowlist.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidateUrlInput {
+    /// The URL to validate.
+    pub url: String,
+    /// Override allowlist for testing.
+    pub allowlist_override: Option<Vec<String>>,
+}
+
+/// Output from URL validation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidateUrlOutput {
+    /// Whether the URL is allowed.
+    pub allowed: bool,
+    /// The host component of the URL.
+    pub host: String,
+    /// The allowlist entries that were checked against.
+    pub checked_against: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// HMAC Signing DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for signing a payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HmacSignInput {
+    /// The payload bytes to sign.
+    pub payload: Vec<u8>,
+    /// Optional key override. If None, uses configured key.
+    pub key_override: Option<Vec<u8>>,
+}
+
+/// Output from HMAC signing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HmacSignOutput {
+    /// The hex-encoded signature.
+    pub signature: String,
+    /// Key identifier used.
+    pub key_id: String,
+}
+
+/// Input for verifying an HMAC signature.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HmacVerifyInput {
+    /// The original payload bytes.
+    pub payload: Vec<u8>,
+    /// The signature to verify.
+    pub signature: String,
+    /// Optional key override. If None, uses configured key.
+    pub key_override: Option<Vec<u8>>,
+}
+
+/// Output from HMAC signature verification.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HmacVerifyOutput {
+    /// Whether the signature is valid.
+    pub valid: bool,
+    /// Key identifier used for verification.
+    pub key_id: String,
+}
+
+// ---------------------------------------------------------------------------
+// Security Policy DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for loading the security policy.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LoadPolicyInput {
+    /// Override path to security.toml. If None, defaults to `.rigorix/security.toml`.
+    pub path_override: Option<String>,
+    /// Override content for testing (TOML string).
+    pub content_override: Option<String>,
+}
+
+/// Output from loading the security policy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoadPolicyOutput {
+    /// The parsed security policy.
+    pub policy: SecurityPolicy,
+    /// Path the policy was loaded from.
+    pub source_path: String,
+}
+
+/// Input for loading an organization-level policy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoadOrgPolicyInput {
+    /// URL or path to the org policy file.
+    pub policy_url: String,
+    /// Whether the org policy is required (fail if unreachable).
+    pub required: bool,
+}
+
+/// Output from loading an organization-level policy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoadOrgPolicyOutput {
+    /// The loaded org policy rules.
+    pub rules: Vec<String>,
+    /// Number of rules loaded.
+    pub rules_count: u32,
+    /// Whether the policy was loaded from cache.
+    pub from_cache: bool,
+}

--- a/actions/src/security_config/application/factory.rs
+++ b/actions/src/security_config/application/factory.rs
@@ -1,0 +1,98 @@
+//! Factory interfaces for constructing Security Configuration domain objects.
+//!
+//! @canonical actions/.pi/architecture/modules/security-config.md
+//! Implements: Contract Freeze — SecurityContextFactory, HmacKeyFactory, SecurityPolicyFactory traits
+//! Issue: issue-contract-freeze
+//!
+//! Factories encapsulate the construction of complex domain objects,
+//! allowing implementations to inject dependencies and apply defaults
+//! without exposing construction logic to callers.
+//!
+//! # Contract (Frozen)
+//! - Every factory method returns a configured domain object
+//! - Validation is applied during construction
+//! - No mutable state in factory implementations
+
+use async_trait::async_trait;
+
+use crate::security_config::domain::{
+    HmacKey, SecurityContext, SecurityError, SecurityLevel, SecurityPolicy,
+};
+
+/// Factory for constructing `SecurityContext` from raw check results.
+///
+/// Handles the resolution of individual check results into a unified
+/// security context with the correct security level.
+#[async_trait]
+pub trait SecurityContextFactory: Send + Sync {
+    /// Build a `SecurityContext` from individual check results.
+    ///
+    /// Determines the `SecurityLevel` based on:
+    /// - Fork PR + no API key → `Restricted`
+    /// - Token invalid → `Blocked`
+    /// - URL blocked → `Blocked`
+    /// - All pass → `Full`
+    async fn build(
+        &self,
+        is_fork_pr: bool,
+        has_required_permissions: bool,
+        api_key_masked: bool,
+        backend_url_allowed: bool,
+        policy_changed_from_base: bool,
+        org_policy_loaded: bool,
+    ) -> SecurityContext;
+
+    /// Build a `SecurityContext` at the `Blocked` level.
+    /// Used when critical checks fail.
+    fn blocked(&self) -> SecurityContext;
+
+    /// Build a `SecurityContext` at the `Full` level.
+    /// Used when all checks pass.
+    fn full(&self) -> SecurityContext;
+
+    /// Determine the security level from individual check results.
+    fn resolve_security_level(
+        &self,
+        is_fork_pr: bool,
+        has_required_permissions: bool,
+        api_key_masked: bool,
+        backend_url_allowed: bool,
+    ) -> SecurityLevel;
+}
+
+/// Factory for constructing `HmacKey` values.
+///
+/// Handles key generation, parsing, and expiration management.
+#[async_trait]
+pub trait HmacKeyFactory: Send + Sync {
+    /// Generate a new cryptographically random HMAC key.
+    async fn generate_key(&self, key_id: Option<String>) -> Result<HmacKey, SecurityError>;
+
+    /// Parse an HMAC key from raw bytes.
+    fn from_bytes(&self, key: Vec<u8>, key_id: String) -> Result<HmacKey, SecurityError>;
+
+    /// Parse an HMAC key from a hex-encoded string.
+    fn from_hex(&self, hex_key: &str, key_id: String) -> Result<HmacKey, SecurityError>;
+
+    /// Check if a key has expired.
+    fn is_expired(&self, key: &HmacKey) -> bool;
+}
+
+/// Factory for constructing `SecurityPolicy` from TOML configuration.
+///
+/// Handles parsing and validation of the `.rigorix/security.toml` file.
+#[async_trait]
+pub trait SecurityPolicyFactory: Send + Sync {
+    /// Build a `SecurityPolicy` from raw TOML content.
+    async fn from_toml(&self, toml_content: &str) -> Result<SecurityPolicy, SecurityError>;
+
+    /// Create a default security policy with safe defaults.
+    fn defaults(&self) -> SecurityPolicy;
+
+    /// Merge a loaded policy with defaults (org policy overrides local).
+    async fn merge(
+        &self,
+        local: SecurityPolicy,
+        org: SecurityPolicy,
+    ) -> Result<SecurityPolicy, SecurityError>;
+}

--- a/actions/src/security_config/application/mod.rs
+++ b/actions/src/security_config/application/mod.rs
@@ -1,0 +1,24 @@
+//! Application layer for the Security Configuration bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/security-config.md#application
+//! Implements: Contract Freeze — service traits, DTO schemas, factory interfaces
+//! Issue: issue-contract-freeze
+//!
+//! This module defines the application-level contracts:
+//! - Service interfaces (use cases) in `service.rs`
+//! - Input/output DTO schemas in `dto/`
+//! - Factory interfaces in `factory.rs`
+//!
+//! # Contract (Frozen)
+//! - All service traits are async (use `async-trait`)
+//! - All public methods return `Result<_, SecurityError>`
+//! - DTOs carry full documentation for each field
+//! - No implementation — only contract signatures
+
+pub mod dto;
+pub mod factory;
+pub mod service;
+
+pub use dto::*;
+pub use factory::*;
+pub use service::*;

--- a/actions/src/security_config/application/service.rs
+++ b/actions/src/security_config/application/service.rs
@@ -1,0 +1,236 @@
+//! Service interfaces (use cases) for the Security Configuration bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/security-config.md
+//! Implements: Contract Freeze — SecurityValidationService, ForkDetectionService,
+//! SecretMaskingService, TokenValidationService, UrlAllowlistService,
+//! HmacSigningService, PolicyLoadingService traits
+//! Issue: issue-contract-freeze
+//!
+//! These traits define the application-level operations for security validation,
+//! fork detection, secret masking, token validation, URL allowlisting, HMAC
+//! signing, and policy loading. All methods are async and return domain error types.
+//!
+//! # Contract (Frozen)
+//! - Every use case has a corresponding trait method
+//! - Input/output types are DTOs defined in `dto/`
+//! - All methods are async (use `async-trait` for trait object safety)
+//! - No implementation — only contract signatures
+
+use async_trait::async_trait;
+
+use crate::security_config::domain::{ActionMode, HmacKey, SecurityError};
+
+use super::dto::{
+    DetectForkInput, DetectForkOutput, HmacSignInput, HmacSignOutput, HmacVerifyInput,
+    HmacVerifyOutput, LoadOrgPolicyInput, LoadOrgPolicyOutput, LoadPolicyInput, LoadPolicyOutput,
+    MaskSecretsInput, MaskSecretsOutput, ValidateSecurityInput, ValidateSecurityOutput,
+    ValidateTokenInput, ValidateTokenOutput, ValidateUrlInput, ValidateUrlOutput,
+};
+
+/// Application service for orchestrating all pre-flight security checks.
+///
+/// Implements the `SecurityValidator` component from the architecture doc.
+/// Runs all security checks in the correct order and short-circuits on
+/// critical violations:
+///
+/// 1. Fork detection (block secret exposure)
+/// 2. Secret masking (before any logging)
+/// 3. Token permission check
+/// 4. URL allowlist check
+/// 5. Security level determination
+///
+/// # Contract (Frozen)
+/// - `validate()` is the primary entry point
+/// - Returns a complete `SecurityContext` with all check results
+/// - Short-circuits on `Blocked` security level
+/// - Secrets are masked BEFORE any other check that might log
+#[async_trait]
+pub trait SecurityValidationService: Send + Sync {
+    /// Run all pre-flight security checks in order.
+    ///
+    /// Execution order:
+    /// 1. Fork detection
+    /// 2. Secret masking (first, before any logging)
+    /// 3. Token validation
+    /// 4. URL allowlist validation
+    /// 5. Security level resolution
+    ///
+    /// Returns a complete `ValidateSecurityOutput` with the security context
+    /// and any warnings.
+    async fn validate(
+        &self,
+        input: ValidateSecurityInput,
+    ) -> Result<ValidateSecurityOutput, SecurityError>;
+
+    /// Check if the security level allows operations.
+    async fn is_operation_allowed(&self, level: &super::super::domain::SecurityLevel) -> bool;
+
+    /// Get the effective security level from the current context.
+    async fn current_security_level(&self) -> super::super::domain::SecurityLevel;
+}
+
+/// Application service for detecting PRs from forked repositories.
+///
+/// Implements the `ForkDetector` component from the architecture doc.
+/// Compares the head repository against the base repository to detect
+/// forked PRs where secrets are not available.
+///
+/// # Contract (Frozen)
+/// - `detect()` compares `GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME` against `GITHUB_REPOSITORY`
+/// - Returns `true` only when running in a PR context and repos differ
+/// - Returns `false` for non-PR events (workflow_dispatch, push)
+#[async_trait]
+pub trait ForkDetectionService: Send + Sync {
+    /// Detect if this is a fork PR.
+    ///
+    /// Compares head repo against base repo using GitHub-provided env vars.
+    async fn detect(&self, input: DetectForkInput) -> Result<DetectForkOutput, SecurityError>;
+
+    /// Get the fork owner's username.
+    /// Returns `None` if not a fork or env var is absent.
+    async fn fork_owner(&self) -> Result<Option<String>, SecurityError>;
+
+    /// Get the head repository full name.
+    async fn head_repo(&self) -> Result<Option<String>, SecurityError>;
+
+    /// Get the base repository full name.
+    async fn base_repo(&self) -> Result<String, SecurityError>;
+}
+
+/// Application service for masking secrets from workflow logs.
+///
+/// Implements the `SecretMasker` component from the architecture doc.
+/// Uses GitHub Actions `::add-mask::<value>` workflow commands to prevent
+/// secrets from appearing in CI logs.
+///
+/// # Contract (Frozen)
+/// - `mask()` must be called BEFORE any logging
+/// - Logs `::add-mask::<value>` for each secret
+/// - Empty secrets are silently ignored
+#[async_trait]
+pub trait SecretMaskingService: Send + Sync {
+    /// Mask a single secret value.
+    ///
+    /// After this call, the value will appear as `***` in workflow logs.
+    /// Must be called before any logging that might include the secret.
+    async fn mask(&self, secret: &str) -> Result<(), SecurityError>;
+
+    /// Mask multiple secrets at once.
+    async fn mask_all(&self, input: MaskSecretsInput) -> Result<MaskSecretsOutput, SecurityError>;
+
+    /// Check if a value contains any known secret patterns.
+    /// Useful for log scrubbing before output.
+    async fn contains_secret(&self, text: &str) -> bool;
+}
+
+/// Application service for validating GitHub token permissions.
+///
+/// Implements the `TokenValidator` component from the architecture doc.
+/// Validates the token by calling the GitHub API and checking scopes.
+///
+/// # Contract (Frozen)
+/// - `validate()` calls GitHub API `/user` or `/installation/repositories`
+/// - Returns structured results with available and missing scopes
+/// - Mode-specific permission requirements
+#[async_trait]
+pub trait TokenValidationService: Send + Sync {
+    /// Validate the GitHub token and check permissions.
+    ///
+    /// Makes an API call to GitHub to verify the token is valid and
+    /// has the required scopes for the given action mode.
+    async fn validate(
+        &self,
+        input: ValidateTokenInput,
+    ) -> Result<ValidateTokenOutput, SecurityError>;
+
+    /// Check if the token is valid (basic auth check).
+    async fn is_token_valid(&self, token: &str) -> Result<bool, SecurityError>;
+
+    /// Get the required permissions for a given mode.
+    fn required_permissions(mode: ActionMode) -> &'static [(&'static str, &'static str)];
+}
+
+/// Application service for validating backend URLs against an allowlist.
+///
+/// Implements the `UrlAllowlist` component from the architecture doc.
+/// Loads allowed hosts from `.rigorix/security.toml` and validates URLs
+/// against the configured allowlist.
+///
+/// # Contract (Frozen)
+/// - `validate()` parses the URL and checks host against allowlist
+/// - Returns `Ok(true)` if no allowlist configured (fail-open for dev)
+/// - Returns `UrlBlocked` error if host is not allowed
+/// - Host matching uses suffix/prefix matching
+#[async_trait]
+pub trait UrlAllowlistService: Send + Sync {
+    /// Validate a URL against the configured allowlist.
+    async fn validate(
+        &self,
+        input: ValidateUrlInput,
+    ) -> Result<ValidateUrlOutput, SecurityError>;
+
+    /// Load the allowlist from the security policy.
+    async fn load_allowlist(&self) -> Result<Vec<String>, SecurityError>;
+
+    /// Add a host to the runtime allowlist (for programmatic additions).
+    async fn add_allowed_host(&self, host: String) -> Result<(), SecurityError>;
+
+    /// Check if a host matches any allowlist entry.
+    async fn is_host_allowed(&self, host: &str) -> Result<bool, SecurityError>;
+}
+
+/// Application service for HMAC-SHA256 signing and verification.
+///
+/// Implements the `HmacSigner` component from the architecture doc.
+/// Signs audit record payloads and verifies signatures using constant-time
+/// comparison to prevent timing attacks.
+///
+/// # Contract (Frozen)
+/// - `sign()` produces hex-encoded HMAC-SHA256 signatures
+/// - `verify()` uses constant-time comparison
+/// - `generate_key()` produces cryptographically random 32-byte keys
+/// - Key rotation is supported via key_id tracking
+#[async_trait]
+pub trait HmacSigningService: Send + Sync {
+    /// Sign a payload and return the hex-encoded signature.
+    async fn sign(&self, input: HmacSignInput) -> Result<HmacSignOutput, SecurityError>;
+
+    /// Verify a signature against a payload (constant-time comparison).
+    async fn verify(&self, input: HmacVerifyInput) -> Result<HmacVerifyOutput, SecurityError>;
+
+    /// Generate a new HMAC key (32 random bytes).
+    async fn generate_key(&self) -> Result<HmacKey, SecurityError>;
+
+    /// Load the HMAC signing key from the configured source.
+    async fn load_key(&self) -> Result<HmacKey, SecurityError>;
+
+    /// Rotate the HMAC signing key.
+    async fn rotate_key(&self) -> Result<HmacKey, SecurityError>;
+}
+
+/// Application service for loading security policy configuration.
+///
+/// Implements the `OrgPolicyLoader` component from the architecture doc.
+/// Loads `.rigorix/security.toml` and organization-level security policies.
+///
+/// # Contract (Frozen)
+/// - Loads from `.rigorix/security.toml` by default
+/// - Supports organization-level policy URLs
+/// - Returns defaults if file not found (non-fatal)
+#[async_trait]
+pub trait PolicyLoadingService: Send + Sync {
+    /// Load the security policy from configuration.
+    async fn load_policy(&self, input: LoadPolicyInput) -> Result<LoadPolicyOutput, SecurityError>;
+
+    /// Load an organization-level security policy.
+    async fn load_org_policy(
+        &self,
+        input: LoadOrgPolicyInput,
+    ) -> Result<LoadOrgPolicyOutput, SecurityError>;
+
+    /// Get the configured allowed hosts from the policy.
+    async fn allowed_hosts(&self) -> Result<Vec<String>, SecurityError>;
+
+    /// Get the HMAC key configuration.
+    async fn hmac_config(&self) -> Result<(String, u32), SecurityError>;
+}

--- a/actions/src/security_config/domain/error.rs
+++ b/actions/src/security_config/domain/error.rs
@@ -1,0 +1,156 @@
+//! Error types for the Security Configuration bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/security-config.md#error
+//! Implements: Contract Freeze — SecurityError enum
+//! Issue: issue-contract-freeze
+//!
+//! All errors use `thiserror` derive macros. No `anyhow` in library code.
+//!
+//! # Contract (Frozen)
+//! - `SecurityError` is the single error type for this module
+//! - Each variant carries structured context for error reporting
+//! - Implements `std::error::Error` for library compatibility
+
+use thiserror::Error;
+
+/// Errors that can occur during security validation.
+#[derive(Debug, Error)]
+pub enum SecurityError {
+    /// The PR originates from a forked repository — secrets not available.
+    #[error("Fork PR detected: repository secrets are not available for pull requests from forks. Head repo '{head_repo}' differs from base repo '{base_repo}'.")]
+    ForkDetected {
+        /// The head repository full name (e.g., "user/repo").
+        head_repo: String,
+        /// The base repository full name (e.g., "org/repo").
+        base_repo: String,
+    },
+
+    /// GitHub token validation failed (network error or invalid token).
+    #[error("GitHub token validation failed: {detail}")]
+    TokenValidationFailed {
+        /// Details about the failure.
+        detail: String,
+        /// HTTP status code if available.
+        status_code: Option<u16>,
+    },
+
+    /// Token is valid but lacks required permissions.
+    #[error("GitHub token has insufficient permissions. Required: {required:?}, available: {available:?}")]
+    TokenInsufficient {
+        /// Permissions the token requires but does not have.
+        required: Vec<String>,
+        /// Permissions the token actually has.
+        available: Vec<String>,
+    },
+
+    /// A URL was blocked by the allowlist.
+    #[error("URL blocked by allowlist: {url}. Allowed hosts: {allowed:?}")]
+    UrlBlocked {
+        /// The URL that was blocked.
+        url: String,
+        /// The list of allowed hosts.
+        allowed: Vec<String>,
+    },
+
+    /// A URL could not be parsed.
+    #[error("Invalid URL: {0}")]
+    InvalidUrl(String),
+
+    /// HMAC signature verification failed.
+    #[error("HMAC signature verification failed: expected '{expected}', got '{actual}'")]
+    HmacVerificationFailed {
+        /// The expected signature.
+        expected: String,
+        /// The actual signature provided.
+        actual: String,
+    },
+
+    /// HMAC signing key not available.
+    #[error("HMAC signing key not available: {detail}")]
+    HmacKeyMissing {
+        /// Details about the missing key.
+        detail: String,
+    },
+
+    /// Organization policy could not be loaded.
+    #[error("Failed to load organization policy from '{path}': {detail}")]
+    OrgPolicyLoadFailed {
+        /// The path or URL that was attempted.
+        path: String,
+        /// Details about the failure.
+        detail: String,
+    },
+
+    /// Security policy file missing or unreadable.
+    #[error("Security policy file not found at '{path}': {detail}")]
+    PolicyFileNotFound {
+        /// The expected path.
+        path: String,
+        /// Additional details.
+        detail: String,
+    },
+
+    /// Security policy parse error.
+    #[error("Failed to parse security policy: {detail}")]
+    PolicyParseError {
+        /// Parse error description.
+        detail: String,
+    },
+
+    /// IO error (file system, network).
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// JSON serialization/deserialization error.
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// YAML serialization/deserialization error.
+    #[error("YAML error: {0}")]
+    Yaml(#[from] serde_yaml::Error),
+
+    /// TOML parse error.
+    #[error("TOML parse error: {detail}")]
+    TomlParseError {
+        /// Parse error description.
+        detail: String,
+    },
+
+    /// HTTP client error.
+    #[error("HTTP error: {detail}")]
+    HttpError {
+        /// Error description.
+        detail: String,
+    },
+
+    /// Internal invariant violation (should not happen).
+    #[error("Internal error: {detail}")]
+    Internal {
+        /// Error description.
+        detail: String,
+    },
+}
+
+impl SecurityError {
+    /// Whether the error is retriable.
+    pub fn is_retriable(&self) -> bool {
+        matches!(
+            self,
+            SecurityError::Io(_)
+                | SecurityError::HttpError { .. }
+                | SecurityError::TokenValidationFailed { .. }
+                | SecurityError::OrgPolicyLoadFailed { .. }
+        )
+    }
+
+    /// Whether the error is a security violation (action should abort).
+    pub fn is_security_violation(&self) -> bool {
+        matches!(
+            self,
+            SecurityError::ForkDetected { .. }
+                | SecurityError::TokenInsufficient { .. }
+                | SecurityError::UrlBlocked { .. }
+                | SecurityError::HmacVerificationFailed { .. }
+        )
+    }
+}

--- a/actions/src/security_config/domain/event/mod.rs
+++ b/actions/src/security_config/domain/event/mod.rs
@@ -1,0 +1,108 @@
+//! Event payload schemas for the Security Configuration bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/security-config.md
+//! Implements: Contract Freeze — SecurityEvent payload schemas
+//! Issue: issue-contract-freeze
+//!
+//! These events are emitted whenever security checks run, forks are detected,
+//! secrets are masked, or signatures are verified. Consumers (audit, action-entrypoint)
+//! subscribe to these event types.
+//!
+//! # Contract (Frozen)
+//! - Each event carries the full context needed by consumers
+//! - No internal implementation details exposed
+//! - Events are serializable for audit logging
+
+use serde::{Deserialize, Serialize};
+
+use crate::security_config::domain::SecurityLevel;
+
+/// Events emitted by the Security Configuration module.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SecurityEvent {
+    /// Pre-flight security validation completed.
+    ValidationCompleted {
+        /// The resolved security level.
+        security_level: SecurityLevel,
+        /// Whether the context was validated successfully.
+        success: bool,
+        /// Count of checks that passed.
+        checks_passed: u32,
+        /// Count of checks that failed.
+        checks_failed: u32,
+    },
+
+    /// Pre-flight validation failed — action is blocked.
+    ValidationFailed {
+        /// The security level that caused the failure.
+        security_level: SecurityLevel,
+        /// Human-readable failure reason.
+        reason: String,
+    },
+
+    /// Fork PR detected.
+    ForkDetected {
+        /// Head repository full name.
+        head_repo: String,
+        /// Base repository full name.
+        base_repo: String,
+        /// Fork owner username.
+        fork_owner: Option<String>,
+    },
+
+    /// A secret was masked from workflow logs.
+    SecretMasked {
+        /// Hint identifying the secret type (not the value).
+        secret_hint: String,
+    },
+
+    /// Token permission check completed.
+    TokenChecked {
+        /// Whether the token has required permissions.
+        has_permissions: bool,
+        /// The action mode checked against.
+        mode: String,
+    },
+
+    /// URL allowlist validation completed.
+    UrlValidated {
+        /// The URL that was validated.
+        url: String,
+        /// Whether the URL is allowed.
+        allowed: bool,
+    },
+
+    /// HMAC signature was verified.
+    HmacVerification {
+        /// Whether the signature was valid.
+        valid: bool,
+        /// Key identifier used for verification.
+        key_id: String,
+    },
+
+    /// HMAC signature was created.
+    HmacSigned {
+        /// Key identifier used for signing.
+        key_id: String,
+    },
+
+    /// Organization policy was loaded.
+    OrgPolicyLoaded {
+        /// The path the policy was loaded from.
+        path: String,
+        /// Whether the load succeeded.
+        success: bool,
+        /// Number of policy rules loaded.
+        rules_count: u32,
+    },
+
+    /// Security configuration was loaded from security.toml.
+    SecurityConfigLoaded {
+        /// Path to the config file.
+        path: String,
+        /// Number of allowed hosts configured.
+        allowed_hosts_count: u32,
+        /// Whether HMAC signing is configured.
+        hmac_enabled: bool,
+    },
+}

--- a/actions/src/security_config/domain/mod.rs
+++ b/actions/src/security_config/domain/mod.rs
@@ -1,0 +1,25 @@
+//! Domain entities and interfaces for the Security Configuration bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/security-config.md#domain
+//! Implements: Contract Freeze — domain entities SecurityContext, SecurityLevel,
+//! ActionMode, HmacKey, SecurityPolicy, SecurityError, SecurityEvent
+//! Issue: issue-contract-freeze
+//!
+//! This module defines the core domain types — `SecurityContext`, `SecurityLevel`,
+//! `ActionMode`, `HmacKey`, `SecurityPolicy`, `SecurityError`, and `SecurityEvent`.
+//! These are pure domain objects with no framework dependencies. They serve as the
+//! frozen contract that all implementation must satisfy.
+//!
+//! # Contract (Frozen)
+//! - No implementation logic beyond constructors and field accessors
+//! - All validation must happen in the application layer (service traits)
+//! - All persistence must happen behind repository interfaces
+//! - All domain types are serializable (Serialize + Deserialize)
+
+pub mod error;
+pub mod event;
+pub mod types;
+
+pub use error::*;
+pub use event::*;
+pub use types::*;

--- a/actions/src/security_config/domain/types.rs
+++ b/actions/src/security_config/domain/types.rs
@@ -1,0 +1,210 @@
+//! Domain types for the Security Configuration bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/security-config.md#types
+//! Implements: Contract Freeze — SecurityContext, SecurityLevel, and related types
+//! Issue: issue-contract-freeze
+//!
+//! These are the core domain types that represent the security validation
+//! context, including fork detection results, token permissions, secret masking
+//! status, URL allowlist validation, and HMAC signing. They serve as the
+//! frozen contract that all implementation must satisfy.
+//!
+//! # Contract (Frozen)
+//! - No implementation logic beyond constructors and field accessors
+//! - All validation must happen in the application layer (service traits)
+//! - All persistence must happen behind repository interfaces
+//! - All domain types are serializable (Serialize + Deserialize)
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// SecurityContext
+// ---------------------------------------------------------------------------
+
+/// Results of pre-flight security validation.
+///
+/// Built during Phase 0 of the action lifecycle. All fields must be
+/// validated before any operation begins.
+///
+/// ## Validation Order
+///
+/// 1. Fork detection (block secret exposure)
+/// 2. Secret masking (before any logging)
+/// 3. Token permission check
+/// 4. URL allowlist check
+/// 5. Policy integrity check (deferred to PolicyLoader)
+/// 6. Security level determination
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SecurityContext {
+    /// Whether this is a PR from a forked repository.
+    pub is_fork_pr: bool,
+
+    /// Whether the GitHub token has all required permissions.
+    pub has_required_permissions: bool,
+
+    /// Whether all API keys have been masked from workflow logs.
+    pub api_key_masked: bool,
+
+    /// Whether the policy file was modified in this PR (compared to base).
+    pub policy_changed_from_base: bool,
+
+    /// Whether the backend URL is in the configured allowlist.
+    pub backend_url_allowed: bool,
+
+    /// Whether organization-level security policy was loaded.
+    pub org_policy_loaded: bool,
+
+    /// The effective security level after validation.
+    pub security_level: SecurityLevel,
+}
+
+impl SecurityContext {
+    /// Create a new SecurityContext with all fields defaulting to safe values.
+    ///
+    /// Safe defaults assume the most restrictive posture:
+    /// - `is_fork_pr`: `false` (assume safe until proven otherwise)
+    /// - `has_required_permissions`: `false` (must be explicitly validated)
+    /// - `api_key_masked`: `false` (must be explicitly done)
+    /// - `security_level`: `Blocked` (must pass checks to unlock)
+    pub fn new() -> Self {
+        Self {
+            is_fork_pr: false,
+            has_required_permissions: false,
+            api_key_masked: false,
+            policy_changed_from_base: false,
+            backend_url_allowed: false,
+            org_policy_loaded: false,
+            security_level: SecurityLevel::Blocked,
+        }
+    }
+}
+
+impl Default for SecurityContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SecurityLevel
+// ---------------------------------------------------------------------------
+
+/// The effective security level after all pre-flight checks.
+///
+/// Determines what operations are permitted during the action execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SecurityLevel {
+    /// All checks passed, full operation allowed.
+    Full,
+
+    /// Fork PR or restricted environment: secret-dependent operations skipped.
+    Restricted,
+
+    /// Critical security violation: all operations blocked.
+    Blocked,
+}
+
+impl SecurityLevel {
+    /// Whether operations are permitted at this level.
+    pub fn is_allowed(&self) -> bool {
+        matches!(self, SecurityLevel::Full | SecurityLevel::Restricted)
+    }
+
+    /// Whether secret-dependent operations are permitted.
+    pub fn secrets_allowed(&self) -> bool {
+        matches!(self, SecurityLevel::Full)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ActionMode
+// ---------------------------------------------------------------------------
+
+/// The mode of action execution, used to determine required permissions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ActionMode {
+    /// Mode A: Policy governance — PR diff analysis + policy enforcement.
+    Governance,
+
+    /// Mode B: Full execution — plan → execute → validate → persist.
+    Run,
+
+    /// Mode B: Self-correcting validation loop.
+    Validate,
+
+    /// Mode B: Planning phase only.
+    Plan,
+
+    /// Show current execution status.
+    Status,
+
+    /// Auto-detect from event context.
+    Auto,
+}
+
+impl ActionMode {
+    /// Get the required GitHub token permissions for this mode.
+    pub fn required_scopes(&self) -> &'static [(&'static str, &'static str)] {
+        match self {
+            ActionMode::Run | ActionMode::Validate | ActionMode::Plan => &[
+                ("contents", "write"),
+                ("pull-requests", "write"),
+                ("issues", "write"),
+                ("statuses", "write"),
+            ],
+            ActionMode::Governance => &[
+                ("contents", "read"),
+                ("pull-requests", "write"),
+                ("statuses", "write"),
+            ],
+            ActionMode::Status | ActionMode::Auto => &[
+                ("contents", "read"),
+            ],
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HmacKey
+// ---------------------------------------------------------------------------
+
+/// An HMAC signing key with metadata for key rotation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HmacKey {
+    /// The raw key bytes (32 bytes for SHA-256).
+    pub key: Vec<u8>,
+
+    /// A human-readable identifier for the key (for key rotation).
+    pub key_id: String,
+
+    /// ISO 8601 timestamp when the key was created.
+    pub created_at: String,
+
+    /// ISO 8601 timestamp when the key expires.
+    pub expires_at: String,
+}
+
+// ---------------------------------------------------------------------------
+// SecurityPolicy
+// ---------------------------------------------------------------------------
+
+/// Organization-level security policy configuration.
+///
+/// Loaded from `.rigorix/security.toml` or organization-level URL.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SecurityPolicy {
+    /// Allowed backend API hosts (prefix matching).
+    pub allowed_hosts: Vec<String>,
+
+    /// Path to organization-wide policy file.
+    pub org_policy_path: Option<String>,
+
+    /// Whether org policy is required (fail if unreachable).
+    pub org_policy_required: bool,
+
+    /// Environment variable name for the HMAC signing key.
+    pub hmac_key_env_var: Option<String>,
+
+    /// HMAC key rotation interval in days.
+    pub hmac_rotation_days: Option<u32>,
+}

--- a/actions/src/security_config/infrastructure/mod.rs
+++ b/actions/src/security_config/infrastructure/mod.rs
@@ -1,0 +1,19 @@
+//! Infrastructure layer for the Security Configuration bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/security-config.md#infrastructure
+//! Implements: Contract Freeze — repository interfaces for fork detection, token validation,
+//! policy loading, HMAC key management, and URL allowlisting
+//! Issue: issue-contract-freeze
+//!
+//! This module defines the repository interfaces that abstract data access
+//! for the Security Configuration module. Implementations will read from
+//! environment variables, filesystem, GitHub API, and other sources.
+//!
+//! # Contract (Frozen)
+//! - All repository methods are async
+//! - All methods return `Result<_, SecurityError>`
+//! - No dependencies on external frameworks
+
+pub mod repository;
+
+pub use repository::*;

--- a/actions/src/security_config/infrastructure/repository/mod.rs
+++ b/actions/src/security_config/infrastructure/repository/mod.rs
@@ -1,0 +1,124 @@
+//! Repository interfaces for the Security Configuration bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/security-config.md
+//! Implements: Contract Freeze — ForkRepository, TokenRepository, PolicyRepository,
+//! HmacKeyRepository, AllowlistRepository traits
+//! Issue: issue-contract-freeze
+//!
+//! Repositories abstract data access behind interfaces, allowing
+//! implementations to use environment variables, filesystem, GitHub API,
+//! or mock storage without coupling domain logic to infrastructure.
+//!
+//! # Contract (Frozen)
+//! - All repository methods are async
+//! - All methods return domain error types
+//! - No framework-specific annotations on trait definitions
+//! - Implementations are hidden behind these interfaces
+
+use async_trait::async_trait;
+
+use crate::security_config::domain::{HmacKey, SecurityError, SecurityPolicy};
+
+/// Repository for reading GitHub environment variables related to fork detection.
+///
+/// Abstracts `std::env::var` behind a trait for testability.
+/// Implementations can use real environment variables or an in-memory map.
+#[async_trait]
+pub trait ForkRepository: Send + Sync {
+    /// Get the base repository full name (e.g., "org/repo").
+    /// Reads `GITHUB_REPOSITORY` env var.
+    async fn base_repo(&self) -> Result<String, SecurityError>;
+
+    /// Get the head repository full name for a PR.
+    /// Reads `GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME` env var.
+    async fn head_repo(&self) -> Result<Option<String>, SecurityError>;
+
+    /// Get the head repository owner for a fork PR.
+    /// Reads `GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_OWNER` env var.
+    async fn head_repo_owner(&self) -> Result<Option<String>, SecurityError>;
+
+    /// Get the event name (e.g., "pull_request", "push").
+    /// Reads `GITHUB_EVENT_NAME` env var.
+    async fn event_name(&self) -> Result<Option<String>, SecurityError>;
+
+    /// Get the PR number if this is a pull request event.
+    /// Reads `GITHUB_EVENT_PULL_REQUEST_NUMBER` env var.
+    async fn pr_number(&self) -> Result<Option<u64>, SecurityError>;
+}
+
+/// Repository for validating GitHub tokens and checking permissions.
+///
+/// Abstracts GitHub API calls behind a trait for testability.
+#[async_trait]
+pub trait TokenRepository: Send + Sync {
+    /// Validate a GitHub token by calling the API.
+    /// Returns true if the token is valid and responds.
+    async fn validate_token(&self, token: &str) -> Result<bool, SecurityError>;
+
+    /// Get the authenticated user's scopes/permissions.
+    /// Returns a list of permission strings (e.g., "repo", "workflow").
+    async fn get_scopes(&self, token: &str) -> Result<Vec<String>, SecurityError>;
+
+    /// Check if the token has a specific scope.
+    async fn has_scope(&self, token: &str, scope: &str) -> Result<bool, SecurityError>;
+}
+
+/// Repository for reading security policy configuration.
+///
+/// Abstracts filesystem and HTTP access to `.rigorix/security.toml` and
+/// org-level policy URLs behind a trait for testability.
+#[async_trait]
+pub trait PolicyRepository: Send + Sync {
+    /// Read the security policy file content.
+    /// Searches CWD for `.rigorix/security.toml` by default.
+    async fn read_policy_file(&self, path_override: Option<&str>) -> Result<Option<String>, SecurityError>;
+
+    /// Fetch an organization-level policy from a URL.
+    async fn fetch_org_policy(&self, url: &str) -> Result<String, SecurityError>;
+
+    /// Resolve the path to the security policy file.
+    async fn resolve_policy_path(&self) -> Result<Option<String>, SecurityError>;
+
+    /// Check if the policy file exists.
+    async fn policy_file_exists(&self) -> Result<bool, SecurityError>;
+}
+
+/// Repository for managing HMAC signing keys.
+///
+/// Abstracts key storage behind a trait for testability.
+/// In production, keys are loaded from environment variables.
+#[async_trait]
+pub trait HmacKeyRepository: Send + Sync {
+    /// Load the HMAC signing key from its configured source.
+    /// Typically reads from an environment variable.
+    async fn load_key(&self, env_var: &str) -> Result<Option<HmacKey>, SecurityError>;
+
+    /// Store a new HMAC key (for key rotation).
+    /// In production, this would update a secret store.
+    async fn store_key(&self, key: &HmacKey) -> Result<(), SecurityError>;
+
+    /// Get the key rotation configuration.
+    async fn rotation_config(&self) -> Result<(u32, String), SecurityError>;
+
+    /// List all available key IDs (for key rotation).
+    async fn list_keys(&self) -> Result<Vec<String>, SecurityError>;
+}
+
+/// Repository for managing the URL allowlist.
+///
+/// Abstracts allowlist storage behind a trait for testability.
+/// In production, the allowlist is loaded from the security policy.
+#[async_trait]
+pub trait AllowlistRepository: Send + Sync {
+    /// Load the allowlist entries from configuration.
+    async fn load_allowlist(&self) -> Result<Vec<String>, SecurityError>;
+
+    /// Add an entry to the runtime allowlist.
+    async fn add_entry(&self, host: String) -> Result<(), SecurityError>;
+
+    /// Remove an entry from the runtime allowlist.
+    async fn remove_entry(&self, host: &str) -> Result<(), SecurityError>;
+
+    /// Check if a host is in the allowlist.
+    async fn contains(&self, host: &str) -> Result<bool, SecurityError>;
+}

--- a/actions/src/security_config/interfaces/http/mod.rs
+++ b/actions/src/security_config/interfaces/http/mod.rs
@@ -1,0 +1,310 @@
+//! HTTP API contracts for Security Configuration endpoints.
+//!
+//! @canonical actions/.pi/architecture/modules/security-config.md
+//! Implements: Contract Freeze — HTTP endpoint contracts and error formats
+//! Issue: issue-contract-freeze
+//!
+//! Defines endpoint paths, methods, request/response schemas, and error
+//! response formats. These contracts are framework-agnostic — they describe
+//! the API surface that any HTTP server implementation must satisfy.
+//!
+//! Note: In production, security checks run before the action pipeline.
+//! These contracts exist for:
+//! - Local development & debugging endpoints
+//! - Runtime introspection (health checks, status)
+//! - Testing via HTTP mocks
+//!
+//! # Contract (Frozen)
+//! - All endpoints documented with method, path, request, and response types
+//! - Error responses follow a unified format
+//! - No framework-specific annotations (axum/actix/warp annotations added by implementation)
+
+use serde::{Deserialize, Serialize};
+
+use crate::security_config::domain::{
+    HmacKey, SecurityContext, SecurityLevel, SecurityPolicy,
+};
+
+use super::super::application::dto::{
+    DetectForkOutput, HmacSignOutput, HmacVerifyOutput, MaskSecretsOutput, ValidateSecurityOutput,
+    ValidateTokenOutput, ValidateUrlOutput,
+};
+
+// ---------------------------------------------------------------------------
+// API Base Path
+// ---------------------------------------------------------------------------
+
+/// All security config endpoints are served under this base path.
+pub const API_BASE_PATH: &str = "/api/v1/security";
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/security/validate
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/security/validate
+///
+/// Run all pre-flight security checks.
+///
+/// **Request:** `ValidateRequest`
+/// **Response:** `200 OK` with `ValidateResponse`
+pub const VALIDATE_PATH: &str = "/api/v1/security/validate";
+pub const VALIDATE_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/security/validate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidateRequest {
+    /// The GitHub token to validate.
+    pub github_token: String,
+    /// Optional API key to mask.
+    pub api_key: Option<String>,
+    /// Path to the policy file.
+    pub policy_path: String,
+    /// Backend audit URL to validate.
+    pub backend_url: Option<String>,
+    /// Action mode to check permissions for.
+    pub mode: String,
+}
+
+/// Response body for POST /api/v1/security/validate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidateResponse {
+    pub success: bool,
+    pub context: SecurityContext,
+    pub warnings: Vec<String>,
+    pub duration_ms: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: GET /api/v1/security/context
+// ---------------------------------------------------------------------------
+
+/// GET /api/v1/security/context
+///
+/// Get the current security context.
+///
+/// **Response:** `200 OK` with `GetContextResponse`
+pub const GET_CONTEXT_PATH: &str = "/api/v1/security/context";
+pub const GET_CONTEXT_METHOD: &str = "GET";
+
+/// Response for GET /api/v1/security/context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetContextResponse {
+    pub context: SecurityContext,
+    pub level: SecurityLevel,
+    pub is_allowed: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: GET /api/v1/security/fork
+// ---------------------------------------------------------------------------
+
+/// GET /api/v1/security/fork
+///
+/// Detect if this is a fork PR.
+///
+/// **Response:** `200 OK` with `ForkDetectionResponse`
+pub const FORK_DETECTION_PATH: &str = "/api/v1/security/fork";
+pub const FORK_DETECTION_METHOD: &str = "GET";
+
+/// Response for GET /api/v1/security/fork.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForkDetectionResponse {
+    pub is_fork: bool,
+    pub head_repo: Option<String>,
+    pub base_repo: Option<String>,
+    pub fork_owner: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/security/mask
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/security/mask
+///
+/// Mask secrets from workflow logs.
+///
+/// **Request:** `MaskRequest`
+/// **Response:** `200 OK` with `MaskResponse`
+pub const MASK_PATH: &str = "/api/v1/security/mask";
+pub const MASK_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/security/mask.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MaskRequest {
+    pub secrets: Vec<String>,
+}
+
+/// Response body for POST /api/v1/security/mask.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MaskResponse {
+    pub masked_count: u32,
+    pub masked_hints: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/security/token
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/security/token
+///
+/// Validate the GitHub token and check permissions.
+///
+/// **Request:** `TokenValidateRequest`
+/// **Response:** `200 OK` with `TokenValidateResponse`
+pub const TOKEN_VALIDATE_PATH: &str = "/api/v1/security/token";
+pub const TOKEN_VALIDATE_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/security/token.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenValidateRequest {
+    pub token: String,
+    pub mode: String,
+}
+
+/// Response body for POST /api/v1/security/token.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenValidateResponse {
+    pub valid: bool,
+    pub has_required_permissions: bool,
+    pub available_scopes: Vec<String>,
+    pub missing_scopes: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/security/url
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/security/url
+///
+/// Validate a URL against the allowlist.
+///
+/// **Request:** `UrlValidateRequest`
+/// **Response:** `200 OK` with `UrlValidateResponse`
+pub const URL_VALIDATE_PATH: &str = "/api/v1/security/url";
+pub const URL_VALIDATE_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/security/url.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UrlValidateRequest {
+    pub url: String,
+}
+
+/// Response body for POST /api/v1/security/url.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UrlValidateResponse {
+    pub allowed: bool,
+    pub host: String,
+    pub checked_against: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/security/hmac/sign
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/security/hmac/sign
+///
+/// Sign a payload with HMAC-SHA256.
+///
+/// **Request:** `HmacSignRequest`
+/// **Response:** `200 OK` with `HmacSignResponse`
+pub const HMAC_SIGN_PATH: &str = "/api/v1/security/hmac/sign";
+pub const HMAC_SIGN_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/security/hmac/sign.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HmacSignRequest {
+    pub payload: String,
+}
+
+/// Response body for POST /api/v1/security/hmac/sign.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HmacSignResponse {
+    pub signature: String,
+    pub key_id: String,
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/security/hmac/verify
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/security/hmac/verify
+///
+/// Verify an HMAC-SHA256 signature.
+///
+/// **Request:** `HmacVerifyRequest`
+/// **Response:** `200 OK` with `HmacVerifyResponse`
+pub const HMAC_VERIFY_PATH: &str = "/api/v1/security/hmac/verify";
+pub const HMAC_VERIFY_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/security/hmac/verify.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HmacVerifyRequest {
+    pub payload: String,
+    pub signature: String,
+}
+
+/// Response body for POST /api/v1/security/hmac/verify.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HmacVerifyResponse {
+    pub valid: bool,
+    pub key_id: String,
+}
+
+// ---------------------------------------------------------------------------
+// Unified Error Response Format
+// ---------------------------------------------------------------------------
+
+/// Standard error response for all Security Configuration API endpoints.
+///
+/// All 4xx/5xx responses use this format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiErrorResponse {
+    /// HTTP status code.
+    pub status: u16,
+    /// Machine-readable error code.
+    pub code: String,
+    /// Human-readable error message.
+    pub message: String,
+    /// Detailed error context (optional, may include field-level errors).
+    pub details: Option<serde_json::Value>,
+    /// Request ID for tracing (if available).
+    pub request_id: Option<String>,
+}
+
+/// Standardized error codes for Security Configuration API.
+pub mod error_codes {
+    /// Fork PR detected.
+    pub const FORK_DETECTED: &str = "FORK_DETECTED";
+    /// Token validation failed.
+    pub const TOKEN_VALIDATION_FAILED: &str = "TOKEN_VALIDATION_FAILED";
+    /// Token has insufficient permissions.
+    pub const TOKEN_INSUFFICIENT: &str = "TOKEN_INSUFFICIENT";
+    /// URL blocked by allowlist.
+    pub const URL_BLOCKED: &str = "URL_BLOCKED";
+    /// Invalid URL format.
+    pub const INVALID_URL: &str = "INVALID_URL";
+    /// HMAC signature verification failed.
+    pub const HMAC_VERIFICATION_FAILED: &str = "HMAC_VERIFICATION_FAILED";
+    /// HMAC key not available.
+    pub const HMAC_KEY_MISSING: &str = "HMAC_KEY_MISSING";
+    /// Policy file not found.
+    pub const POLICY_NOT_FOUND: &str = "POLICY_NOT_FOUND";
+    /// Policy parse error.
+    pub const POLICY_PARSE_ERROR: &str = "POLICY_PARSE_ERROR";
+    /// Internal server error.
+    pub const INTERNAL_ERROR: &str = "INTERNAL_ERROR";
+}
+
+/// HTTP status code mappings for Security Configuration errors.
+pub mod status_codes {
+    pub const FORK_DETECTED: u16 = 403;
+    pub const TOKEN_VALIDATION_FAILED: u16 = 401;
+    pub const TOKEN_INSUFFICIENT: u16 = 403;
+    pub const URL_BLOCKED: u16 = 403;
+    pub const INVALID_URL: u16 = 400;
+    pub const HMAC_VERIFICATION_FAILED: u16 = 401;
+    pub const HMAC_KEY_MISSING: u16 = 500;
+    pub const POLICY_NOT_FOUND: u16 = 404;
+    pub const POLICY_PARSE_ERROR: u16 = 400;
+    pub const INTERNAL_ERROR: u16 = 500;
+}

--- a/actions/src/security_config/interfaces/mod.rs
+++ b/actions/src/security_config/interfaces/mod.rs
@@ -1,0 +1,18 @@
+//! Interfaces layer for the Security Configuration bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/security-config.md#interfaces
+//! Implements: Contract Freeze — HTTP API contracts
+//! Issue: issue-contract-freeze
+//!
+//! This module defines the external-facing API contracts for the
+//! Security Configuration module. HTTP endpoints are framework-agnostic
+//! contracts that any HTTP server implementation must satisfy.
+//!
+//! # Contract (Frozen)
+//! - All endpoint paths, methods, requests, and responses are documented
+//! - Error responses follow a unified format
+//! - No framework-specific annotations
+
+pub mod http;
+
+pub use http::*;

--- a/actions/src/security_config/mod.rs
+++ b/actions/src/security_config/mod.rs
@@ -1,0 +1,69 @@
+//! Security Configuration — pre-flight security validation bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/security-config.md
+//! Implements: Contract Freeze — all component interfaces for security-config epic
+//! Issue: issue-contract-freeze
+//!
+//! This module enforces operational security for the GitHub Action. It validates
+//! the execution environment before any operation begins — detecting fork PRs
+//! (to prevent secret exposure), masking sensitive values from logs, validating
+//! token permissions, and verifying that policies haven't been tampered with.
+//!
+//! This is a **Phase 0** module — it runs before any diff analysis, policy
+//! evaluation, or engine execution.
+//!
+//! # Components
+//!
+//! | Component | Domain | Application | Infrastructure | Interfaces |
+//! |-----------|--------|-------------|----------------|------------|
+//! | SecurityContext | `domain::types::SecurityContext` | `application::dto` | — | `interfaces::http` |
+//! | SecurityValidator | — | `application::service::SecurityValidationService` | — | — |
+//! | ForkDetector | `domain::types` | `application::service::ForkDetectionService` | `infrastructure::repository::ForkRepository` | — |
+//! | SecretMasker | — | `application::service::SecretMaskingService` | — | — |
+//! | TokenValidator | — | `application::service::TokenValidationService` | `infrastructure::repository::TokenRepository` | — |
+//! | UrlAllowlist | — | `application::service::UrlAllowlistService` | `infrastructure::repository::AllowlistRepository` | — |
+//! | HmacSigner | `domain::types::HmacKey` | `application::service::HmacSigningService` | `infrastructure::repository::HmacKeyRepository` | — |
+//! | OrgPolicyLoader | `domain::types::SecurityPolicy` | `application::service::PolicyLoadingService` | `infrastructure::repository::PolicyRepository` | — |
+//!
+//! # Layer Structure
+//!
+//! ```text
+//! security_config/
+//! ├── mod.rs                          # Module root
+//! ├── domain/                         # Domain entities and interfaces
+//! │   ├── mod.rs
+//! │   ├── types.rs                    # SecurityContext, SecurityLevel, ActionMode, HmacKey, SecurityPolicy
+//! │   ├── error.rs                    # SecurityError
+//! │   └── event/
+//! │       └── mod.rs                  # SecurityEvent payloads
+//! ├── application/                    # Application service interfaces and DTOs
+//! │   ├── mod.rs
+//! │   ├── service.rs                  # Service traits (SecurityValidationService, etc.)
+//! │   ├── dto/
+//! │   │   └── mod.rs                  # Input/output DTO schemas
+//! │   └── factory.rs                  # Factory interfaces
+//! ├── infrastructure/                 # Infrastructure layer
+//! │   ├── mod.rs
+//! │   └── repository/
+//! │       └── mod.rs                  # Repository interfaces (ForkRepository, TokenRepository, etc.)
+//! └── interfaces/                     # External interfaces
+//!     ├── mod.rs
+//!     └── http/
+//!         └── mod.rs                  # HTTP API contracts
+//! ```
+//!
+//! # Contract Freeze
+//!
+//! All public interfaces, DTO schemas, and contracts in this module are
+//! frozen. Implementation must satisfy these contracts, not the other way around.
+//! See `actions/.pi/architecture/modules/security-config.md` for the canonical spec.
+//!
+//! # Related Issues
+//!
+//! - Issue #538: Contract Freeze (this issue)
+//! - Issue #537: Epic "security-config"
+
+pub mod application;
+pub mod domain;
+pub mod infrastructure;
+pub mod interfaces;


### PR DESCRIPTION
## Contract Freeze: security-config

Define and freeze all public interfaces, contracts, and schemas for the security-config epic.

### Components Frozen
- **SecurityContext/SecurityLevel** — pre-flight validation results
- **ForkDetector** — detects fork PRs to prevent secret exposure
- **SecretMasker** — masks secrets from workflow logs
- **TokenValidator** — validates GitHub token permissions
- **UrlAllowlist** — validates backend URLs against allowlist
- **HmacSigner** — HMAC-SHA256 signing and verification
- **OrgPolicyLoader** — loads security policy configuration

### Clean Architecture Layers
- `domain/` — types, error enum, event schemas
- `application/` — 7 service traits, DTOs, 3 factory interfaces
- `infrastructure/repository/` — 5 repository interfaces
- `interfaces/http/` — 12 API endpoint contracts

### Verification
- ✅ `cargo build` — passes
- ✅ `cargo clippy` — no new warnings
- ✅ Interface-only: zero implementation logic

Closes #538
Epic: #537