### PR TITLE
feat: contract freeze for action-entrypoint module (#613)

### DIFF
--- a/actions/src/action_entrypoint/application/dto/mod.rs
+++ b/actions/src/action_entrypoint/application/dto/mod.rs
@@ -1,0 +1,168 @@
+//! Data Transfer Objects for the Action Entrypoint module.
+//!
+//! @canonical actions/.pi/architecture/modules/action-entrypoint.md
+//! Implements: Contract Freeze — DTO schemas for context building, mode resolution,
+//! and dispatch operations
+//! Issue: issue-contract-freeze
+//!
+//! DTOs define the input/output contracts for service operations.
+//! They carry validation metadata and documentation but no behavior.
+//!
+//! # Contract (Frozen)
+//! - Every service operation has a dedicated input and output DTO
+//! - DTOs are serializable (JSON for event processing and audit logging)
+//! - Validation constraints are documented in field docs
+
+use serde::{Deserialize, Serialize};
+
+use crate::action_entrypoint::domain::{ActionContext, ActionMode, ActionOutput, GitHubEvent};
+
+// ---------------------------------------------------------------------------
+// Dispatch DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for dispatching an action through the router.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DispatchInput {
+    /// The fully built action context.
+    pub context: ActionContext,
+
+    /// Maximum time to wait for the dispatch in seconds.
+    /// If `None`, uses default timeout.
+    pub timeout_secs: Option<u64>,
+
+    /// Whether to force dispatch even if the event type is not routable.
+    pub force: bool,
+}
+
+/// Output from dispatching an action.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DispatchOutput {
+    /// The formatted action output.
+    pub output: ActionOutput,
+    /// The execution mode that was actually dispatched.
+    pub mode: ActionMode,
+    /// Duration of the dispatch in milliseconds.
+    pub duration_ms: u64,
+    /// Whether the dispatch was successful.
+    pub success: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Mode Resolution DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for resolving the execution mode.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResolveModeInput {
+    /// The raw `INPUT_MODE` value from environment (if set).
+    pub input_mode: Option<String>,
+    /// The event name from `GITHUB_EVENT_NAME`.
+    pub event_name: String,
+    /// The event payload JSON value (for extracting intent from commands).
+    pub event_payload: Option<serde_json::Value>,
+    /// The raw `INPUT_INTENT` value from environment (if set).
+    pub input_intent: Option<String>,
+}
+
+/// Output from resolving the execution mode.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResolveModeOutput {
+    /// The resolved execution mode.
+    pub mode: ActionMode,
+    /// The source of resolution (input, event_command, event_type, default).
+    pub source: String,
+    /// Whether the resolution was unambiguous.
+    pub unambiguous: bool,
+    /// Warnings from resolution (e.g., conflicting inputs).
+    pub warnings: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Context Building DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for building an ActionContext from the environment.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BuildContextInput {
+    /// Override environment for testing (maps variable name → value).
+    /// If `None`, reads from real `std::env::var`.
+    pub env_override: Option<std::collections::HashMap<String, String>>,
+
+    /// Override the workspace root path for testing.
+    pub workspace_override: Option<String>,
+
+    /// Override the event name for testing.
+    pub event_name_override: Option<String>,
+
+    /// Override the event payload path for testing.
+    pub event_path_override: Option<String>,
+
+    /// Override the event payload JSON content for testing.
+    /// If set, skips reading from the event path file.
+    pub event_payload_override: Option<String>,
+}
+
+/// Output from building an ActionContext.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BuildContextOutput {
+    /// The fully built action context.
+    pub context: ActionContext,
+    /// The raw event name from the environment.
+    pub event_name: String,
+    /// The raw input mode string (if present).
+    pub input_mode: Option<String>,
+    /// Warnings from context construction.
+    pub warnings: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Event Parsing DTOs
+// ---------------------------------------------------------------------------
+
+/// Input for parsing a GitHub event payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParseEventInput {
+    /// The event name (e.g., "workflow_dispatch", "issue_comment").
+    pub event_name: String,
+    /// Path to the event payload JSON file.
+    pub event_path: String,
+    /// Override JSON content for testing (if `None`, reads from file).
+    pub content_override: Option<String>,
+}
+
+/// Output from parsing a GitHub event payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParseEventOutput {
+    /// The parsed GitHub event.
+    pub event: GitHubEvent,
+    /// The raw event payload JSON (for further processing).
+    pub raw_payload: serde_json::Value,
+    /// File size of the event payload in bytes (if read from file).
+    pub file_size_bytes: Option<u64>,
+}
+
+// ---------------------------------------------------------------------------
+// Validation Loop DTOs
+// ---------------------------------------------------------------------------
+
+/// Configuration for the validation loop dispatch.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidationLoopConfig {
+    /// Maximum number of validation iterations.
+    pub max_iterations: u32,
+    /// Minimum quality score to accept (0.0 - 1.0).
+    pub min_quality_score: Option<f64>,
+    /// Whether to persist intermediate results.
+    pub persist_intermediate: bool,
+}
+
+impl Default for ValidationLoopConfig {
+    fn default() -> Self {
+        Self {
+            max_iterations: 3,
+            min_quality_score: None,
+            persist_intermediate: false,
+        }
+    }
+}

--- a/actions/src/action_entrypoint/application/factory.rs
+++ b/actions/src/action_entrypoint/application/factory.rs
@@ -1,0 +1,143 @@
+//! Factory interfaces for constructing Action Entrypoint domain objects.
+//!
+//! @canonical actions/.pi/architecture/modules/action-entrypoint.md
+//! Implements: Contract Freeze — ActionRouterFactory, ContextFactory, OutputFactory, ModeFactory traits
+//! Issue: issue-contract-freeze
+//!
+//! Factories encapsulate the construction of complex domain objects,
+//! allowing implementations to inject dependencies and apply defaults
+//! without exposing construction logic to callers.
+//!
+//! # Contract (Frozen)
+//! - Every factory method returns a configured domain object
+//! - Validation is applied during construction
+//! - No mutable state in factory implementations
+
+use async_trait::async_trait;
+
+use crate::action_entrypoint::domain::{
+    ActionContext, ActionError, ActionMode, ActionOutput, GitHubEvent,
+};
+
+/// Factory for constructing `ActionRouter` implementations.
+///
+/// Encapsulates the wiring of engine dependencies (orchestrator service,
+/// validation loop service) into a configured router.
+#[async_trait]
+pub trait ActionRouterFactory: Send + Sync {
+    /// Create a new `ActionRouter` with the given engine dependencies.
+    ///
+    /// The factory resolves engine service references and wires them
+    /// into the router. Returns an error if required dependencies
+    /// are unavailable.
+    async fn create_router(
+        &self,
+    ) -> Result<Box<dyn crate::action_entrypoint::application::ActionRouter>, ActionError>;
+
+    /// Create a router with validation loop support.
+    ///
+    /// Like `create_router()`, but also wires the validation loop
+    /// service for `ActionMode::Validate` dispatch.
+    async fn create_router_with_validation(
+        &self,
+    ) -> Result<Box<dyn crate::action_entrypoint::application::ActionRouter>, ActionError>;
+}
+
+/// Factory for constructing `ActionContext` instances.
+///
+/// Handles environment variable reading, event payload parsing, and
+/// input resolution to build a fully configured `ActionContext`.
+#[async_trait]
+pub trait ContextFactory: Send + Sync {
+    /// Build an `ActionContext` from environment data.
+    ///
+    /// Reads workspace root, event info, and token from the environment.
+    async fn build_from_env(&self) -> Result<ActionContext, ActionError>;
+
+    /// Build an `ActionContext` from explicit values (for testing).
+    async fn build_from_values(
+        &self,
+        workspace_root: String,
+        event: GitHubEvent,
+        mode: ActionMode,
+        github_token: Option<String>,
+    ) -> Result<ActionContext, ActionError>;
+
+    /// Apply mode to an existing context (returns new context).
+    async fn apply_mode(&self, ctx: &ActionContext, mode: ActionMode) -> ActionContext;
+
+    /// Apply configuration parameters to a context.
+    ///
+    /// Sets max_iterations, max_llm_calls, max_llm_tokens, etc.
+    /// from the provided map of string key-value pairs.
+    async fn apply_config(
+        &self,
+        ctx: ActionContext,
+        config: std::collections::HashMap<String, String>,
+    ) -> Result<ActionContext, ActionError>;
+}
+
+/// Factory for constructing `ActionOutput` instances.
+///
+/// Provides convenience methods for creating common output shapes
+/// (success, failure, skipped, error annotations).
+#[async_trait]
+pub trait OutputFactory: Send + Sync {
+    /// Create a success output.
+    async fn success(
+        &self,
+        summary: &str,
+        execution_id: Option<String>,
+    ) -> Result<ActionOutput, ActionError>;
+
+    /// Create a failure output from an error.
+    async fn failure(
+        &self,
+        error: &ActionError,
+        summary: &str,
+    ) -> Result<ActionOutput, ActionError>;
+
+    /// Create a skipped output.
+    async fn skipped(
+        &self,
+        reason: &str,
+    ) -> Result<ActionOutput, ActionError>;
+
+    /// Create an output with annotations.
+    async fn with_annotations(
+        &self,
+        base: ActionOutput,
+        annotations: Vec<crate::action_entrypoint::domain::WorkflowAnnotation>,
+    ) -> Result<ActionOutput, ActionError>;
+
+    /// Create an output from a mode mismatch (unsupported mode).
+    async fn unsupported_mode(
+        &self,
+        mode: &ActionMode,
+    ) -> Result<ActionOutput, ActionError>;
+}
+
+/// Factory for constructing `ActionMode` values.
+///
+/// Handles parsing mode strings and event context to produce
+/// resolved `ActionMode` values with proper intent extraction.
+#[async_trait]
+pub trait ModeFactory: Send + Sync {
+    /// Create a Run mode with the given intent.
+    async fn run(intent: String) -> ActionMode;
+
+    /// Create a Plan mode with the given intent.
+    async fn plan(intent: String) -> ActionMode;
+
+    /// Create a Validate mode with the given intent.
+    async fn validate(intent: String) -> ActionMode;
+
+    /// Create a Status mode.
+    async fn status() -> ActionMode;
+
+    /// Parse a mode from a string.
+    ///
+    /// Valid values: "run", "plan", "validate", "status".
+    /// Returns `None` for unknown values.
+    async fn from_string(mode_str: &str, intent: Option<String>) -> Option<ActionMode>;
+}

--- a/actions/src/action_entrypoint/application/mod.rs
+++ b/actions/src/action_entrypoint/application/mod.rs
@@ -1,0 +1,24 @@
+//! Application layer for the Action Entrypoint bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/action-entrypoint.md#application
+//! Implements: Contract Freeze — service traits, DTO schemas, factory interfaces
+//! Issue: issue-contract-freeze
+//!
+//! This module defines the application-level contracts:
+//! - Service interfaces (use cases) in `service.rs`
+//! - Input/output DTO schemas in `dto/`
+//! - Factory interfaces in `factory.rs`
+//!
+//! # Contract (Frozen)
+//! - All service traits are async (use `async-trait`)
+//! - All public methods return `Result<_, ActionError>`
+//! - DTOs carry full documentation for each field
+//! - No implementation — only contract signatures
+
+pub mod dto;
+pub mod factory;
+pub mod service;
+
+pub use dto::*;
+pub use factory::*;
+pub use service::*;

--- a/actions/src/action_entrypoint/application/service.rs
+++ b/actions/src/action_entrypoint/application/service.rs
@@ -1,0 +1,164 @@
+//! Service interfaces (use cases) for the Action Entrypoint bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/action-entrypoint.md
+//! Implements: Contract Freeze — ActionRouter trait, ModeResolver trait
+//! Issue: issue-contract-freeze
+//!
+//! These traits define the application-level operations for event routing,
+//! mode resolution, and action dispatch. All methods are async and return
+//! domain error types.
+//!
+//! # Contract (Frozen)
+//! - Every use case has a corresponding trait method
+//! - Input/output types are DTOs defined in `dto/`
+//! - All methods are async (use `async-trait` for trait object safety)
+//! - No implementation — only contract signatures
+
+use async_trait::async_trait;
+
+use crate::action_entrypoint::domain::{ActionError, ActionMode};
+
+use super::dto::{
+    BuildContextInput, BuildContextOutput, DispatchInput, DispatchOutput, ResolveModeInput,
+    ResolveModeOutput,
+};
+
+/// Routes GitHub Action events to engine orchestrator calls.
+///
+/// The router is stateless — all state lives in the engine. It maps
+/// the resolved `ActionMode` and `ActionContext` to the appropriate
+/// engine service call, formats the result into `ActionOutput`.
+///
+/// # Contract (Frozen)
+/// - `dispatch()` is the primary entry point
+/// - The router never holds state across calls
+/// - All engine interaction is through trait methods
+/// - Unknown events return `DispatchStatus::Skipped`
+#[async_trait]
+pub trait ActionRouter: Send + Sync {
+    /// Dispatch based on event type and action mode.
+    ///
+    /// Routes the action context to the appropriate engine call:
+    /// - `ActionMode::Run` → orchestrator run
+    /// - `ActionMode::Plan` → orchestrator plan_only
+    /// - `ActionMode::Validate` → validation loop (with fallback to run)
+    /// - `ActionMode::Status` → orchestrator status
+    ///
+    /// # Returns
+    ///
+    /// `ActionOutput` with status, summary, and any annotations.
+    async fn dispatch(&self, input: DispatchInput) -> Result<DispatchOutput, ActionError>;
+
+    /// Dispatch but with a timeout.
+    ///
+    /// Same as `dispatch()` but with a configurable timeout.
+    /// Returns `ActionError::EngineError` if the timeout is exceeded
+    /// (with `is_retriable() = true`).
+    async fn dispatch_with_timeout(
+        &self,
+        input: DispatchInput,
+        timeout_secs: u64,
+    ) -> Result<DispatchOutput, ActionError>;
+
+    /// Check if this router can handle the given mode.
+    ///
+    /// Returns `true` for all supported `ActionMode` variants.
+    /// Used by the entrypoint to decide whether to dispatch or skip.
+    async fn can_handle(&self, mode: &ActionMode) -> bool;
+
+    /// Get the list of supported execution modes.
+    ///
+    /// Returns all `ActionMode` variants that this router supports.
+    async fn supported_modes(&self) -> Vec<ActionMode>;
+}
+
+/// Resolves the execution mode from inputs and event context.
+///
+/// Determines what the action should do (run, plan, validate, status)
+/// based on `INPUT_MODE`, the event type, and slash commands in comments.
+///
+/// # Contract (Frozen)
+/// - `resolve()` is the primary entry point
+/// - Mode resolution follows a priority order: explicit input > event context > default
+/// - Returns `ActionMode::Status` as the fallback
+#[async_trait]
+pub trait ModeResolver: Send + Sync {
+    /// Resolve the execution mode from inputs and event context.
+    ///
+    /// Resolution priority:
+    /// 1. Explicit `INPUT_MODE` from workflow inputs (highest priority)
+    /// 2. Event context: issue_comment with /rigorix command
+    /// 3. Event context: pull_request → Validate
+    /// 4. Event context: workflow_dispatch → Run
+    /// 5. Fallback: Status (lowest priority)
+    async fn resolve(&self, input: ResolveModeInput) -> Result<ResolveModeOutput, ActionError>;
+
+    /// Resolve mode from a raw mode string (from `INPUT_MODE`).
+    ///
+    /// Valid values: "run", "plan", "validate", "status", "auto".
+    /// Returns `None` for unknown values (caller should fall back to event-based resolution).
+    async fn resolve_from_string(&self, mode_str: &str) -> Option<ActionMode>;
+
+    /// Resolve mode from a slash command in a comment.
+    ///
+    /// Maps `/rigorix run <intent>` → `ActionMode::Run`
+    /// Maps `/rigorix validate <intent>` → `ActionMode::Validate`
+    /// Maps `/rigorix plan <intent>` → `ActionMode::Plan`
+    /// Maps `/rigorix status` → `ActionMode::Status`
+    async fn resolve_from_command(
+        &self,
+        command_type: &str,
+        intent: Option<String>,
+    ) -> Result<ActionMode, ActionError>;
+
+    /// Resolve mode from event type.
+    ///
+    /// - `workflow_dispatch` → Run (with intent from input)
+    /// - `pull_request` → Validate
+    /// - `push` → Status
+    /// - `issue_comment` → depends on slash command content
+    async fn resolve_from_event(
+        &self,
+        event_type: &str,
+        event_data: &serde_json::Value,
+    ) -> Result<ActionMode, ActionError>;
+}
+
+/// Builds an `ActionContext` from the environment and inputs.
+///
+/// Handles parsing environment variables, event payload JSON,
+/// and input values into a typed `ActionContext` that can be
+/// passed to the router.
+///
+/// # Contract (Frozen)
+/// - `build()` is the primary entry point
+/// - All environment reads use the `ContextRepository` trait
+/// - Missing optional fields result in `None`, not errors
+/// - Missing required fields result in `ActionError::MissingContext`
+#[async_trait]
+pub trait ContextBuilder: Send + Sync {
+    /// Build an `ActionContext` from the environment.
+    ///
+    /// Reads:
+    /// - `GITHUB_WORKSPACE` → workspace_root
+    /// - `GITHUB_EVENT_NAME` + `GITHUB_EVENT_PATH` → event
+    /// - `INPUT_*` → mode + configuration
+    /// - `GITHUB_TOKEN` / `INPUT_GITHUB_TOKEN` → token
+    async fn build(&self, input: BuildContextInput) -> Result<BuildContextOutput, ActionError>;
+
+    /// Get the workspace root from the environment.
+    ///
+    /// Reads `GITHUB_WORKSPACE` and validates it exists.
+    async fn get_workspace_root(&self) -> Result<String, ActionError>;
+
+    /// Get the GitHub token from the environment.
+    ///
+    /// Checks `GITHUB_TOKEN` then `INPUT_GITHUB_TOKEN`.
+    /// Returns `Ok(None)` if no token is set (non-fatal).
+    async fn get_github_token(&self) -> Result<Option<String>, ActionError>;
+
+    /// Parse the event payload from `GITHUB_EVENT_PATH`.
+    ///
+    /// Reads the JSON file and deserializes into a `GitHubEvent`.
+    async fn parse_event(&self, event_name: &str, event_path: &str) -> Result<super::dto::ParseEventOutput, ActionError>;
+}

--- a/actions/src/action_entrypoint/domain/error.rs
+++ b/actions/src/action_entrypoint/domain/error.rs
@@ -1,0 +1,160 @@
+//! Error types for the Action Entrypoint bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/action-entrypoint.md
+//! Implements: Contract Freeze — ActionError enum
+//! Issue: issue-contract-freeze
+//!
+//! All errors use `thiserror` derive macros. No `anyhow` in library code.
+//!
+//! # Contract (Frozen)
+//! - `ActionError` is the single error type for this module
+//! - Each variant carries structured context for error reporting
+//! - Every variant maps to a GitHub Action annotation level (error/warning/notice)
+//! - Implements `std::error::Error` for library compatibility
+
+use thiserror::Error;
+
+use crate::shared::github_client::GitHubClientError;
+
+/// Errors that can occur during action entrypoint dispatch.
+///
+/// Each variant includes enough context to produce a GitHub Action
+/// annotation (`::error file=...::message`) or a structured error
+/// response.
+#[derive(Debug, Error)]
+pub enum ActionError {
+    /// No execution mode could be resolved from inputs/event.
+    #[error("Cannot determine execution mode: {detail}")]
+    ModeResolutionError {
+        /// Explanation of why mode resolution failed.
+        detail: String,
+        /// The value of `INPUT_MODE` if set.
+        input_mode: Option<String>,
+        /// The event name from `GITHUB_EVENT_NAME`.
+        event_name: Option<String>,
+    },
+
+    /// The GitHub event type is not supported for routing.
+    #[error("Unsupported event type '{event_name}': {detail}")]
+    UnsupportedEvent {
+        /// The event name from `GITHUB_EVENT_NAME`.
+        event_name: String,
+        /// Explanation of why the event is not supported.
+        detail: String,
+    },
+
+    /// Missing required context (workspace, token, etc.).
+    #[error("Missing required context: {detail}")]
+    MissingContext {
+        /// Description of what context is missing.
+        detail: String,
+        /// The environment variable name that was checked.
+        env_var: Option<String>,
+    },
+
+    /// Engine orchestrator call failed.
+    #[error("Engine orchestrator error: {detail}")]
+    EngineError {
+        /// Description of the engine error.
+        detail: String,
+        /// Optional engine-side error code.
+        code: Option<String>,
+    },
+
+    /// Engine validation loop call failed.
+    #[error("Validation loop error: {detail}")]
+    ValidationLoopError {
+        /// Description of the validation loop error.
+        detail: String,
+        /// Number of completed iterations before failure.
+        iterations_completed: Option<u32>,
+    },
+
+    /// The workspace root path is invalid or inaccessible.
+    #[error("Invalid workspace root '{path}': {detail}")]
+    InvalidWorkspaceRoot {
+        /// The resolved workspace root path.
+        path: String,
+        /// Details about the validation failure.
+        detail: String,
+    },
+
+    /// Context repository read/write failure.
+    #[error("Context repository error: {detail}")]
+    ContextRepositoryError {
+        /// Description of the repository error.
+        detail: String,
+    },
+
+    /// Error formatting or writing action output.
+    #[error("Output formatting error: {detail}")]
+    OutputError {
+        /// Description of the output error.
+        detail: String,
+    },
+
+    /// GitHub API client error (PR comments, status checks).
+    #[error("GitHub API error: {0}")]
+    GitHubApi(#[from] GitHubClientError),
+
+    /// IO error (file system, environment).
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// JSON serialization/deserialization error.
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// Internal invariant violation (should not happen).
+    #[error("Internal error: {detail}")]
+    Internal {
+        /// Error description.
+        detail: String,
+    },
+}
+
+impl ActionError {
+    /// Whether the error is retriable (transient infrastructure failures).
+    pub fn is_retriable(&self) -> bool {
+        matches!(
+            self,
+            ActionError::Io(_)
+                | ActionError::GitHubApi(_)
+                | ActionError::EngineError { .. }
+                | ActionError::ValidationLoopError { .. }
+        )
+    }
+
+    /// The GitHub Action annotation level for this error.
+    ///
+    /// - `Error` → `::error` — fails the step
+    /// - `Warning` → `::warning` — visible but non-fatal
+    pub fn annotation_level(&self) -> &'static str {
+        match self {
+            ActionError::ModeResolutionError { .. }
+            | ActionError::MissingContext { .. }
+            | ActionError::InvalidWorkspaceRoot { .. }
+            | ActionError::Internal { .. } => "error",
+            ActionError::UnsupportedEvent { .. }
+            | ActionError::OutputError { .. } => "warning",
+            ActionError::EngineError { .. }
+            | ActionError::ValidationLoopError { .. }
+            | ActionError::ContextRepositoryError { .. }
+            | ActionError::GitHubApi(_)
+            | ActionError::Io(_)
+            | ActionError::Json(_) => "error",
+        }
+    }
+
+    /// The exit code to use when this error terminates the action.
+    ///
+    /// - 1: Fatal error (action failed)
+    /// - 0: Non-fatal (action completed with warnings)
+    pub fn exit_code(&self) -> i32 {
+        if self.annotation_level() == "warning" {
+            0
+        } else {
+            1
+        }
+    }
+}

--- a/actions/src/action_entrypoint/domain/event/mod.rs
+++ b/actions/src/action_entrypoint/domain/event/mod.rs
@@ -1,0 +1,84 @@
+//! Event payload schemas for the Action Entrypoint bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/action-entrypoint.md
+//! Implements: Contract Freeze — ActionEntrypointEvent payload schemas
+//! Issue: issue-contract-freeze
+//!
+//! These events are emitted on the EventBus whenever the entrypoint dispatches
+//! an action, resolves a mode, or encounters an error. Consumers (audit, console
+//! printer) subscribe to these event types.
+//!
+//! # Contract (Frozen)
+//! - Each event carries the full context needed by consumers
+//! - No internal implementation details exposed
+//! - Events are serializable for audit logging
+
+use serde::{Deserialize, Serialize};
+
+use crate::action_entrypoint::domain::ActionMode;
+
+/// Events emitted by the Action Entrypoint module.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ActionEntrypointEvent {
+    /// Action context was built from the environment.
+    ContextBuilt {
+        /// The resolved execution mode.
+        mode: ActionMode,
+        /// The triggering event type.
+        event_type: String,
+        /// Whether a GitHub token was available.
+        has_token: bool,
+        /// The workspace root path.
+        workspace_root: String,
+    },
+
+    /// A dispatch was initiated.
+    DispatchInitiated {
+        /// The execution mode being dispatched.
+        mode: ActionMode,
+        /// The event type that triggered the dispatch.
+        event_type: String,
+        /// `Some` if dispatching to the validation loop.
+        is_validation: bool,
+    },
+
+    /// A dispatch completed successfully.
+    DispatchCompleted {
+        /// The execution mode that was dispatched.
+        mode: ActionMode,
+        /// The dispatch status.
+        status: String,
+        /// Execution ID if one was produced.
+        execution_id: Option<String>,
+        /// Duration in milliseconds.
+        duration_ms: u64,
+    },
+
+    /// A dispatch failed with an error.
+    DispatchFailed {
+        /// The execution mode that was attempted.
+        mode: ActionMode,
+        /// Error message.
+        error: String,
+        /// Duration in milliseconds before failure.
+        duration_ms: u64,
+        /// Whether the error is retriable.
+        retriable: bool,
+    },
+
+    /// Mode was resolved from inputs/event context.
+    ModeResolved {
+        /// The resolved mode.
+        mode: ActionMode,
+        /// The source of resolution (input, event, default).
+        source: String,
+    },
+
+    /// An unsupported event type was received.
+    UnsupportedEventReceived {
+        /// The unsupported event name.
+        event_name: String,
+        /// Available event types for routing.
+        supported_types: Vec<String>,
+    },
+}

--- a/actions/src/action_entrypoint/domain/mod.rs
+++ b/actions/src/action_entrypoint/domain/mod.rs
@@ -1,0 +1,25 @@
+//! Domain entities and interfaces for the Action Entrypoint bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/action-entrypoint.md#domain
+//! Implements: Contract Freeze — domain entities ActionContext, ActionMode,
+//! ActionOutput, GitHubEvent, ActionError, ActionEntrypointEvent
+//! Issue: issue-contract-freeze
+//!
+//! This module defines the core domain types — `ActionContext`, `ActionMode`,
+//! `ActionOutput`, `GitHubEvent`, `ActionError`, and `ActionEntrypointEvent`.
+//! These are pure domain objects with no framework dependencies. They serve as
+//! the frozen contract that all implementation must satisfy.
+//!
+//! # Contract (Frozen)
+//! - No implementation logic beyond constructors and field accessors
+//! - All validation must happen in the application layer (service traits)
+//! - All persistence must happen behind repository interfaces
+//! - All domain types are serializable (Serialize + Deserialize) where applicable
+
+pub mod error;
+pub mod event;
+pub mod types;
+
+pub use error::*;
+pub use event::*;
+pub use types::*;

--- a/actions/src/action_entrypoint/domain/types.rs
+++ b/actions/src/action_entrypoint/domain/types.rs
@@ -1,0 +1,384 @@
+//! Domain types for the Action Entrypoint bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/action-entrypoint.md#types
+//! Implements: Contract Freeze — ActionContext, ActionMode, ActionOutput, GitHubEvent
+//! Issue: issue-contract-freeze
+//!
+//! These are the core domain types that represent the GitHub Action execution
+//! context, execution mode, routing output, and GitHub event types. They serve
+//! as the frozen contract that all implementation must satisfy.
+//!
+//! # Contract (Frozen)
+//! - No implementation logic beyond constructors and field accessors
+//! - All validation must happen in the application layer (service traits)
+//! - All persistence must happen behind repository interfaces
+//! - All types are serializable (Serialize + Deserialize) where applicable
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// ActionMode
+// ---------------------------------------------------------------------------
+
+/// The execution mode determining what the engine should do.
+///
+/// This is distinct from `security_config::domain::ActionMode` which controls
+/// GitHub token permission scopes. This enum describes the action's execution
+/// intent passed to the engine orchestrator.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ActionMode {
+    /// Full lifecycle: plan → execute → persist → emit.
+    Run {
+        /// Natural-language intent describing the work to be done.
+        intent: String,
+    },
+
+    /// Plan only: generate template without executing.
+    Plan {
+        /// Natural-language intent for planning.
+        intent: String,
+    },
+
+    /// Run with validation loop (self-correcting, max `max_iterations`).
+    Validate {
+        /// Natural-language intent for validation.
+        intent: String,
+    },
+
+    /// Show current execution status.
+    Status,
+}
+
+impl ActionMode {
+    /// Whether this mode requires a user intent string.
+    pub fn requires_intent(&self) -> bool {
+        matches!(
+            self,
+            ActionMode::Run { .. } | ActionMode::Plan { .. } | ActionMode::Validate { .. }
+        )
+    }
+
+    /// Get the intent string if this mode carries one.
+    pub fn intent(&self) -> Option<&str> {
+        match self {
+            ActionMode::Run { intent } | ActionMode::Plan { intent } | ActionMode::Validate { intent } => {
+                Some(intent.as_str())
+            }
+            ActionMode::Status => None,
+        }
+    }
+
+    /// Human-readable mode name for logging and event metadata.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ActionMode::Run { .. } => "run",
+            ActionMode::Plan { .. } => "plan",
+            ActionMode::Validate { .. } => "validate",
+            ActionMode::Status => "status",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GitHubEvent
+// ---------------------------------------------------------------------------
+
+/// GitHub event types that the action entrypoint can route.
+///
+/// Parsed from `GITHUB_EVENT_NAME` and `GITHUB_EVENT_PATH` by the
+/// `ActionContext` builder. Represents the trigger that started
+/// the workflow execution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "event_type")]
+pub enum GitHubEvent {
+    /// Triggered by `workflow_dispatch` — manual trigger via UI or API.
+    WorkflowDispatch {
+        /// Branch/tag/ref that was dispatched.
+        ref_name: String,
+    },
+
+    /// Triggered by `issue_comment` on an issue or PR.
+    IssueComment {
+        /// The issue or PR number.
+        issue_number: u64,
+        /// The raw comment body text.
+        comment_body: String,
+        /// The username that posted the comment.
+        commenter: String,
+    },
+
+    /// Triggered by `pull_request` events.
+    PullRequest {
+        /// The PR number.
+        pr_number: u64,
+        /// The PR action (opened, synchronize, closed, labeled, etc.).
+        action: String,
+        /// PR title.
+        title: String,
+        /// Base branch name.
+        base_branch: String,
+        /// Head branch name.
+        head_branch: String,
+        /// Head commit SHA.
+        head_sha: String,
+    },
+
+    /// Triggered by `push` events.
+    Push {
+        /// Branch name.
+        branch: String,
+        /// Commit SHA.
+        sha: String,
+        /// Pusher username.
+        pusher: String,
+    },
+
+    /// Unknown or unsupported event type.
+    Unknown {
+        /// The raw event name from `GITHUB_EVENT_NAME`.
+        event_name: String,
+    },
+}
+
+impl GitHubEvent {
+    /// Human-readable event type name.
+    pub fn event_type(&self) -> &'static str {
+        match self {
+            GitHubEvent::WorkflowDispatch { .. } => "workflow_dispatch",
+            GitHubEvent::IssueComment { .. } => "issue_comment",
+            GitHubEvent::PullRequest { .. } => "pull_request",
+            GitHubEvent::Push { .. } => "push",
+            GitHubEvent::Unknown { .. } => "unknown",
+        }
+    }
+
+    /// Whether this event type supports routing to engine execution.
+    pub fn is_routable(&self) -> bool {
+        matches!(
+            self,
+            GitHubEvent::WorkflowDispatch { .. }
+                | GitHubEvent::IssueComment { .. }
+                | GitHubEvent::PullRequest { .. }
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ActionContext
+// ---------------------------------------------------------------------------
+
+/// Typed representation of the GitHub Action execution context.
+///
+/// Parsed from environment variables set by GitHub Actions:
+/// - `GITHUB_WORKSPACE` — workspace root
+/// - `GITHUB_EVENT_NAME` — trigger event type
+/// - `GITHUB_EVENT_PATH` — path to event payload JSON
+/// - `INPUT_*` — workflow inputs from action.yml
+///
+/// This is the primary input to `ActionRouter::dispatch()`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActionContext {
+    /// Absolute path to the repository workspace.
+    pub workspace_root: String,
+
+    /// The event that triggered this workflow.
+    pub event: GitHubEvent,
+
+    /// The resolved execution mode.
+    pub mode: ActionMode,
+
+    /// GitHub token for API calls (PR comments, status checks).
+    pub github_token: Option<String>,
+
+    /// Maximum validation loop iterations (default: 3).
+    pub max_validation_iterations: u32,
+
+    /// Maximum LLM API calls per execution.
+    pub max_llm_calls: Option<u32>,
+
+    /// Maximum LLM tokens per execution.
+    pub max_llm_tokens: Option<u64>,
+
+    /// Configuration profile to use.
+    pub profile: Option<String>,
+
+    /// Permission mode for engine tool execution.
+    pub permission_mode: Option<String>,
+}
+
+impl ActionContext {
+    /// Create a new ActionContext with all required fields.
+    pub fn new(
+        workspace_root: String,
+        event: GitHubEvent,
+        mode: ActionMode,
+        github_token: Option<String>,
+    ) -> Self {
+        Self {
+            workspace_root,
+            event,
+            mode,
+            github_token,
+            max_validation_iterations: 3,
+            max_llm_calls: None,
+            max_llm_tokens: None,
+            profile: None,
+            permission_mode: None,
+        }
+    }
+
+    /// Convert action context into a JSON-compatible engine configuration value.
+    ///
+    /// Extracts engine-relevant fields (permission mode, budget limits, repo root)
+    /// and serializes them as `serde_json::Value` for the engine's `RunInput.config` field.
+    pub fn to_engine_config(&self) -> serde_json::Value {
+        serde_json::json!({
+            "repo_root": self.workspace_root,
+            "permission_mode": self.permission_mode.as_deref().unwrap_or("workspace_write"),
+            "max_llm_calls": self.max_llm_calls,
+            "max_llm_tokens": self.max_llm_tokens,
+            "profile": self.profile,
+        })
+    }
+
+    /// Return a new ActionContext with a different mode (used for fallback dispatch).
+    pub fn with_mode(&self, mode: ActionMode) -> Self {
+        Self {
+            mode,
+            workspace_root: self.workspace_root.clone(),
+            event: self.event.clone(),
+            github_token: self.github_token.clone(),
+            max_validation_iterations: self.max_validation_iterations,
+            max_llm_calls: self.max_llm_calls,
+            max_llm_tokens: self.max_llm_tokens,
+            profile: self.profile.clone(),
+            permission_mode: self.permission_mode.clone(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ActionOutput
+// ---------------------------------------------------------------------------
+
+/// Typed output from an action dispatch operation.
+///
+/// Represents the formatted result of an engine call that will be
+/// written to GitHub Action outputs (step summary, annotations, variables).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActionOutput {
+    /// Status of the dispatch operation.
+    pub status: DispatchStatus,
+
+    /// Human-readable summary of the operation result.
+    pub summary: String,
+
+    /// Execution ID if the dispatch resulted in an execution.
+    pub execution_id: Option<String>,
+
+    /// List of annotations to emit as GitHub workflow annotations.
+    pub annotations: Vec<WorkflowAnnotation>,
+
+    /// Output variables to set via `GITHUB_OUTPUT`.
+    pub output_variables: std::collections::HashMap<String, String>,
+}
+
+/// Status of a dispatch operation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DispatchStatus {
+    /// Operation completed successfully.
+    Success,
+    /// Operation failed with recoverable errors.
+    Warning,
+    /// Operation failed with non-recoverable errors.
+    Failure,
+    /// Operation was skipped (e.g., unsupported event).
+    Skipped,
+}
+
+/// A GitHub workflow annotation (error, warning, notice).
+///
+/// Corresponds to GitHub Actions `::error file=...,line=...,title=...::message` syntax.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowAnnotation {
+    /// Annotation level.
+    pub level: AnnotationLevel,
+    /// The annotation message.
+    pub message: String,
+    /// Optional file path the annotation refers to.
+    pub file: Option<String>,
+    /// Optional line number the annotation refers to.
+    pub line: Option<u32>,
+    /// Optional column number the annotation refers to.
+    pub column: Option<u32>,
+    /// Optional title for the annotation.
+    pub title: Option<String>,
+}
+
+/// Annotation severity level.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AnnotationLevel {
+    /// `::error` — fails the workflow step.
+    Error,
+    /// `::warning` — non-fatal warning.
+    Warning,
+    /// `::notice` — informational notice.
+    Notice,
+}
+
+impl ActionOutput {
+    /// Create a success output.
+    pub fn success(summary: impl Into<String>, execution_id: Option<String>) -> Self {
+        Self {
+            status: DispatchStatus::Success,
+            summary: summary.into(),
+            execution_id,
+            annotations: Vec::new(),
+            output_variables: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Create a failure output.
+    pub fn failure(summary: impl Into<String>) -> Self {
+        Self {
+            status: DispatchStatus::Failure,
+            summary: summary.into(),
+            execution_id: None,
+            annotations: Vec::new(),
+            output_variables: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Create a skipped output.
+    pub fn skipped(summary: impl Into<String>) -> Self {
+        Self {
+            status: DispatchStatus::Skipped,
+            summary: summary.into(),
+            execution_id: None,
+            annotations: Vec::new(),
+            output_variables: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Add an annotation to this output.
+    pub fn with_annotation(mut self, annotation: WorkflowAnnotation) -> Self {
+        self.annotations.push(annotation);
+        self
+    }
+
+    /// Add an output variable.
+    pub fn with_variable(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.output_variables.insert(key.into(), value.into());
+        self
+    }
+
+    /// Whether the dispatch was successful.
+    pub fn is_success(&self) -> bool {
+        self.status == DispatchStatus::Success
+    }
+
+    /// Whether the dispatch failed.
+    pub fn is_failure(&self) -> bool {
+        self.status == DispatchStatus::Failure
+    }
+}

--- a/actions/src/action_entrypoint/infrastructure/mod.rs
+++ b/actions/src/action_entrypoint/infrastructure/mod.rs
@@ -1,0 +1,18 @@
+//! Infrastructure layer for the Action Entrypoint bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/action-entrypoint.md#infrastructure
+//! Implements: Contract Freeze — repository interfaces for context data access
+//! Issue: issue-contract-freeze
+//!
+//! This module defines the repository interfaces that abstract data access
+//! for the Action Entrypoint module. Implementations will read from environment
+//! variables, filesystem (event payloads), and CLI arguments.
+//!
+//! # Contract (Frozen)
+//! - All repository methods are async
+//! - All methods return `Result<_, ActionError>`
+//! - No dependencies on external frameworks
+
+pub mod repository;
+
+pub use repository::*;

--- a/actions/src/action_entrypoint/infrastructure/repository/mod.rs
+++ b/actions/src/action_entrypoint/infrastructure/repository/mod.rs
@@ -1,0 +1,90 @@
+//! Repository interfaces for the Action Entrypoint bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/action-entrypoint.md
+//! Implements: Contract Freeze — ContextRepository trait
+//! Issue: issue-contract-freeze
+//!
+//! Repositories abstract data access behind interfaces, allowing
+//! implementations to use environment variables, filesystem, or mock
+//! storage without coupling domain logic to infrastructure.
+//!
+//! # Contract (Frozen)
+//! - All repository methods are async
+//! - All methods return domain error types
+//! - No framework-specific annotations on trait definitions
+//! - Implementations are hidden behind these interfaces
+
+use async_trait::async_trait;
+
+use crate::action_entrypoint::domain::ActionError;
+
+/// Repository for reading GitHub Action execution context.
+///
+/// Abstracts `std::env::var` / `std::env::vars` and filesystem access
+/// to event payload files behind a trait for testability.
+///
+/// # Security
+/// - Implementations MUST NOT log sensitive values (tokens, secrets)
+/// - File paths must be validated against directory traversal
+#[async_trait]
+pub trait ContextRepository: Send + Sync {
+    /// Read a single environment variable by name.
+    ///
+    /// Returns `Ok(None)` if the variable is not set.
+    async fn read_env_var(&self, name: &str) -> Result<Option<String>, ActionError>;
+
+    /// Read all environment variables matching a prefix.
+    ///
+    /// Returns a map of variable names (without prefix) to values.
+    /// E.g., prefix `INPUT_` with `INPUT_MODE=run` returns `{"MODE": "run"}`.
+    async fn read_env_vars(
+        &self,
+        prefix: &str,
+    ) -> Result<std::collections::HashMap<String, String>, ActionError>;
+
+    /// Check if an environment variable is set.
+    async fn has_env_var(&self, name: &str) -> Result<bool, ActionError>;
+
+    /// Get the workspace root path.
+    ///
+    /// Reads `GITHUB_WORKSPACE` in CI.
+    async fn workspace_root(&self) -> Result<String, ActionError>;
+
+    /// Get the GitHub event name.
+    ///
+    /// Reads `GITHUB_EVENT_NAME`.
+    async fn event_name(&self) -> Result<String, ActionError>;
+
+    /// Get the GitHub event payload file path.
+    ///
+    /// Reads `GITHUB_EVENT_PATH`.
+    async fn event_path(&self) -> Result<String, ActionError>;
+
+    /// Read the GitHub event payload file content.
+    ///
+    /// Reads the file at the path specified by `GITHUB_EVENT_PATH`.
+    async fn read_event_payload(&self, path: &str) -> Result<String, ActionError>;
+
+    /// Get the GitHub token.
+    ///
+    /// Checks `GITHUB_TOKEN` then `INPUT_GITHUB_TOKEN`.
+    async fn github_token(&self) -> Result<Option<String>, ActionError>;
+
+    /// Get the GitHub API URL base.
+    ///
+    /// Reads `GITHUB_API_URL` (default: `https://api.github.com`).
+    async fn github_api_url(&self) -> Result<String, ActionError>;
+
+    /// Get all CI-related environment variables.
+    ///
+    /// Returns variables like `GITHUB_ACTIONS`, `GITHUB_EVENT_NAME`,
+    /// `GITHUB_EVENT_PATH`, `GITHUB_ACTOR`, `GITHUB_REPOSITORY`, etc.
+    async fn read_ci_env_vars(
+        &self,
+    ) -> Result<std::collections::HashMap<String, String>, ActionError>;
+
+    /// Resolve the absolute path for a potentially relative path.
+    ///
+    /// If `path` is relative, resolves it against the workspace root.
+    async fn resolve_path(&self, path: &str) -> Result<String, ActionError>;
+}

--- a/actions/src/action_entrypoint/interfaces/http/mod.rs
+++ b/actions/src/action_entrypoint/interfaces/http/mod.rs
@@ -1,0 +1,215 @@
+//! HTTP API contracts for Action Entrypoint endpoints.
+//!
+//! @canonical actions/.pi/architecture/modules/action-entrypoint.md
+//! Implements: Contract Freeze — HTTP endpoint contracts and error formats
+//! Issue: issue-contract-freeze
+//!
+//! Defines endpoint paths, methods, request/response schemas, and error
+//! response formats. These contracts are framework-agnostic — they describe
+//! the API surface that any HTTP server implementation must satisfy.
+//!
+//! Note: In production, the action runs as a GitHub Action, not an HTTP server.
+//! These contracts exist for:
+//! - Local development & debugging endpoints
+//! - Runtime introspection (health checks, status)
+//! - Testing via HTTP mocks
+//!
+//! # Contract (Frozen)
+//! - All endpoints documented with method, path, request, and response types
+//! - Error responses follow a unified format
+//! - No framework-specific annotations (axum/actix/warp annotations added by implementation)
+
+use serde::{Deserialize, Serialize};
+
+use crate::action_entrypoint::domain::{ActionContext, ActionMode, ActionOutput};
+
+// ---------------------------------------------------------------------------
+// API Base Path
+// ---------------------------------------------------------------------------
+
+/// All action entrypoint endpoints are served under this base path.
+pub const API_BASE_PATH: &str = "/api/v1/action-entrypoint";
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/action-entrypoint/dispatch
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/action-entrypoint/dispatch
+///
+/// Dispatch an action execution. This is the primary API endpoint —
+/// it takes a built context and routes to the appropriate engine call.
+///
+/// **Request:** `DispatchRequest`
+/// **Response:** `200 OK` with `DispatchResponse`
+pub const DISPATCH_PATH: &str = "/api/v1/action-entrypoint/dispatch";
+pub const DISPATCH_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/action-entrypoint/dispatch.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DispatchRequest {
+    /// The action execution context.
+    pub context: ActionContext,
+    /// Optional timeout in seconds.
+    pub timeout_secs: Option<u64>,
+    /// Whether to force dispatch even for non-routable events.
+    pub force: Option<bool>,
+}
+
+/// Response body for POST /api/v1/action-entrypoint/dispatch.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DispatchResponse {
+    pub success: bool,
+    pub output: ActionOutput,
+    pub mode: ActionMode,
+    pub duration_ms: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/action-entrypoint/resolve-mode
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/action-entrypoint/resolve-mode
+///
+/// Resolve the execution mode from inputs and event context.
+/// Useful for testing mode resolution logic without dispatching.
+///
+/// **Request:** `ResolveModeRequest`
+/// **Response:** `200 OK` with `ResolveModeResponse`
+pub const RESOLVE_MODE_PATH: &str = "/api/v1/action-entrypoint/resolve-mode";
+pub const RESOLVE_MODE_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/action-entrypoint/resolve-mode.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResolveModeRequest {
+    /// Raw INPUT_MODE string (optional).
+    pub input_mode: Option<String>,
+    /// GitHub event name.
+    pub event_name: String,
+    /// Event payload JSON (optional, used for slash command detection).
+    pub event_payload: Option<serde_json::Value>,
+    /// Raw INPUT_INTENT string (optional).
+    pub input_intent: Option<String>,
+}
+
+/// Response body for POST /api/v1/action-entrypoint/resolve-mode.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResolveModeResponse {
+    pub mode: ActionMode,
+    pub source: String,
+    pub unambiguous: bool,
+    pub warnings: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: POST /api/v1/action-entrypoint/context
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/action-entrypoint/context
+///
+/// Build an ActionContext from environment overrides or explicit values.
+/// Useful for testing context construction logic.
+///
+/// **Request:** `BuildContextRequest`
+/// **Response:** `200 OK` with `BuildContextResponse`
+pub const BUILD_CONTEXT_PATH: &str = "/api/v1/action-entrypoint/context";
+pub const BUILD_CONTEXT_METHOD: &str = "POST";
+
+/// Request body for POST /api/v1/action-entrypoint/context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BuildContextRequest {
+    /// Environment variable overrides (name → value).
+    pub env_overrides: Option<std::collections::HashMap<String, String>>,
+    /// Override workspace root.
+    pub workspace_override: Option<String>,
+    /// Override event name.
+    pub event_name_override: Option<String>,
+    /// Override event payload path.
+    pub event_path_override: Option<String>,
+    /// Override event payload JSON content.
+    pub event_payload_override: Option<String>,
+}
+
+/// Response body for POST /api/v1/action-entrypoint/context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BuildContextResponse {
+    pub context: ActionContext,
+    pub event_name: String,
+    pub warnings: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint: GET /api/v1/action-entrypoint/status
+// ---------------------------------------------------------------------------
+
+/// GET /api/v1/action-entrypoint/status
+///
+/// Health check and status endpoint for the entrypoint module.
+///
+/// **Response:** `200 OK` with `StatusResponse`
+pub const STATUS_PATH: &str = "/api/v1/action-entrypoint/status";
+pub const STATUS_METHOD: &str = "GET";
+
+/// Response for GET /api/v1/action-entrypoint/status.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatusResponse {
+    pub healthy: bool,
+    pub supported_modes: Vec<String>,
+    pub supported_events: Vec<String>,
+    pub available: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Unified Error Response Format
+// ---------------------------------------------------------------------------
+
+/// Standard error response for all Action Entrypoint API endpoints.
+///
+/// All 4xx/5xx responses use this format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiErrorResponse {
+    /// HTTP status code.
+    pub status: u16,
+    /// Machine-readable error code.
+    pub code: String,
+    /// Human-readable error message.
+    pub message: String,
+    /// Detailed error context (optional, may include field-level errors).
+    pub details: Option<serde_json::Value>,
+    /// Request ID for tracing (if available).
+    pub request_id: Option<String>,
+}
+
+/// Standardized error codes for Action Entrypoint API.
+pub mod error_codes {
+    /// Mode could not be resolved.
+    pub const MODE_RESOLUTION_ERROR: &str = "MODE_RESOLUTION_ERROR";
+    /// Unsupported event type.
+    pub const UNSUPPORTED_EVENT: &str = "UNSUPPORTED_EVENT";
+    /// Missing required context.
+    pub const MISSING_CONTEXT: &str = "MISSING_CONTEXT";
+    /// Engine orchestrator error.
+    pub const ENGINE_ERROR: &str = "ENGINE_ERROR";
+    /// Validation loop error.
+    pub const VALIDATION_LOOP_ERROR: &str = "VALIDATION_LOOP_ERROR";
+    /// Invalid workspace root.
+    pub const INVALID_WORKSPACE: &str = "INVALID_WORKSPACE";
+    /// Context repository error.
+    pub const CONTEXT_REPOSITORY_ERROR: &str = "CONTEXT_REPOSITORY_ERROR";
+    /// Output formatting error.
+    pub const OUTPUT_ERROR: &str = "OUTPUT_ERROR";
+    /// Internal server error.
+    pub const INTERNAL_ERROR: &str = "INTERNAL_ERROR";
+}
+
+/// HTTP status code mappings for Action Entrypoint errors.
+pub mod status_codes {
+    pub const MODE_RESOLUTION_ERROR: u16 = 400;
+    pub const UNSUPPORTED_EVENT: u16 = 400;
+    pub const MISSING_CONTEXT: u16 = 400;
+    pub const ENGINE_ERROR: u16 = 502;
+    pub const VALIDATION_LOOP_ERROR: u16 = 502;
+    pub const INVALID_WORKSPACE: u16 = 400;
+    pub const CONTEXT_REPOSITORY_ERROR: u16 = 500;
+    pub const OUTPUT_ERROR: u16 = 500;
+    pub const INTERNAL_ERROR: u16 = 500;
+}

--- a/actions/src/action_entrypoint/interfaces/mod.rs
+++ b/actions/src/action_entrypoint/interfaces/mod.rs
@@ -1,0 +1,13 @@
+//! External interfaces for the Action Entrypoint bounded context.
+//!
+//! @canonical actions/.pi/architecture/modules/action-entrypoint.md#interfaces
+//! Implements: Contract Freeze — HTTP API contracts
+//! Issue: issue-contract-freeze
+//!
+//! These interfaces define how external systems interact with the action
+//! entrypoint. Currently only HTTP endpoints are defined (for local
+//! development, debugging, and testing).
+
+pub mod http;
+
+pub use http::*;

--- a/actions/src/action_entrypoint/mod.rs
+++ b/actions/src/action_entrypoint/mod.rs
@@ -1,0 +1,61 @@
+//! Action Entrypoint — Event routing + dispatch for the Rigorix GitHub Action.
+//!
+//! @canonical actions/.pi/architecture/modules/action-entrypoint.md
+//! Implements: Contract Freeze — all component interfaces for action-entrypoint epic
+//! Issue: issue-contract-freeze
+//!
+//! This module handles GitHub Action event routing — mapping workflow triggers
+//! (`workflow_dispatch`, `issue_comment`, `pull_request`) to engine orchestrator calls.
+//! All business logic lives in `rigorix-engine`; this module is a thin dispatch layer.
+//!
+//! # Components
+//!
+//! | Component | Domain | Application | Infrastructure | Interfaces |
+//! |-----------|--------|-------------|----------------|------------|
+//! | ActionRouter | — | `application::service::ActionRouter` | — | — |
+//! | ActionContext | `domain::types::ActionContext` | - | `infrastructure::repository::ContextRepository` | — |
+//! | ActionMode | `domain::types::ActionMode` | — | — | — |
+//! | ActionError | `domain::error::ActionError` | — | — | — |
+//!
+//! # Layer Structure
+//!
+//! ```text
+//! action_entrypoint/
+//! ├── mod.rs                          # Module root
+//! ├── domain/                         # Domain entities and interfaces
+//! │   ├── mod.rs
+//! │   ├── types.rs                    # ActionContext, ActionMode, ActionOutput, GitHubEvent
+//! │   ├── error.rs                    # ActionError
+//! │   └── event/
+//! │       └── mod.rs                  # ActionEntrypointEvent payloads
+//! ├── application/                    # Application service interfaces and DTOs
+//! │   ├── mod.rs
+//! │   ├── service.rs                  # Service traits (ActionRouter, ModeResolver)
+//! │   ├── dto/
+//! │   │   └── mod.rs                  # Input/output DTO schemas
+//! │   └── factory.rs                  # Factory interfaces
+//! ├── infrastructure/                 # Infrastructure layer
+//! │   ├── mod.rs
+//! │   └── repository/
+//! │       └── mod.rs                  # Repository interfaces (ContextRepository)
+//! └── interfaces/                     # External interfaces
+//!     ├── mod.rs
+//!     └── http/
+//!         └── mod.rs                  # HTTP API contracts
+//! ```
+//!
+//! # Contract Freeze
+//!
+//! All public interfaces, DTO schemas, and contracts in this module are
+//! frozen. Implementation must satisfy these contracts, not the other way around.
+//! See `actions/.pi/architecture/modules/action-entrypoint.md` for the canonical spec.
+//!
+//! # Related Issues
+//!
+//! - Issue #613: Contract Freeze (this issue)
+//! - Issue #612: Epic "action-entrypoint"
+
+pub mod application;
+pub mod domain;
+pub mod infrastructure;
+pub mod interfaces;

--- a/actions/src/lib.rs
+++ b/actions/src/lib.rs
@@ -42,6 +42,7 @@
 pub mod shared;
 
 // ── Phase 1: Contract Freeze — interface-only declarations ──
+// ── Phase 5: action_entrypoint — interface-only (contract frozen) ──
 pub mod action_input;
 pub mod action_output;
 pub mod ci_integration;
@@ -49,4 +50,4 @@ pub mod diff_analyzer; // Phase 1: Contract Freeze (issue-contract-freeze)
 pub mod policy_evaluator;
 pub mod security_config; // Phase 1: Contract Freeze (issue-contract-freeze) // Phase 1: Contract Freeze (issue-contract-freeze) // Phase 1: Contract Freeze (issue-contract-freeze)
 pub mod audit_posting;      // Phase 1: Contract Freeze (issue-contract-freeze)
-// pub mod action_entrypoint;  // Phase 5
+pub mod action_entrypoint;  // Phase 1: Contract Freeze (issue-contract-freeze)


### PR DESCRIPTION
## Contract Freeze: action-entrypoint

Defines and freezes all public interfaces, contracts, and schemas for the action-entrypoint epic.

### Components Frozen

- **ActionRouter** — Event routing + dispatch service trait
- **ActionContext** — GitHub Action execution context domain model
- **ActionMode** — Execution mode enum (Run, Plan, Validate, Status)

### Clean Architecture Layers

| Layer | Contents |
|-------|----------|
| **domain/** | ActionContext, ActionMode, ActionOutput, GitHubEvent, ActionError, event payloads |
| **application/** | ActionRouter, ModeResolver, ContextBuilder traits + DTOs + factory interfaces |
| **infrastructure/** | ContextRepository trait for env/filesystem/event access |
| **interfaces/http/** | HTTP API contracts: dispatch, resolve-mode, build-context, status |

### Acceptance Criteria

- [x] All component interfaces defined in domain/ and application/
- [x] DTO schemas documented with field-level docs
- [x] HTTP API contracts defined with endpoints, methods, request/response
- [x] No implementation — interface-only contract freeze
- [x] Build compiles cleanly

Closes #613