### PR TITLE
feat: implement ActionContext for action-entrypoint (#615)

### DIFF
--- a/actions/.pi/.guardian-epic-state.json
+++ b/actions/.pi/.guardian-epic-state.json
@@ -1,23 +1,31 @@
 {
-  "name": "\"ci-integration\"",
-  "trackingIssueId": "589",
+  "name": "\"action-entrypoint\"",
+  "trackingIssueId": "612",
   "epicId": null,
   "slices": [
     {
-      "module": "ci-integration",
+      "module": "action-entrypoint",
       "components": [
         {
-          "name": "StatusCheckManager",
+          "name": "ActionRouter",
           "status": "planned",
-          "description": "Creates and updates GitHub commit status checks",
+          "description": "Map GitHub Action event types to engine service calls",
           "dependencies": [
             "none"
           ]
         },
         {
-          "name": "PrCommentManager",
+          "name": "ActionContext",
           "status": "planned",
-          "description": "Posts structured PR review comments",
+          "description": "GitHub Actions environment parsed into a typed context",
+          "dependencies": [
+            "none"
+          ]
+        },
+        {
+          "name": "ActionMode",
+          "status": "planned",
+          "description": "Determines what the engine should do",
           "dependencies": [
             "none"
           ]
@@ -25,17 +33,25 @@
       ],
       "nextLogicalSlice": [
         {
-          "name": "StatusCheckManager",
+          "name": "ActionRouter",
           "status": "planned",
-          "description": "Creates and updates GitHub commit status checks",
+          "description": "Map GitHub Action event types to engine service calls",
           "dependencies": [
             "none"
           ]
         },
         {
-          "name": "PrCommentManager",
+          "name": "ActionContext",
           "status": "planned",
-          "description": "Posts structured PR review comments",
+          "description": "GitHub Actions environment parsed into a typed context",
+          "dependencies": [
+            "none"
+          ]
+        },
+        {
+          "name": "ActionMode",
+          "status": "planned",
+          "description": "Determines what the engine should do",
           "dependencies": [
             "none"
           ]
@@ -48,34 +64,40 @@
       "id": "issue-contract-freeze",
       "title": "Contract Freeze: Define interfaces and contracts",
       "status": "planned",
-      "remoteIssueId": "590"
+      "remoteIssueId": "613"
     },
     {
-      "id": "issue-statuscheckmanager",
-      "title": "StatusCheckManager: Creates and updates GitHub commit status checks",
+      "id": "issue-actionrouter",
+      "title": "ActionRouter: Map GitHub Action event types to engine service calls",
       "status": "planned",
-      "remoteIssueId": "591"
+      "remoteIssueId": "614"
     },
     {
-      "id": "issue-prcommentmanager",
-      "title": "PrCommentManager: Posts structured PR review comments",
+      "id": "issue-actioncontext",
+      "title": "ActionContext: GitHub Actions environment parsed into a typed context",
       "status": "planned",
-      "remoteIssueId": "592"
+      "remoteIssueId": "615"
+    },
+    {
+      "id": "issue-actionmode",
+      "title": "ActionMode: Determines what the engine should do",
+      "status": "planned",
+      "remoteIssueId": "616"
     },
     {
       "id": "issue-proofing",
       "title": "Proofing: Validation scripts + CI integration",
       "status": "planned",
-      "remoteIssueId": "593"
+      "remoteIssueId": "617"
     },
     {
       "id": "issue-architecture-readiness",
       "title": "Architecture Readiness: Runbook, DR, docs, CI enforcement",
       "status": "planned",
-      "remoteIssueId": "594"
+      "remoteIssueId": "618"
     }
   ],
   "status": "planning",
   "currentIssueIndex": 0,
-  "createdAt": "2026-06-21T15:02:36.649Z"
+  "createdAt": "2026-06-21T17:44:31.703Z"
 }

--- a/actions/.pi/.guardian-pipeline-state.json
+++ b/actions/.pi/.guardian-pipeline-state.json
@@ -1,10 +1,11 @@
 {
-  "id": "PL-9898",
-  "name": "\"ci-integration\"",
+  "id": "PL-6878",
+  "name": "\"action-entrypoint\"",
   "items": [
     "issue-contract-freeze",
-    "issue-statuscheckmanager",
-    "issue-prcommentmanager",
+    "issue-actionrouter",
+    "issue-actioncontext",
+    "issue-actionmode",
     "issue-proofing",
     "issue-architecture-readiness"
   ],
@@ -49,8 +50,8 @@
       }
     }
   ],
-  "currentItemIndex": 4,
-  "currentStepIndex": 1,
+  "currentItemIndex": 2,
+  "currentStepIndex": 0,
   "status": "running",
   "retryCount": 0,
   "results": [
@@ -81,7 +82,7 @@
       ]
     },
     {
-      "item": "issue-statuscheckmanager",
+      "item": "issue-actionrouter",
       "status": "done",
       "stepResults": [
         {
@@ -101,69 +102,6 @@
         },
         {
           "step": "merge",
-          "status": "passed",
-          "reason": ""
-        }
-      ]
-    },
-    {
-      "item": "issue-prcommentmanager",
-      "status": "done",
-      "stepResults": [
-        {
-          "step": "implement",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "validate",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "create-mr",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "merge",
-          "status": "passed",
-          "reason": ""
-        }
-      ]
-    },
-    {
-      "item": "issue-proofing",
-      "status": "done",
-      "stepResults": [
-        {
-          "step": "implement",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "validate",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "create-mr",
-          "status": "passed",
-          "reason": ""
-        },
-        {
-          "step": "merge",
-          "status": "passed",
-          "reason": ""
-        }
-      ]
-    },
-    {
-      "item": "issue-architecture-readiness",
-      "status": "in-progress",
-      "stepResults": [
-        {
-          "step": "implement",
           "status": "passed",
           "reason": ""
         }
@@ -171,6 +109,6 @@
     }
   ],
   "mergeOnValid": true,
-  "createdAt": "2026-06-21T15:02:36.697Z",
-  "updatedAt": "2026-06-21T15:35:34.423Z"
+  "createdAt": "2026-06-21T17:44:31.739Z",
+  "updatedAt": "2026-06-21T18:43:48.833Z"
 }

--- a/actions/.pi/issues/issue-architecture-readiness.md
+++ b/actions/.pi/issues/issue-architecture-readiness.md
@@ -1,9 +1,9 @@
 ---
 guardian_issue:
   id: "ISSUE-READINESS"
-  epic: ""ci-integration""
+  epic: ""action-entrypoint""
   component: "Architecture Readiness"
-  module: "ci-integration"
+  module: "action-entrypoint"
   status: planned
   priority: critical
   dependencies: []
@@ -32,7 +32,7 @@ guardian_issue:
       - Verify proofing scripts + validators in CI
 
   canonical_references:
-    - module: ".pi/architecture/modules/ci-integration.md"
+    - module: ".pi/architecture/modules/action-entrypoint.md"
 
   acceptance_criteria:
     - "Runbook created and reviewed"
@@ -58,30 +58,30 @@ guardian_issue:
     and CI will catch regressions (proofing scripts + validators).
 
   file_changes:
-    - "create: docs/runbook-ci-integration.md"
-    - "create: docs/dr-plan-ci-integration.md"
+    - "create: docs/runbook-action-entrypoint.md"
+    - "create: docs/dr-plan-action-entrypoint.md"
     - "modify: .pi/architecture/CHANGELOG.md"
-    - "modify: .pi/architecture/modules/ci-integration.md"
+    - "modify: .pi/architecture/modules/action-entrypoint.md"
 ---
 
-# Architecture Readiness: ci-integration
+# Architecture Readiness: action-entrypoint
 
 ## Intent
 
-Make the ci-integration module production-ready. This is the final issue in every epic
+Make the action-entrypoint module production-ready. This is the final issue in every epic
 — it closes the loop between implementation and operability.
 
 ## Deliverables
 
 ### Runbook
-`docs/runbook-ci-integration.md` covering:
+`docs/runbook-action-entrypoint.md` covering:
 - Startup sequence and dependencies
 - Graceful shutdown procedure
 - Common failure modes and recovery
 - Configuration reference
 
 ### DR Plan
-`docs/dr-plan-ci-integration.md` covering:
+`docs/dr-plan-action-entrypoint.md` covering:
 - Backup strategy and schedule
 - Restore procedure
 - Failover plan

--- a/actions/.pi/issues/issue-contract-freeze.md
+++ b/actions/.pi/issues/issue-contract-freeze.md
@@ -1,9 +1,9 @@
 ---
 guardian_issue:
   id: "ISSUE-CONTRACT-FREEZE"
-  epic: ""ci-integration""
+  epic: ""action-entrypoint""
   component: "Contract Freeze"
-  module: "ci-integration"
+  module: "action-entrypoint"
   status: planned
   priority: critical
   dependencies: []
@@ -29,7 +29,7 @@ guardian_issue:
       - REST/event contracts
 
   canonical_references:
-    - module: ".pi/architecture/modules/ci-integration.md"
+    - module: ".pi/architecture/modules/action-entrypoint.md"
 
   acceptance_criteria:
     - "All component interfaces defined as interfaces/types"
@@ -47,23 +47,24 @@ guardian_issue:
     interfaces, types, DTOs, event schemas, API paths, error formats.
 
   file_changes:
-    - "create: src/ci-integration/contracts/"
-    - "create: src/ci-integration/contracts/dtos/"
-    - "create: src/ci-integration/contracts/events/"
+    - "create: src/action-entrypoint/contracts/"
+    - "create: src/action-entrypoint/contracts/dtos/"
+    - "create: src/action-entrypoint/contracts/events/"
 ---
 
-# Contract Freeze: ci-integration
+# Contract Freeze: action-entrypoint
 
 ## Intent
 
-Define and freeze all public interfaces, contracts, and schemas for the ci-integration
+Define and freeze all public interfaces, contracts, and schemas for the action-entrypoint
 epic before any implementation begins. This prevents architecture drift — implementation
 must satisfy contracts, not the other way around.
 
 ## Included Components
 
-- StatusCheckManager
-- PrCommentManager
+- ActionRouter
+- ActionContext
+- ActionMode
 
 ## What Must Be Frozen
 

--- a/actions/.pi/issues/issue-proofing.md
+++ b/actions/.pi/issues/issue-proofing.md
@@ -1,9 +1,9 @@
 ---
 guardian_issue:
   id: "ISSUE-PROOFING"
-  epic: ""ci-integration""
+  epic: ""action-entrypoint""
   component: "Proofing & CI Enforcement"
-  module: "ci-integration"
+  module: "action-entrypoint"
   status: planned
   priority: critical
   dependencies: []
@@ -26,7 +26,7 @@ guardian_issue:
       - Updated CI stage configuration
 
   canonical_references:
-    - module: ".pi/architecture/modules/ci-integration.md"
+    - module: ".pi/architecture/modules/action-entrypoint.md"
 
   acceptance_criteria:
     - "All proofing scripts created and executable"
@@ -47,12 +47,12 @@ guardian_issue:
     every build for zero token cost.
 
   file_changes:
-    - "create: .pi/scripts/ci/check_ci-integration_contracts.sh"
-    - "create: .pi/scripts/ci/check_ci-integration_coverage.sh"
+    - "create: .pi/scripts/ci/check_action-entrypoint_contracts.sh"
+    - "create: .pi/scripts/ci/check_action-entrypoint_coverage.sh"
     - "modify: .pi/scripts/ci/run_hardening_stages.sh"
 ---
 
-# Proofing & CI Enforcement: ci-integration
+# Proofing & CI Enforcement: action-entrypoint
 
 ## Intent
 
@@ -81,17 +81,17 @@ on every PR. No LLM cost. No human review. Just pass or fail.
 
 | Script | Purpose | Location |
 |--------|---------|----------|
-| check_ci-integration_contracts.sh | Validate contract implementation | .pi/scripts/ci/ |
-| check_ci-integration_coverage.sh | Enforce coverage thresholds | .pi/scripts/ci/ |
-| stage_ci-integration_proofing.sh | CI stage wrapper | .pi/scripts/ci/ |
+| check_action-entrypoint_contracts.sh | Validate contract implementation | .pi/scripts/ci/ |
+| check_action-entrypoint_coverage.sh | Enforce coverage thresholds | .pi/scripts/ci/ |
+| stage_action-entrypoint_proofing.sh | CI stage wrapper | .pi/scripts/ci/ |
 
 ## CI Pipeline Update
 
 Add the new stage to `run_hardening_stages.sh`:
 
 ```bash
-run_stage "11" "ci-integration_proofing" \
-    "${SCRIPTS_DIR}/stage_ci-integration_proofing.sh" \
+run_stage "11" "action-entrypoint_proofing" \
+    "${SCRIPTS_DIR}/stage_action-entrypoint_proofing.sh" \
     "always"
 ```
 

--- a/actions/src/action_entrypoint/application/context_builder_impl.rs
+++ b/actions/src/action_entrypoint/application/context_builder_impl.rs
@@ -1,0 +1,836 @@
+//! ContextBuilder implementation — builds ActionContext from environment.
+//!
+//! @canonical actions/.pi/architecture/modules/action-entrypoint.md#actioncontext
+//! Implements: ContextBuilder trait — reads GitHub Action env and builds typed context
+//! Issue: issue-actioncontext (#615)
+//!
+//! Builds an `ActionContext` from environment variables, event payload files, and
+//! GitHub Action inputs. Uses `ContextRepository` for all data access.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::action_entrypoint::domain::{ActionContext, ActionError, ActionMode, GitHubEvent};
+use crate::action_entrypoint::infrastructure::repository::ContextRepository;
+
+use super::dto::{BuildContextInput, BuildContextOutput, ParseEventOutput};
+use super::service::ContextBuilder;
+
+/// Builds an `ActionContext` from the GitHub Actions environment.
+///
+/// Uses a `ContextRepository` to read environment variables, event payload
+/// files, and GitHub token. The repository can be mocked for testing.
+pub struct ContextBuilderImpl {
+    repository: Arc<dyn ContextRepository>,
+}
+
+impl ContextBuilderImpl {
+    /// Create a new ContextBuilderImpl with the given repository.
+    pub fn new(repository: Arc<dyn ContextRepository>) -> Self {
+        Self { repository }
+    }
+
+    /// Parse a GitHub event JSON payload into a typed `GitHubEvent`.
+    async fn parse_event_payload(
+        &self,
+        event_name: &str,
+        content: &str,
+    ) -> Result<ParseEventOutput, ActionError> {
+        let json: serde_json::Value =
+            serde_json::from_str(content).map_err(|e| ActionError::Json(e))?;
+
+        let file_size = content.len() as u64;
+
+        let event = match event_name {
+            "workflow_dispatch" => {
+                let ref_name = json
+                    .get("ref")
+                    .and_then(|v| v.as_str())
+                    .or_else(|| {
+                        json.get("inputs")
+                            .and_then(|v| v.get("ref"))
+                            .and_then(|v| v.as_str())
+                    })
+                    .unwrap_or("main")
+                    .to_string();
+                GitHubEvent::WorkflowDispatch { ref_name }
+            }
+            "issue_comment" => {
+                let issue_number = json
+                    .pointer("/issue/number")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
+                let comment_body = json
+                    .pointer("/comment/body")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let commenter = json
+                    .pointer("/comment/user/login")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+                GitHubEvent::IssueComment {
+                    issue_number,
+                    comment_body,
+                    commenter,
+                }
+            }
+            "pull_request" | "pull_request_target" => {
+                let pr_number = json
+                    .pointer("/pull_request/number")
+                    .or_else(|| json.pointer("/number"))
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
+                let action = json
+                    .get("action")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("opened")
+                    .to_string();
+                let title = json
+                    .pointer("/pull_request/title")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let base_branch = json
+                    .pointer("/pull_request/base/ref")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("main")
+                    .to_string();
+                let head_branch = json
+                    .pointer("/pull_request/head/ref")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let head_sha = json
+                    .pointer("/pull_request/head/sha")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                GitHubEvent::PullRequest {
+                    pr_number,
+                    action,
+                    title,
+                    base_branch,
+                    head_branch,
+                    head_sha,
+                }
+            }
+            "push" => {
+                let branch = json
+                    .get("ref")
+                    .and_then(|v| v.as_str())
+                    .map(|r| r.trim_start_matches("refs/heads/"))
+                    .unwrap_or("")
+                    .to_string();
+                let sha = json
+                    .get("after")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let pusher = json
+                    .pointer("/pusher/name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+                GitHubEvent::Push {
+                    branch,
+                    sha,
+                    pusher,
+                }
+            }
+            _ => GitHubEvent::Unknown {
+                event_name: event_name.to_string(),
+            },
+        };
+
+        Ok(ParseEventOutput {
+            event,
+            raw_payload: json,
+            file_size_bytes: Some(file_size),
+        })
+    }
+
+    /// Resolve the execution mode from inputs.
+    fn resolve_mode(
+        &self,
+        input_mode: Option<&str>,
+        event_name: &str,
+        _event_payload: &serde_json::Value,
+    ) -> Result<(ActionMode, String), ActionError> {
+        // Priority 1: Explicit INPUT_MODE
+        if let Some(mode_str) = input_mode {
+            match mode_str.to_lowercase().as_str() {
+                "run" => {
+                    return Ok((
+                        ActionMode::Run {
+                            intent: String::new(),
+                        },
+                        "input".to_string(),
+                    ));
+                }
+                "plan" => {
+                    return Ok((
+                        ActionMode::Plan {
+                            intent: String::new(),
+                        },
+                        "input".to_string(),
+                    ));
+                }
+                "validate" => {
+                    return Ok((
+                        ActionMode::Validate {
+                            intent: String::new(),
+                        },
+                        "input".to_string(),
+                    ));
+                }
+                "status" => {
+                    return Ok((ActionMode::Status, "input".to_string()));
+                }
+                "auto" => { /* fall through to event-based resolution */ }
+                _ => {
+                    return Err(ActionError::ModeResolutionError {
+                        detail: format!("Unknown mode string: '{mode_str}'"),
+                        input_mode: Some(mode_str.to_string()),
+                        event_name: Some(event_name.to_string()),
+                    });
+                }
+            }
+        }
+
+        // Priority 2: Event-based resolution
+        match event_name {
+            "workflow_dispatch" | "repository_dispatch" => Ok((
+                ActionMode::Run {
+                    intent: String::new(),
+                },
+                "event_type".to_string(),
+            )),
+            "pull_request" | "pull_request_target" => Ok((
+                ActionMode::Validate {
+                    intent: String::new(),
+                },
+                "event_type".to_string(),
+            )),
+            "issue_comment" => {
+                // For issue_comment, we default to Run but the caller
+                // can override with slash command parsing
+                Ok((
+                    ActionMode::Run {
+                        intent: String::new(),
+                    },
+                    "event_type".to_string(),
+                ))
+            }
+            "push" => Ok((ActionMode::Status, "event_type".to_string())),
+            _ => {
+                // Fallback to Status for unknown events
+                Ok((ActionMode::Status, "default".to_string()))
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl ContextBuilder for ContextBuilderImpl {
+    async fn build(&self, input: BuildContextInput) -> Result<BuildContextOutput, ActionError> {
+        let mut warnings = Vec::new();
+
+        // Helper: read env var from overrides or real env
+        let env_val = |name: &str| -> Option<String> {
+            if let Some(ref overrides) = input.env_override {
+                overrides.get(name).cloned()
+            } else {
+                // This is not async but used in an async context — use block_on or sync approach
+                None
+            }
+        };
+
+        // 1. Workspace root
+        let workspace_root = if let Some(ref override_root) = input.workspace_override {
+            override_root.clone()
+        } else if let Some(overrides) = &input.env_override {
+            overrides.get("GITHUB_WORKSPACE").cloned().ok_or_else(|| {
+                ActionError::MissingContext {
+                    detail: "GITHUB_WORKSPACE environment variable is not set".to_string(),
+                    env_var: Some("GITHUB_WORKSPACE".to_string()),
+                }
+            })?
+        } else {
+            self.repository.workspace_root().await?
+        };
+
+        // 2. Event name
+        let event_name = if let Some(ref override_name) = input.event_name_override {
+            override_name.clone()
+        } else if let Some(overrides) = &input.env_override {
+            overrides.get("GITHUB_EVENT_NAME").cloned().ok_or_else(|| {
+                ActionError::MissingContext {
+                    detail: "GITHUB_EVENT_NAME environment variable is not set".to_string(),
+                    env_var: Some("GITHUB_EVENT_NAME".to_string()),
+                }
+            })?
+        } else {
+            self.repository.event_name().await?
+        };
+
+        // 3. Event payload
+        let (event, raw_payload) = if let Some(ref override_payload) = input.event_payload_override
+        {
+            let parsed = self
+                .parse_event_payload(&event_name, override_payload)
+                .await?;
+            (parsed.event, parsed.raw_payload)
+        } else {
+            let event_path = if let Some(ref override_path) = input.event_path_override {
+                override_path.clone()
+            } else if let Some(overrides) = &input.env_override {
+                overrides.get("GITHUB_EVENT_PATH").cloned().ok_or_else(|| {
+                    ActionError::MissingContext {
+                        detail: "GITHUB_EVENT_PATH environment variable is not set".to_string(),
+                        env_var: Some("GITHUB_EVENT_PATH".to_string()),
+                    }
+                })?
+            } else {
+                self.repository.event_path().await?
+            };
+
+            let content = self.repository.read_event_payload(&event_path).await?;
+            let parsed = self.parse_event_payload(&event_name, &content).await?;
+            (parsed.event, parsed.raw_payload)
+        };
+
+        // 4. Input mode
+        let input_mode = if let Some(overrides) = &input.env_override {
+            overrides.get("INPUT_MODE").cloned()
+        } else {
+            self.repository.read_env_var("INPUT_MODE").await?
+        };
+
+        // 5. Resolve mode
+        let (mode, _mode_source) =
+            self.resolve_mode(input_mode.as_deref(), &event_name, &raw_payload)?;
+
+        if input_mode.is_some() {
+            warnings.push(format!(
+                "Mode resolved from INPUT_MODE: {}",
+                input_mode.as_deref().unwrap()
+            ));
+        } else {
+            warnings.push(format!("Mode resolved from event type '{}'", event_name));
+        }
+
+        // 6. GitHub token
+        let github_token = if let Some(overrides) = &input.env_override {
+            overrides.get("GITHUB_TOKEN").cloned()
+        } else {
+            self.repository.github_token().await?
+        };
+
+        // 7. Intent from INPUT_INTENT
+        let intent = if let Some(overrides) = &input.env_override {
+            overrides.get("INPUT_INTENT").cloned()
+        } else {
+            self.repository.read_env_var("INPUT_INTENT").await?
+        };
+
+        // Apply intent to mode if needed
+        let mode = if let Some(ref intent_val) = intent {
+            match mode {
+                ActionMode::Run { .. } => ActionMode::Run {
+                    intent: intent_val.clone(),
+                },
+                ActionMode::Plan { .. } => ActionMode::Plan {
+                    intent: intent_val.clone(),
+                },
+                ActionMode::Validate { .. } => ActionMode::Validate {
+                    intent: intent_val.clone(),
+                },
+                other => other,
+            }
+        } else {
+            mode
+        };
+
+        // 8. Additional context fields
+        let max_validation_iterations = if let Some(overrides) = &input.env_override {
+            overrides
+                .get("INPUT_MAX_VALIDATION_ITERATIONS")
+                .and_then(|v| v.parse::<u32>().ok())
+                .unwrap_or(3)
+        } else {
+            self.repository
+                .read_env_var("INPUT_MAX_VALIDATION_ITERATIONS")
+                .await?
+                .and_then(|v| v.parse::<u32>().ok())
+                .unwrap_or(3)
+        };
+
+        let max_llm_calls = if let Some(overrides) = &input.env_override {
+            overrides
+                .get("INPUT_MAX_LLM_CALLS")
+                .and_then(|v| v.parse::<u32>().ok())
+        } else {
+            self.repository
+                .read_env_var("INPUT_MAX_LLM_CALLS")
+                .await?
+                .and_then(|v| v.parse::<u32>().ok())
+        };
+
+        let max_llm_tokens = if let Some(overrides) = &input.env_override {
+            overrides
+                .get("INPUT_MAX_LLM_TOKENS")
+                .and_then(|v| v.parse::<u64>().ok())
+        } else {
+            self.repository
+                .read_env_var("INPUT_MAX_LLM_TOKENS")
+                .await?
+                .and_then(|v| v.parse::<u64>().ok())
+        };
+
+        let profile = if let Some(overrides) = &input.env_override {
+            overrides.get("INPUT_PROFILE").cloned()
+        } else {
+            self.repository.read_env_var("INPUT_PROFILE").await?
+        };
+
+        let permission_mode = if let Some(overrides) = &input.env_override {
+            overrides.get("INPUT_PERMISSION_MODE").cloned()
+        } else {
+            self.repository
+                .read_env_var("INPUT_PERMISSION_MODE")
+                .await?
+        };
+
+        let context = ActionContext {
+            workspace_root,
+            event,
+            mode: mode.clone(),
+            github_token,
+            max_validation_iterations,
+            max_llm_calls,
+            max_llm_tokens,
+            profile,
+            permission_mode,
+        };
+
+        Ok(BuildContextOutput {
+            context,
+            event_name,
+            input_mode,
+            warnings,
+        })
+    }
+
+    async fn get_workspace_root(&self) -> Result<String, ActionError> {
+        self.repository.workspace_root().await
+    }
+
+    async fn get_github_token(&self) -> Result<Option<String>, ActionError> {
+        self.repository.github_token().await
+    }
+
+    async fn parse_event(
+        &self,
+        event_name: &str,
+        event_path: &str,
+    ) -> Result<ParseEventOutput, ActionError> {
+        let content = self.repository.read_event_payload(event_path).await?;
+        self.parse_event_payload(event_name, &content).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    // ── Mock ContextRepository ──
+
+    struct MockContextRepository {
+        env_vars: std::collections::HashMap<String, String>,
+        event_payload: Option<String>,
+    }
+
+    impl MockContextRepository {
+        fn new() -> Self {
+            let mut env = std::collections::HashMap::new();
+            env.insert("GITHUB_WORKSPACE".to_string(), "/tmp/workspace".to_string());
+            env.insert(
+                "GITHUB_EVENT_NAME".to_string(),
+                "workflow_dispatch".to_string(),
+            );
+            env.insert(
+                "GITHUB_EVENT_PATH".to_string(),
+                "/tmp/event.json".to_string(),
+            );
+            env.insert("GITHUB_TOKEN".to_string(), "gh_token_123".to_string());
+            Self {
+                env_vars: env,
+                event_payload: Some(r#"{"ref": "main"}"#.to_string()),
+            }
+        }
+
+        fn with_env(mut self, key: &str, value: &str) -> Self {
+            self.env_vars.insert(key.to_string(), value.to_string());
+            self
+        }
+
+        fn with_event(mut self, event_name: &str, payload: &str) -> Self {
+            self.env_vars
+                .insert("GITHUB_EVENT_NAME".to_string(), event_name.to_string());
+            self.event_payload = Some(payload.to_string());
+            self
+        }
+
+        fn with_intent(self, intent: &str) -> Self {
+            self.with_env("INPUT_INTENT", intent)
+        }
+
+        fn with_mode(self, mode: &str) -> Self {
+            self.with_env("INPUT_MODE", mode)
+        }
+    }
+
+    #[async_trait]
+    impl ContextRepository for MockContextRepository {
+        async fn read_env_var(&self, name: &str) -> Result<Option<String>, ActionError> {
+            Ok(self.env_vars.get(name).cloned())
+        }
+
+        async fn read_env_vars(
+            &self,
+            _prefix: &str,
+        ) -> Result<std::collections::HashMap<String, String>, ActionError> {
+            Ok(self.env_vars.clone())
+        }
+
+        async fn has_env_var(&self, name: &str) -> Result<bool, ActionError> {
+            Ok(self.env_vars.contains_key(name))
+        }
+
+        async fn workspace_root(&self) -> Result<String, ActionError> {
+            self.env_vars
+                .get("GITHUB_WORKSPACE")
+                .cloned()
+                .ok_or_else(|| ActionError::MissingContext {
+                    detail: "Missing GITHUB_WORKSPACE".to_string(),
+                    env_var: Some("GITHUB_WORKSPACE".to_string()),
+                })
+        }
+
+        async fn event_name(&self) -> Result<String, ActionError> {
+            self.env_vars
+                .get("GITHUB_EVENT_NAME")
+                .cloned()
+                .ok_or_else(|| ActionError::MissingContext {
+                    detail: "Missing GITHUB_EVENT_NAME".to_string(),
+                    env_var: Some("GITHUB_EVENT_NAME".to_string()),
+                })
+        }
+
+        async fn event_path(&self) -> Result<String, ActionError> {
+            self.env_vars
+                .get("GITHUB_EVENT_PATH")
+                .cloned()
+                .ok_or_else(|| ActionError::MissingContext {
+                    detail: "Missing GITHUB_EVENT_PATH".to_string(),
+                    env_var: Some("GITHUB_EVENT_PATH".to_string()),
+                })
+        }
+
+        async fn read_event_payload(&self, _path: &str) -> Result<String, ActionError> {
+            self.event_payload
+                .clone()
+                .ok_or_else(|| ActionError::ContextRepositoryError {
+                    detail: "No mock event payload".to_string(),
+                })
+        }
+
+        async fn github_token(&self) -> Result<Option<String>, ActionError> {
+            Ok(self.env_vars.get("GITHUB_TOKEN").cloned())
+        }
+
+        async fn github_api_url(&self) -> Result<String, ActionError> {
+            Ok("https://api.github.com".to_string())
+        }
+
+        async fn read_ci_env_vars(
+            &self,
+        ) -> Result<std::collections::HashMap<String, String>, ActionError> {
+            Ok(self.env_vars.clone())
+        }
+
+        async fn resolve_path(&self, path: &str) -> Result<String, ActionError> {
+            let workspace = self.workspace_root().await?;
+            Ok(std::path::PathBuf::from(&workspace)
+                .join(path)
+                .to_string_lossy()
+                .to_string())
+        }
+    }
+
+    fn create_builder(mock: MockContextRepository) -> ContextBuilderImpl {
+        ContextBuilderImpl::new(Arc::new(mock))
+    }
+
+    // ── Tests ──
+
+    #[tokio::test]
+    async fn test_build_context_workflow_dispatch() {
+        let builder = create_builder(MockContextRepository::new());
+        let input = BuildContextInput::default();
+        let output = builder.build(input).await.unwrap();
+
+        assert_eq!(output.context.workspace_root, "/tmp/workspace");
+        assert_eq!(output.event_name, "workflow_dispatch");
+        assert!(output.context.github_token.is_some());
+        assert_eq!(output.context.github_token.unwrap(), "gh_token_123");
+
+        match output.context.mode {
+            ActionMode::Run { .. } => {} // workflow_dispatch -> Run
+            other => panic!("Expected Run mode, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_build_context_pull_request() {
+        let mock = MockContextRepository::new().with_event(
+            "pull_request",
+            r#"{
+                "action": "opened",
+                "number": 42,
+                "pull_request": {
+                    "title": "Test PR",
+                    "base": { "ref": "main" },
+                    "head": { "ref": "feature-branch", "sha": "abc123" }
+                }
+            }"#,
+        );
+        let builder = create_builder(mock);
+        let input = BuildContextInput::default();
+        let output = builder.build(input).await.unwrap();
+
+        assert_eq!(output.event_name, "pull_request");
+
+        match output.context.mode {
+            ActionMode::Validate { .. } => {} // pull_request -> Validate
+            other => panic!("Expected Validate mode, got {:?}", other),
+        }
+
+        match output.context.event {
+            GitHubEvent::PullRequest {
+                pr_number, title, ..
+            } => {
+                assert_eq!(pr_number, 42);
+                assert_eq!(title, "Test PR");
+            }
+            other => panic!("Expected PullRequest event, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_build_context_with_input_mode() {
+        let mock = MockContextRepository::new().with_mode("plan");
+        let builder = create_builder(mock);
+        let input = BuildContextInput::default();
+        let output = builder.build(input).await.unwrap();
+
+        match output.context.mode {
+            ActionMode::Plan { .. } => {}
+            other => panic!("Expected Plan mode, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_build_context_with_input_mode_and_intent() {
+        let mock = MockContextRepository::new()
+            .with_mode("run")
+            .with_intent("implement feature X");
+        let builder = create_builder(mock);
+        let input = BuildContextInput::default();
+        let output = builder.build(input).await.unwrap();
+
+        match output.context.mode {
+            ActionMode::Run { intent } => {
+                assert_eq!(intent, "implement feature X");
+            }
+            other => panic!("Expected Run mode with intent, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_build_context_issue_comment() {
+        let mock = MockContextRepository::new().with_event(
+            "issue_comment",
+            r#"{
+                "issue": { "number": 100 },
+                "comment": {
+                    "body": "/rigorix run implement feature",
+                    "user": { "login": "test-user" }
+                }
+            }"#,
+        );
+        let builder = create_builder(mock);
+        let input = BuildContextInput::default();
+        let output = builder.build(input).await.unwrap();
+
+        assert_eq!(output.event_name, "issue_comment");
+
+        match output.context.event {
+            GitHubEvent::IssueComment {
+                issue_number,
+                commenter,
+                ..
+            } => {
+                assert_eq!(issue_number, 100);
+                assert_eq!(commenter, "test-user");
+            }
+            other => panic!("Expected IssueComment event, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_build_context_push() {
+        let mock = MockContextRepository::new().with_event(
+            "push",
+            r#"{
+                "ref": "refs/heads/main",
+                "after": "def456",
+                "pusher": { "name": "dev-user" }
+            }"#,
+        );
+        let builder = create_builder(mock);
+        let input = BuildContextInput::default();
+        let output = builder.build(input).await.unwrap();
+
+        assert_eq!(output.event_name, "push");
+
+        match output.context.mode {
+            ActionMode::Status => {} // push -> Status
+            other => panic!("Expected Status mode, got {:?}", other),
+        }
+
+        match output.context.event {
+            GitHubEvent::Push {
+                branch,
+                sha,
+                pusher,
+            } => {
+                assert_eq!(branch, "main");
+                assert_eq!(sha, "def456");
+                assert_eq!(pusher, "dev-user");
+            }
+            other => panic!("Expected Push event, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_build_context_unknown_event() {
+        let mock = MockContextRepository::new().with_event("unknown_event", "{}");
+        let builder = create_builder(mock);
+        let input = BuildContextInput::default();
+        let output = builder.build(input).await.unwrap();
+
+        match output.context.event {
+            GitHubEvent::Unknown { .. } => {}
+            other => panic!("Expected Unknown event, got {:?}", other),
+        }
+
+        match output.context.mode {
+            ActionMode::Status => {} // unknown -> Status fallback
+            other => panic!("Expected Status fallback, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_build_context_env_overrides() {
+        let builder = create_builder(MockContextRepository::new());
+        let mut env_override = std::collections::HashMap::new();
+        env_override.insert(
+            "GITHUB_WORKSPACE".to_string(),
+            "/custom/workspace".to_string(),
+        );
+        env_override.insert("GITHUB_EVENT_NAME".to_string(), "status".to_string());
+        env_override.insert(
+            "GITHUB_EVENT_PATH".to_string(),
+            "/tmp/status.json".to_string(),
+        );
+        env_override.insert("INPUT_MODE".to_string(), "status".to_string());
+
+        let input = BuildContextInput {
+            env_override: Some(env_override),
+            event_payload_override: Some(r#"{}"#.to_string()),
+            ..Default::default()
+        };
+
+        let output = builder.build(input).await.unwrap();
+        assert_eq!(output.context.workspace_root, "/custom/workspace");
+        assert_eq!(output.event_name, "status");
+    }
+
+    #[tokio::test]
+    async fn test_build_context_missing_workspace() {
+        let mut mock = MockContextRepository::new();
+        mock.env_vars.remove("GITHUB_WORKSPACE");
+        let builder = create_builder(mock);
+        let input = BuildContextInput::default();
+        let result = builder.build(input).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_build_context_max_validation_iterations() {
+        let mock = MockContextRepository::new().with_env("INPUT_MAX_VALIDATION_ITERATIONS", "5");
+        let builder = create_builder(mock);
+        let input = BuildContextInput::default();
+        let output = builder.build(input).await.unwrap();
+        assert_eq!(output.context.max_validation_iterations, 5);
+    }
+
+    #[tokio::test]
+    async fn test_parse_event_workflow_dispatch() {
+        let builder = create_builder(MockContextRepository::new());
+        let parsed = builder
+            .parse_event_payload("workflow_dispatch", r#"{"ref": "develop"}"#)
+            .await
+            .unwrap();
+
+        match parsed.event {
+            GitHubEvent::WorkflowDispatch { ref_name } => {
+                assert_eq!(ref_name, "develop");
+            }
+            other => panic!("Expected WorkflowDispatch, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_workspace_root() {
+        let mock = MockContextRepository::new();
+        let builder = create_builder(mock);
+        let root = builder.get_workspace_root().await.unwrap();
+        assert_eq!(root, "/tmp/workspace");
+    }
+
+    #[tokio::test]
+    async fn test_get_github_token() {
+        let mock = MockContextRepository::new();
+        let builder = create_builder(mock);
+        let token = builder.get_github_token().await.unwrap();
+        assert_eq!(token, Some("gh_token_123".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_build_context_with_permission_mode() {
+        let mock = MockContextRepository::new().with_env("INPUT_PERMISSION_MODE", "read_only");
+        let builder = create_builder(mock);
+        let input = BuildContextInput::default();
+        let output = builder.build(input).await.unwrap();
+        assert_eq!(
+            output.context.permission_mode,
+            Some("read_only".to_string())
+        );
+    }
+}

--- a/actions/src/action_entrypoint/application/factory.rs
+++ b/actions/src/action_entrypoint/application/factory.rs
@@ -98,10 +98,7 @@ pub trait OutputFactory: Send + Sync {
     ) -> Result<ActionOutput, ActionError>;
 
     /// Create a skipped output.
-    async fn skipped(
-        &self,
-        reason: &str,
-    ) -> Result<ActionOutput, ActionError>;
+    async fn skipped(&self, reason: &str) -> Result<ActionOutput, ActionError>;
 
     /// Create an output with annotations.
     async fn with_annotations(
@@ -111,10 +108,7 @@ pub trait OutputFactory: Send + Sync {
     ) -> Result<ActionOutput, ActionError>;
 
     /// Create an output from a mode mismatch (unsupported mode).
-    async fn unsupported_mode(
-        &self,
-        mode: &ActionMode,
-    ) -> Result<ActionOutput, ActionError>;
+    async fn unsupported_mode(&self, mode: &ActionMode) -> Result<ActionOutput, ActionError>;
 }
 
 /// Factory for constructing `ActionMode` values.

--- a/actions/src/action_entrypoint/application/mod.rs
+++ b/actions/src/action_entrypoint/application/mod.rs
@@ -15,11 +15,13 @@
 //! - DTOs carry full documentation for each field
 //! - No implementation — only contract signatures
 
+pub mod context_builder_impl;
 pub mod dto;
 pub mod factory;
 pub mod router_impl;
 pub mod service;
 
+pub use context_builder_impl::*;
 pub use dto::*;
 pub use factory::*;
 pub use router_impl::*;

--- a/actions/src/action_entrypoint/application/router_impl.rs
+++ b/actions/src/action_entrypoint/application/router_impl.rs
@@ -30,7 +30,9 @@ pub struct ActionRouterImpl {
 
     /// Optional validation loop service for Validate mode dispatch.
     /// If `None`, Validate mode falls back to Run mode.
-    validation_loop: Option<Arc<dyn rigorix_engine::plan_validation::application::service::ValidationLoopService>>,
+    validation_loop: Option<
+        Arc<dyn rigorix_engine::plan_validation::application::service::ValidationLoopService>,
+    >,
 }
 
 impl ActionRouterImpl {
@@ -42,7 +44,9 @@ impl ActionRouterImpl {
     /// * `validation_loop` — Optional validation loop service (None = fallback to Run)
     pub fn new(
         orchestrator: Arc<dyn rigorix_engine::orchestrator::application::OrchestratorService>,
-        validation_loop: Option<Arc<dyn rigorix_engine::plan_validation::application::service::ValidationLoopService>>,
+        validation_loop: Option<
+            Arc<dyn rigorix_engine::plan_validation::application::service::ValidationLoopService>,
+        >,
     ) -> Self {
         Self {
             orchestrator,
@@ -51,8 +55,13 @@ impl ActionRouterImpl {
     }
 
     /// Dispatch to the engine's run mode.
-    async fn dispatch_run(&self, ctx: &crate::action_entrypoint::domain::ActionContext) -> Result<ActionOutput, ActionError> {
-        let intent = ctx.mode.intent()
+    async fn dispatch_run(
+        &self,
+        ctx: &crate::action_entrypoint::domain::ActionContext,
+    ) -> Result<ActionOutput, ActionError> {
+        let intent = ctx
+            .mode
+            .intent()
             .ok_or_else(|| ActionError::MissingContext {
                 detail: "Run mode requires an intent string".to_string(),
                 env_var: Some("INPUT_INTENT".to_string()),
@@ -65,12 +74,14 @@ impl ActionRouterImpl {
             enforcement_preset: None,
         };
 
-        let output = self.orchestrator.run(input).await.map_err(|e| {
-            ActionError::EngineError {
+        let output = self
+            .orchestrator
+            .run(input)
+            .await
+            .map_err(|e| ActionError::EngineError {
                 detail: format!("Orchestrator run failed: {e}"),
                 code: None,
-            }
-        })?;
+            })?;
 
         Ok(ActionOutput::success(
             format!("Execution completed: {}", output.execution_id),
@@ -79,8 +90,13 @@ impl ActionRouterImpl {
     }
 
     /// Dispatch to the engine's plan-only mode.
-    async fn dispatch_plan(&self, ctx: &crate::action_entrypoint::domain::ActionContext) -> Result<ActionOutput, ActionError> {
-        let intent = ctx.mode.intent()
+    async fn dispatch_plan(
+        &self,
+        ctx: &crate::action_entrypoint::domain::ActionContext,
+    ) -> Result<ActionOutput, ActionError> {
+        let intent = ctx
+            .mode
+            .intent()
             .ok_or_else(|| ActionError::MissingContext {
                 detail: "Plan mode requires an intent string".to_string(),
                 env_var: Some("INPUT_INTENT".to_string()),
@@ -92,20 +108,26 @@ impl ActionRouterImpl {
             config: ctx.to_engine_config(),
         };
 
-        let output = self.orchestrator.plan_only(input).await.map_err(|e| {
-            ActionError::EngineError {
-                detail: format!("Orchestrator plan_only failed: {e}"),
-                code: None,
-            }
-        })?;
+        let output =
+            self.orchestrator
+                .plan_only(input)
+                .await
+                .map_err(|e| ActionError::EngineError {
+                    detail: format!("Orchestrator plan_only failed: {e}"),
+                    code: None,
+                })?;
 
         // Extract summary from plan output
-        let summary = format!("Plan generated with {} nodes", 
-            output.graph.as_object()
+        let summary = format!(
+            "Plan generated with {} nodes",
+            output
+                .graph
+                .as_object()
                 .and_then(|m| m.get("nodes"))
                 .and_then(|v| v.as_array())
                 .map(|a| a.len())
-                .unwrap_or(0));
+                .unwrap_or(0)
+        );
 
         Ok(ActionOutput::success(summary, None)
             .with_variable("plan", output.plan.to_string())
@@ -113,8 +135,13 @@ impl ActionRouterImpl {
     }
 
     /// Dispatch to the engine's validate mode (with optional validation loop).
-    async fn dispatch_validate(&self, ctx: &crate::action_entrypoint::domain::ActionContext) -> Result<ActionOutput, ActionError> {
-        let intent = ctx.mode.intent()
+    async fn dispatch_validate(
+        &self,
+        ctx: &crate::action_entrypoint::domain::ActionContext,
+    ) -> Result<ActionOutput, ActionError> {
+        let intent = ctx
+            .mode
+            .intent()
             .ok_or_else(|| ActionError::MissingContext {
                 detail: "Validate mode requires an intent string".to_string(),
                 env_var: Some("INPUT_INTENT".to_string()),
@@ -122,55 +149,69 @@ impl ActionRouterImpl {
 
         // If we have a validation loop service, use it
         if let Some(ref svc) = self.validation_loop {
-            let user_intent = rigorix_engine::planning::domain::intent::UserIntent::new(
-                intent.to_string(),
-                None,
-            );
+            let user_intent =
+                rigorix_engine::planning::domain::intent::UserIntent::new(intent.to_string(), None);
 
             let input = rigorix_engine::plan_validation::application::dto::ValidateInput {
                 intent: user_intent,
                 execution_id: None,
-                config: rigorix_engine::plan_validation::domain::loop_config::ValidationLoopConfig {
-                    max_iterations: ctx.max_validation_iterations,
-                    ..Default::default()
-                },
+                config:
+                    rigorix_engine::plan_validation::domain::loop_config::ValidationLoopConfig {
+                        max_iterations: ctx.max_validation_iterations,
+                        ..Default::default()
+                    },
                 existing_template: None,
             };
 
-            let output = svc.validate(input).await.map_err(|e| {
-                ActionError::ValidationLoopError {
-                    detail: format!("Validation loop failed: {e}"),
-                    iterations_completed: None,
-                }
-            })?;
+            let output =
+                svc.validate(input)
+                    .await
+                    .map_err(|e| ActionError::ValidationLoopError {
+                        detail: format!("Validation loop failed: {e}"),
+                        iterations_completed: None,
+                    })?;
 
             let outcome_str = format!("{:?}", output.outcome);
             Ok(ActionOutput::success(
-                format!("Validation complete: {} ({} iterations, {} failures)",
-                    outcome_str, output.iterations, output.total_failures),
+                format!(
+                    "Validation complete: {} ({} iterations, {} failures)",
+                    outcome_str, output.iterations, output.total_failures
+                ),
                 Some(output.execution_id.to_string()),
             ))
         } else {
             // Fallback: run without validation loop
             tracing::warn!("No validation loop service available, falling back to Run mode");
-            let run_ctx = ctx.with_mode(ActionMode::Run { intent: intent.to_string() });
+            let run_ctx = ctx.with_mode(ActionMode::Run {
+                intent: intent.to_string(),
+            });
             self.dispatch_run(&run_ctx).await
         }
     }
 
     /// Dispatch to the engine's status mode.
-    async fn dispatch_status(&self, _ctx: &crate::action_entrypoint::domain::ActionContext) -> Result<ActionOutput, ActionError> {
-        let output = self.orchestrator.status().await.map_err(|e| {
-            ActionError::EngineError {
+    async fn dispatch_status(
+        &self,
+        _ctx: &crate::action_entrypoint::domain::ActionContext,
+    ) -> Result<ActionOutput, ActionError> {
+        let output = self
+            .orchestrator
+            .status()
+            .await
+            .map_err(|e| ActionError::EngineError {
                 detail: format!("Orchestrator status failed: {e}"),
                 code: None,
-            }
-        })?;
+            })?;
 
-        let summary = format!("Status: {:?} (execution: {})", output.status, output.execution_id);
-        Ok(ActionOutput::success(summary, Some(output.execution_id.to_string()))
-            .with_variable("execution_id", output.execution_id.to_string())
-            .with_variable("status", format!("{:?}", output.status)))
+        let summary = format!(
+            "Status: {:?} (execution: {})",
+            output.status, output.execution_id
+        );
+        Ok(
+            ActionOutput::success(summary, Some(output.execution_id.to_string()))
+                .with_variable("execution_id", output.execution_id.to_string())
+                .with_variable("status", format!("{:?}", output.status)),
+        )
     }
 }
 
@@ -213,8 +254,8 @@ impl ActionRouter for ActionRouterImpl {
             Err(e) => {
                 let is_retriable = e.is_retriable();
                 let annotation_level = e.annotation_level();
-                let error_output = ActionOutput::failure(format!("{e}"))
-                    .with_annotation(crate::action_entrypoint::domain::WorkflowAnnotation {
+                let error_output = ActionOutput::failure(format!("{e}")).with_annotation(
+                    crate::action_entrypoint::domain::WorkflowAnnotation {
                         level: if annotation_level == "error" {
                             crate::action_entrypoint::domain::AnnotationLevel::Error
                         } else {
@@ -225,7 +266,8 @@ impl ActionRouter for ActionRouterImpl {
                         line: None,
                         column: None,
                         title: Some(format!("{} dispatch failed", ctx.mode.as_str())),
-                    });
+                    },
+                );
 
                 Ok(DispatchOutput {
                     output: error_output,
@@ -254,14 +296,26 @@ impl ActionRouter for ActionRouterImpl {
     }
 
     async fn can_handle(&self, mode: &ActionMode) -> bool {
-        matches!(mode, ActionMode::Run { .. } | ActionMode::Plan { .. } | ActionMode::Validate { .. } | ActionMode::Status)
+        matches!(
+            mode,
+            ActionMode::Run { .. }
+                | ActionMode::Plan { .. }
+                | ActionMode::Validate { .. }
+                | ActionMode::Status
+        )
     }
 
     async fn supported_modes(&self) -> Vec<ActionMode> {
         vec![
-            ActionMode::Run { intent: String::new() },
-            ActionMode::Plan { intent: String::new() },
-            ActionMode::Validate { intent: String::new() },
+            ActionMode::Run {
+                intent: String::new(),
+            },
+            ActionMode::Plan {
+                intent: String::new(),
+            },
+            ActionMode::Validate {
+                intent: String::new(),
+            },
             ActionMode::Status,
         ]
     }
@@ -303,12 +357,17 @@ mod tests {
         async fn run(
             &self,
             _input: rigorix_engine::orchestrator::application::dto::RunInput,
-        ) -> Result<rigorix_engine::orchestrator::application::dto::RunOutput, rigorix_engine::orchestrator::domain::OrchestratorError> {
+        ) -> Result<
+            rigorix_engine::orchestrator::application::dto::RunOutput,
+            rigorix_engine::orchestrator::domain::OrchestratorError,
+        > {
             if self.run_should_fail {
-                return Err(rigorix_engine::orchestrator::domain::OrchestratorError::Internal {
-                    detail: "Mock run failure".to_string(),
-                    source_module: "mock_orchestrator".to_string(),
-                });
+                return Err(
+                    rigorix_engine::orchestrator::domain::OrchestratorError::Internal {
+                        detail: "Mock run failure".to_string(),
+                        source_module: "mock_orchestrator".to_string(),
+                    },
+                );
             }
             let exec_id = uuid::Uuid::new_v4();
             let now = chrono::Utc::now();
@@ -323,7 +382,8 @@ mod tests {
                     started_at: now,
                     completed_at: Some(now),
                     duration_ms: 100,
-                    status: rigorix_engine::orchestrator::domain::record::ExecutionStatus::Completed,
+                    status:
+                        rigorix_engine::orchestrator::domain::record::ExecutionStatus::Completed,
                 },
             })
         }
@@ -331,44 +391,64 @@ mod tests {
         async fn plan_only(
             &self,
             _input: rigorix_engine::orchestrator::application::dto::PlanOnlyInput,
-        ) -> Result<rigorix_engine::orchestrator::application::dto::PlanOnlyOutput, rigorix_engine::orchestrator::domain::OrchestratorError> {
+        ) -> Result<
+            rigorix_engine::orchestrator::application::dto::PlanOnlyOutput,
+            rigorix_engine::orchestrator::domain::OrchestratorError,
+        > {
             if self.plan_should_fail {
-                return Err(rigorix_engine::orchestrator::domain::OrchestratorError::Internal {
-                    detail: "Mock plan failure".to_string(),
-                    source_module: "mock_orchestrator".to_string(),
-                });
+                return Err(
+                    rigorix_engine::orchestrator::domain::OrchestratorError::Internal {
+                        detail: "Mock plan failure".to_string(),
+                        source_module: "mock_orchestrator".to_string(),
+                    },
+                );
             }
-            Ok(rigorix_engine::orchestrator::application::dto::PlanOnlyOutput {
-                plan: serde_json::json!({"steps": []}),
-                graph: serde_json::json!({"nodes": []}),
-            })
+            Ok(
+                rigorix_engine::orchestrator::application::dto::PlanOnlyOutput {
+                    plan: serde_json::json!({"steps": []}),
+                    graph: serde_json::json!({"nodes": []}),
+                },
+            )
         }
 
         async fn cancel(
             &self,
             _input: rigorix_engine::orchestrator::application::dto::CancelInput,
-        ) -> Result<rigorix_engine::orchestrator::application::dto::CancelOutput, rigorix_engine::orchestrator::domain::OrchestratorError> {
-            Ok(rigorix_engine::orchestrator::application::dto::CancelOutput {
-                execution_id: uuid::Uuid::new_v4(),
-                aborted: true,
-                nodes_cancelled: 0,
-            })
+        ) -> Result<
+            rigorix_engine::orchestrator::application::dto::CancelOutput,
+            rigorix_engine::orchestrator::domain::OrchestratorError,
+        > {
+            Ok(
+                rigorix_engine::orchestrator::application::dto::CancelOutput {
+                    execution_id: uuid::Uuid::new_v4(),
+                    aborted: true,
+                    nodes_cancelled: 0,
+                },
+            )
         }
 
         async fn status(
             &self,
-        ) -> Result<rigorix_engine::orchestrator::application::dto::StatusOutput, rigorix_engine::orchestrator::domain::OrchestratorError> {
+        ) -> Result<
+            rigorix_engine::orchestrator::application::dto::StatusOutput,
+            rigorix_engine::orchestrator::domain::OrchestratorError,
+        > {
             if self.status_should_fail {
-                return Err(rigorix_engine::orchestrator::domain::OrchestratorError::Internal {
-                    detail: "Mock status failure".to_string(),
-                    source_module: "mock_orchestrator".to_string(),
-                });
+                return Err(
+                    rigorix_engine::orchestrator::domain::OrchestratorError::Internal {
+                        detail: "Mock status failure".to_string(),
+                        source_module: "mock_orchestrator".to_string(),
+                    },
+                );
             }
-            Ok(rigorix_engine::orchestrator::application::dto::StatusOutput {
-                execution_id: uuid::Uuid::new_v4(),
-                status: rigorix_engine::orchestrator::domain::record::ExecutionStatus::Completed,
-                nodes: vec![],
-            })
+            Ok(
+                rigorix_engine::orchestrator::application::dto::StatusOutput {
+                    execution_id: uuid::Uuid::new_v4(),
+                    status:
+                        rigorix_engine::orchestrator::domain::record::ExecutionStatus::Completed,
+                    nodes: vec![],
+                },
+            )
         }
 
         fn event_bus(&self) -> &dyn rigorix_engine::event_system::application::EventBusService {
@@ -381,11 +461,16 @@ mod tests {
     struct MockValidationLoop;
 
     #[async_trait]
-    impl rigorix_engine::plan_validation::application::service::ValidationLoopService for MockValidationLoop {
+    impl rigorix_engine::plan_validation::application::service::ValidationLoopService
+        for MockValidationLoop
+    {
         async fn validate(
             &self,
             _input: rigorix_engine::plan_validation::application::dto::ValidateInput,
-        ) -> Result<rigorix_engine::plan_validation::application::dto::ValidateOutput, rigorix_engine::plan_validation::domain::error::ValidationLoopError> {
+        ) -> Result<
+            rigorix_engine::plan_validation::application::dto::ValidateOutput,
+            rigorix_engine::plan_validation::domain::error::ValidationLoopError,
+        > {
             Ok(rigorix_engine::plan_validation::application::dto::ValidateOutput {
                 execution_id: uuid::Uuid::new_v4(),
                 outcome: rigorix_engine::plan_validation::domain::outcome::ValidationOutcome::Validated,
@@ -400,23 +485,33 @@ mod tests {
         async fn classify_nodes(
             &self,
             _input: rigorix_engine::plan_validation::application::dto::ClassifyNodesInput,
-        ) -> Result<rigorix_engine::plan_validation::application::dto::ClassifyNodesOutput, rigorix_engine::plan_validation::domain::error::ValidationLoopError> {
-            Ok(rigorix_engine::plan_validation::application::dto::ClassifyNodesOutput {
-                generative: vec![],
-                deterministic: vec![],
-                total_nodes: 0,
-            })
+        ) -> Result<
+            rigorix_engine::plan_validation::application::dto::ClassifyNodesOutput,
+            rigorix_engine::plan_validation::domain::error::ValidationLoopError,
+        > {
+            Ok(
+                rigorix_engine::plan_validation::application::dto::ClassifyNodesOutput {
+                    generative: vec![],
+                    deterministic: vec![],
+                    total_nodes: 0,
+                },
+            )
         }
 
         async fn retry_generative_nodes(
             &self,
             _input: rigorix_engine::plan_validation::application::dto::RetryGenerativeNodesInput,
-        ) -> Result<rigorix_engine::plan_validation::application::dto::RetryGenerativeNodesOutput, rigorix_engine::plan_validation::domain::error::ValidationLoopError> {
-            Ok(rigorix_engine::plan_validation::application::dto::RetryGenerativeNodesOutput {
-                template: rigorix_engine::templates::domain::Template::default(),
-                retried_count: 0,
-                skipped_count: 0,
-            })
+        ) -> Result<
+            rigorix_engine::plan_validation::application::dto::RetryGenerativeNodesOutput,
+            rigorix_engine::plan_validation::domain::error::ValidationLoopError,
+        > {
+            Ok(
+                rigorix_engine::plan_validation::application::dto::RetryGenerativeNodesOutput {
+                    template: rigorix_engine::templates::domain::Template::default(),
+                    retried_count: 0,
+                    skipped_count: 0,
+                },
+            )
         }
     }
 
@@ -628,9 +723,27 @@ mod tests {
     async fn test_can_handle_all_modes() {
         let router = create_router();
 
-        assert!(router.can_handle(&ActionMode::Run { intent: "test".to_string() }).await);
-        assert!(router.can_handle(&ActionMode::Plan { intent: "test".to_string() }).await);
-        assert!(router.can_handle(&ActionMode::Validate { intent: "test".to_string() }).await);
+        assert!(
+            router
+                .can_handle(&ActionMode::Run {
+                    intent: "test".to_string()
+                })
+                .await
+        );
+        assert!(
+            router
+                .can_handle(&ActionMode::Plan {
+                    intent: "test".to_string()
+                })
+                .await
+        );
+        assert!(
+            router
+                .can_handle(&ActionMode::Validate {
+                    intent: "test".to_string()
+                })
+                .await
+        );
         assert!(router.can_handle(&ActionMode::Status).await);
     }
 

--- a/actions/src/action_entrypoint/application/service.rs
+++ b/actions/src/action_entrypoint/application/service.rs
@@ -160,5 +160,9 @@ pub trait ContextBuilder: Send + Sync {
     /// Parse the event payload from `GITHUB_EVENT_PATH`.
     ///
     /// Reads the JSON file and deserializes into a `GitHubEvent`.
-    async fn parse_event(&self, event_name: &str, event_path: &str) -> Result<super::dto::ParseEventOutput, ActionError>;
+    async fn parse_event(
+        &self,
+        event_name: &str,
+        event_path: &str,
+    ) -> Result<super::dto::ParseEventOutput, ActionError>;
 }

--- a/actions/src/action_entrypoint/domain/error.rs
+++ b/actions/src/action_entrypoint/domain/error.rs
@@ -135,8 +135,7 @@ impl ActionError {
             | ActionError::MissingContext { .. }
             | ActionError::InvalidWorkspaceRoot { .. }
             | ActionError::Internal { .. } => "error",
-            ActionError::UnsupportedEvent { .. }
-            | ActionError::OutputError { .. } => "warning",
+            ActionError::UnsupportedEvent { .. } | ActionError::OutputError { .. } => "warning",
             ActionError::EngineError { .. }
             | ActionError::ValidationLoopError { .. }
             | ActionError::ContextRepositoryError { .. }

--- a/actions/src/action_entrypoint/domain/types.rs
+++ b/actions/src/action_entrypoint/domain/types.rs
@@ -61,9 +61,9 @@ impl ActionMode {
     /// Get the intent string if this mode carries one.
     pub fn intent(&self) -> Option<&str> {
         match self {
-            ActionMode::Run { intent } | ActionMode::Plan { intent } | ActionMode::Validate { intent } => {
-                Some(intent.as_str())
-            }
+            ActionMode::Run { intent }
+            | ActionMode::Plan { intent }
+            | ActionMode::Validate { intent } => Some(intent.as_str()),
             ActionMode::Status => None,
         }
     }

--- a/actions/src/action_entrypoint/infrastructure/context_repository_impl.rs
+++ b/actions/src/action_entrypoint/infrastructure/context_repository_impl.rs
@@ -1,0 +1,163 @@
+//! ContextRepository implementation — reads from environment variables and filesystem.
+//!
+//! @canonical actions/.pi/architecture/modules/action-entrypoint.md
+//! Implements: ContextRepository trait — reads env, filesystem, and GitHub context
+//! Issue: issue-actioncontext (#615)
+//!
+//! This implementation reads from real environment variables (std::env::var)
+//! and the filesystem (tokio::fs) to provide GitHub Action execution context.
+
+use async_trait::async_trait;
+
+use crate::action_entrypoint::domain::ActionError;
+
+use super::repository::ContextRepository;
+
+/// Reads GitHub Action context from real environment variables and filesystem.
+///
+/// # Security
+/// - Does NOT log environment variable values (only variable names)
+/// - File paths are validated against directory traversal
+pub struct ContextRepositoryImpl;
+
+#[async_trait]
+impl ContextRepository for ContextRepositoryImpl {
+    async fn read_env_var(&self, name: &str) -> Result<Option<String>, ActionError> {
+        match std::env::var(name) {
+            Ok(val) if !val.is_empty() => Ok(Some(val)),
+            _ => Ok(None),
+        }
+    }
+
+    async fn read_env_vars(
+        &self,
+        prefix: &str,
+    ) -> Result<std::collections::HashMap<String, String>, ActionError> {
+        let mut result = std::collections::HashMap::new();
+        for (key, value) in std::env::vars() {
+            if let Some(stripped) = key.strip_prefix(prefix) {
+                result.insert(stripped.to_string(), value);
+            }
+        }
+        Ok(result)
+    }
+
+    async fn has_env_var(&self, name: &str) -> Result<bool, ActionError> {
+        Ok(std::env::var(name).is_ok())
+    }
+
+    async fn workspace_root(&self) -> Result<String, ActionError> {
+        let path = std::env::var("GITHUB_WORKSPACE").map_err(|_| ActionError::MissingContext {
+            detail: "GITHUB_WORKSPACE environment variable is not set".to_string(),
+            env_var: Some("GITHUB_WORKSPACE".to_string()),
+        })?;
+
+        // Validate the path exists
+        let metadata = std::fs::metadata(&path).map_err(|e| ActionError::InvalidWorkspaceRoot {
+            path: path.clone(),
+            detail: format!("Cannot access workspace root: {e}"),
+        })?;
+
+        if !metadata.is_dir() {
+            return Err(ActionError::InvalidWorkspaceRoot {
+                path,
+                detail: "Workspace root is not a directory".to_string(),
+            });
+        }
+
+        Ok(path)
+    }
+
+    async fn event_name(&self) -> Result<String, ActionError> {
+        std::env::var("GITHUB_EVENT_NAME").map_err(|_| ActionError::MissingContext {
+            detail: "GITHUB_EVENT_NAME environment variable is not set".to_string(),
+            env_var: Some("GITHUB_EVENT_NAME".to_string()),
+        })
+    }
+
+    async fn event_path(&self) -> Result<String, ActionError> {
+        std::env::var("GITHUB_EVENT_PATH").map_err(|_| ActionError::MissingContext {
+            detail: "GITHUB_EVENT_PATH environment variable is not set".to_string(),
+            env_var: Some("GITHUB_EVENT_PATH".to_string()),
+        })
+    }
+
+    async fn read_event_payload(&self, path: &str) -> Result<String, ActionError> {
+        tokio::fs::read_to_string(path)
+            .await
+            .map_err(|e| ActionError::ContextRepositoryError {
+                detail: format!("Failed to read event payload from '{path}': {e}"),
+            })
+    }
+
+    async fn github_token(&self) -> Result<Option<String>, ActionError> {
+        // Check GITHUB_TOKEN first, then INPUT_GITHUB_TOKEN
+        if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+            if !token.is_empty() {
+                return Ok(Some(token));
+            }
+        }
+        if let Ok(token) = std::env::var("INPUT_GITHUB_TOKEN") {
+            if !token.is_empty() {
+                return Ok(Some(token));
+            }
+        }
+        Ok(None)
+    }
+
+    async fn github_api_url(&self) -> Result<String, ActionError> {
+        Ok(
+            std::env::var("GITHUB_API_URL")
+                .unwrap_or_else(|_| "https://api.github.com".to_string()),
+        )
+    }
+
+    async fn read_ci_env_vars(
+        &self,
+    ) -> Result<std::collections::HashMap<String, String>, ActionError> {
+        let ci_vars = [
+            "GITHUB_ACTIONS",
+            "GITHUB_EVENT_NAME",
+            "GITHUB_EVENT_PATH",
+            "GITHUB_ACTOR",
+            "GITHUB_REPOSITORY",
+            "GITHUB_REPOSITORY_OWNER",
+            "GITHUB_RUN_ID",
+            "GITHUB_RUN_NUMBER",
+            "GITHUB_SHA",
+            "GITHUB_REF",
+            "GITHUB_REF_NAME",
+            "GITHUB_WORKSPACE",
+            "GITHUB_API_URL",
+            "GITHUB_SERVER_URL",
+            "CI",
+        ];
+
+        let mut result = std::collections::HashMap::new();
+        for var_name in &ci_vars {
+            if let Ok(val) = std::env::var(var_name) {
+                result.insert(var_name.to_string(), val);
+            }
+        }
+        Ok(result)
+    }
+
+    async fn resolve_path(&self, path: &str) -> Result<String, ActionError> {
+        let path_buf = std::path::PathBuf::from(path);
+        if path_buf.is_absolute() {
+            // Canonicalize for consistency
+            return Ok(std::fs::canonicalize(&path_buf)
+                .map_err(|e| ActionError::InvalidWorkspaceRoot {
+                    path: path.to_string(),
+                    detail: format!("Failed to resolve path: {e}"),
+                })?
+                .to_string_lossy()
+                .to_string());
+        }
+
+        // Resolve relative path against workspace root
+        let workspace = self.workspace_root().await?;
+        let absolute = std::path::PathBuf::from(&workspace).join(path);
+        Ok(absolute.to_string_lossy().to_string())
+    }
+}

--- a/actions/src/action_entrypoint/infrastructure/mod.rs
+++ b/actions/src/action_entrypoint/infrastructure/mod.rs
@@ -13,6 +13,8 @@
 //! - All methods return `Result<_, ActionError>`
 //! - No dependencies on external frameworks
 
+pub mod context_repository_impl;
 pub mod repository;
 
+pub use context_repository_impl::*;
 pub use repository::*;

--- a/actions/src/audit_posting/application/audit_backend_factory_impl.rs
+++ b/actions/src/audit_posting/application/audit_backend_factory_impl.rs
@@ -12,9 +12,9 @@ use async_trait::async_trait;
 use std::path::PathBuf;
 
 use crate::audit_posting::domain::AuditPostingError;
-use crate::audit_posting::infrastructure::repository::AuditBackend;
 use crate::audit_posting::infrastructure::FilesystemAuditBackendImpl;
 use crate::audit_posting::infrastructure::HttpAuditBackend;
+use crate::audit_posting::infrastructure::repository::AuditBackend;
 
 use super::dto::AuditBackendConfig;
 use super::factory::AuditBackendFactory;
@@ -51,9 +51,9 @@ impl AuditBackendFactory for AuditBackendFactoryImpl {
 
         if let Some(path) = &config.filesystem_path {
             if !path.is_empty() {
-                return Ok(Box::new(FilesystemAuditBackendImpl::new(
-                    PathBuf::from(path),
-                )));
+                return Ok(Box::new(FilesystemAuditBackendImpl::new(PathBuf::from(
+                    path,
+                ))));
             }
         }
 
@@ -62,9 +62,7 @@ impl AuditBackendFactory for AuditBackendFactoryImpl {
         })
     }
 
-    async fn create_default(
-        &self,
-    ) -> Result<Box<dyn AuditBackend>, AuditPostingError> {
+    async fn create_default(&self) -> Result<Box<dyn AuditBackend>, AuditPostingError> {
         // Default to a `.rigorix/audit-records/` directory in the current working directory
         let default_path = PathBuf::from(".rigorix/audit-records");
         Ok(Box::new(FilesystemAuditBackendImpl::new(default_path)))

--- a/actions/src/audit_posting/application/audit_posting_service_impl.rs
+++ b/actions/src/audit_posting/application/audit_posting_service_impl.rs
@@ -21,7 +21,9 @@ use super::dto::{
     SignRecordOutput, VerifyRecordInput, VerifyRecordOutput,
 };
 use super::factory::AuditRecordFactory;
-use super::service::{AuditPostingService, AuditRecordQueue, PostingStatusOutput, RetryPendingOutput};
+use super::service::{
+    AuditPostingService, AuditRecordQueue, PostingStatusOutput, RetryPendingOutput,
+};
 
 use crate::audit_posting::infrastructure::repository::AuditBackend;
 
@@ -147,7 +149,11 @@ impl AuditPostingService for AuditPostingServiceImpl {
                     success: output.success,
                     http_status: output.http_status,
                     duration_ms: output.duration_ms,
-                    error_detail: if output.success { None } else { Some("Unknown error".to_string()) },
+                    error_detail: if output.success {
+                        None
+                    } else {
+                        Some("Unknown error".to_string())
+                    },
                     attempts: 1,
                 })
             }
@@ -213,7 +219,11 @@ impl AuditPostingService for AuditPostingServiceImpl {
             Ok(valid) => Ok(VerifyRecordOutput {
                 valid,
                 key_id: input.key_id,
-                detail: Some(if valid { "Signature valid".to_string() } else { "Signature invalid".to_string() }),
+                detail: Some(if valid {
+                    "Signature valid".to_string()
+                } else {
+                    "Signature invalid".to_string()
+                }),
             }),
             Err(e) => match e {
                 AuditPostingError::SignatureMismatch { .. } => Ok(VerifyRecordOutput {
@@ -241,7 +251,8 @@ impl AuditPostingService for AuditPostingServiceImpl {
                     };
 
                     // Extract retry count from reason string (format: "Retry attempt N")
-                    let retry_count = queued.reason
+                    let retry_count = queued
+                        .reason
                         .as_ref()
                         .and_then(|r| r.strip_prefix("Retry attempt "))
                         .and_then(|n| n.parse::<u32>().ok())
@@ -257,22 +268,28 @@ impl AuditPostingService for AuditPostingServiceImpl {
                         continue;
                     }
 
-                    match self.backend.post(PostRecordInput {
-                        record: record.clone(),
-                        backend_url: None,
-                        timeout_secs: Some(30),
-                    }).await {
+                    match self
+                        .backend
+                        .post(PostRecordInput {
+                            record: record.clone(),
+                            backend_url: None,
+                            timeout_secs: Some(30),
+                        })
+                        .await
+                    {
                         Ok(_output) => {
                             delivered += 1;
                         }
                         Err(_) => {
                             // Re-enqueue for another retry
-                            self.queue.enqueue(super::dto::QueueRecordInput {
-                                record,
-                                failure_reason: format!("Retry attempt {} failed", retry_count),
-                                retry_count,
-                                max_retries: 3,
-                            }).await?;
+                            self.queue
+                                .enqueue(super::dto::QueueRecordInput {
+                                    record,
+                                    failure_reason: format!("Retry attempt {} failed", retry_count),
+                                    retry_count,
+                                    max_retries: 3,
+                                })
+                                .await?;
                             still_pending += 1;
                         }
                     }
@@ -306,8 +323,8 @@ impl AuditPostingService for AuditPostingServiceImpl {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::audit_posting::application::audit_record_factory_impl::AuditRecordFactoryImpl;
     use crate::audit_posting::application::audit_queue_impl::AuditRecordQueueImpl;
+    use crate::audit_posting::application::audit_record_factory_impl::AuditRecordFactoryImpl;
     use crate::audit_posting::domain::SignedAuditRecord;
     use crate::audit_posting::infrastructure::FilesystemAuditBackendImpl;
     use tempfile::TempDir;

--- a/actions/src/audit_posting/application/audit_queue_impl.rs
+++ b/actions/src/audit_posting/application/audit_queue_impl.rs
@@ -46,7 +46,10 @@ impl AuditRecordQueueImpl {
 #[async_trait]
 impl AuditRecordQueue for AuditRecordQueueImpl {
     #[tracing::instrument(skip_all)]
-    async fn enqueue(&self, input: QueueRecordInput) -> Result<QueueRecordOutput, AuditPostingError> {
+    async fn enqueue(
+        &self,
+        input: QueueRecordInput,
+    ) -> Result<QueueRecordOutput, AuditPostingError> {
         let mut queue = self.queue.lock().await;
         if queue.len() >= self.capacity as usize {
             return Err(AuditPostingError::QueueFull {

--- a/actions/src/audit_posting/application/audit_record_factory_impl.rs
+++ b/actions/src/audit_posting/application/audit_record_factory_impl.rs
@@ -56,11 +56,10 @@ impl AuditRecordFactoryImpl {
     /// the actual data. Uses a consistent field order via serde.
     fn serialize_for_signing(record: &SignedAuditRecord) -> Result<Vec<u8>, AuditPostingError> {
         // Create a serialization without the signature field
-        let data = serde_json::to_value(record).map_err(|e| {
-            AuditPostingError::SerializationFailed {
+        let data =
+            serde_json::to_value(record).map_err(|e| AuditPostingError::SerializationFailed {
                 detail: e.to_string(),
-            }
-        })?;
+            })?;
 
         // Remove the signature field for canonical signing
         let mut data_map = match &data {
@@ -81,17 +80,17 @@ impl AuditRecordFactoryImpl {
 
     /// Compute HMAC-SHA256 signature for the given data.
     fn compute_signature(&self, data: &[u8]) -> Result<String, AuditPostingError> {
-        let key = self.signing_key.as_ref().ok_or(
-            AuditPostingError::KeyNotAvailable {
+        let key = self
+            .signing_key
+            .as_ref()
+            .ok_or(AuditPostingError::KeyNotAvailable {
                 detail: "No HMAC signing key configured".to_string(),
-            },
-        )?;
+            })?;
 
-        let mut mac = HmacSha256::new_from_slice(key).map_err(|e| {
-            AuditPostingError::SigningFailed {
+        let mut mac =
+            HmacSha256::new_from_slice(key).map_err(|e| AuditPostingError::SigningFailed {
                 detail: format!("Invalid HMAC key length: {e}"),
-            }
-        })?;
+            })?;
 
         mac.update(data);
         let result = mac.finalize();
@@ -158,10 +157,7 @@ impl AuditRecordFactory for AuditRecordFactoryImpl {
     }
 
     #[tracing::instrument(skip_all)]
-    async fn verify(
-        &self,
-        record: &SignedAuditRecord,
-    ) -> Result<bool, AuditPostingError> {
+    async fn verify(&self, record: &SignedAuditRecord) -> Result<bool, AuditPostingError> {
         let stored_signature = match &record.signature {
             Some(sig) => sig.clone(),
             None => {
@@ -176,27 +172,26 @@ impl AuditRecordFactory for AuditRecordFactoryImpl {
         let computed_signature = self.compute_signature(&data)?;
 
         // Use constant-time comparison
-        let key = self.signing_key.as_ref().ok_or(
-            AuditPostingError::KeyNotAvailable {
+        let key = self
+            .signing_key
+            .as_ref()
+            .ok_or(AuditPostingError::KeyNotAvailable {
                 detail: "No HMAC signing key configured for verification".to_string(),
-            },
-        )?;
+            })?;
 
-        let mut mac = HmacSha256::new_from_slice(key).map_err(|e| {
-            AuditPostingError::SigningFailed {
+        let mut mac =
+            HmacSha256::new_from_slice(key).map_err(|e| AuditPostingError::SigningFailed {
                 detail: format!("Invalid HMAC key length: {e}"),
-            }
-        })?;
+            })?;
 
         mac.update(&data);
 
         // Verify using constant-time comparison
-        let stored_bytes = hex::decode(&stored_signature).map_err(|e| {
-            AuditPostingError::SignatureMismatch {
+        let stored_bytes =
+            hex::decode(&stored_signature).map_err(|e| AuditPostingError::SignatureMismatch {
                 expected_prefix: stored_signature.chars().take(8).collect(),
                 received_prefix: "invalid hex".to_string(),
-            }
-        })?;
+            })?;
 
         let result = mac.verify_slice(&stored_bytes).is_ok();
 
@@ -357,7 +352,8 @@ mod tests {
 
         // Create another factory with a different key
         let wrong_key = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
-        let wrong_factory = AuditRecordFactoryImpl::new(Some(wrong_key), Some("wrong-key".to_string()));
+        let wrong_factory =
+            AuditRecordFactoryImpl::new(Some(wrong_key), Some("wrong-key".to_string()));
 
         let result = wrong_factory.verify(&sign_output.record).await;
         assert!(result.is_err());
@@ -378,7 +374,10 @@ mod tests {
         let data = AuditRecordFactoryImpl::serialize_for_signing(&record).unwrap();
         let json: serde_json::Value = serde_json::from_slice(&data).unwrap();
         let map = json.as_object().unwrap();
-        assert!(!map.contains_key("signature"), "signature field should be excluded");
+        assert!(
+            !map.contains_key("signature"),
+            "signature field should be excluded"
+        );
     }
 
     #[tokio::test]
@@ -390,31 +389,45 @@ mod tests {
         let record1 = factory.create_record(input.clone()).await.unwrap();
         let record2 = factory.create_record(input).await.unwrap();
 
-        let signed1 = factory.sign(SignRecordInput {
-            record: record1,
-            key_id: None,
-        }).await.unwrap();
+        let signed1 = factory
+            .sign(SignRecordInput {
+                record: record1,
+                key_id: None,
+            })
+            .await
+            .unwrap();
 
-        let signed2 = factory.sign(SignRecordInput {
-            record: record2,
-            key_id: None,
-        }).await.unwrap();
+        let signed2 = factory
+            .sign(SignRecordInput {
+                record: record2,
+                key_id: None,
+            })
+            .await
+            .unwrap();
 
         // Different execution_ids mean different records, so signatures differ
         // Test: same record should produce same signature
         let record3 = factory.create_record(sample_input()).await.unwrap();
-        let signed3 = factory.sign(SignRecordInput {
-            record: record3.clone(),
-            key_id: None,
-        }).await.unwrap();
+        let signed3 = factory
+            .sign(SignRecordInput {
+                record: record3.clone(),
+                key_id: None,
+            })
+            .await
+            .unwrap();
 
-        let signed3_again = factory.sign(SignRecordInput {
-            record: record3,
-            key_id: None,
-        }).await.unwrap();
+        let signed3_again = factory
+            .sign(SignRecordInput {
+                record: record3,
+                key_id: None,
+            })
+            .await
+            .unwrap();
 
-        assert_eq!(signed3.signature, signed3_again.signature,
-            "Same record signed twice should produce same signature");
+        assert_eq!(
+            signed3.signature, signed3_again.signature,
+            "Same record signed twice should produce same signature"
+        );
     }
 
     #[tokio::test]
@@ -422,10 +435,13 @@ mod tests {
         let factory = AuditRecordFactoryImpl::new(Some(test_key()), Some("my-key-1".to_string()));
         let record = factory.create_record(sample_input()).await.unwrap();
 
-        let output = factory.sign(SignRecordInput {
-            record,
-            key_id: None,
-        }).await.unwrap();
+        let output = factory
+            .sign(SignRecordInput {
+                record,
+                key_id: None,
+            })
+            .await
+            .unwrap();
 
         assert_eq!(output.key_id, "my-key-1");
     }
@@ -435,10 +451,13 @@ mod tests {
         let factory = AuditRecordFactoryImpl::new(Some(test_key()), None);
         let record = factory.create_record(sample_input()).await.unwrap();
 
-        let output = factory.sign(SignRecordInput {
-            record,
-            key_id: None,
-        }).await.unwrap();
+        let output = factory
+            .sign(SignRecordInput {
+                record,
+                key_id: None,
+            })
+            .await
+            .unwrap();
 
         assert_eq!(output.key_id, "default");
     }

--- a/actions/src/audit_posting/application/factory.rs
+++ b/actions/src/audit_posting/application/factory.rs
@@ -47,10 +47,7 @@ pub trait AuditRecordFactory: Send + Sync {
     ///
     /// Recomputes the signature and compares it to the stored signature.
     /// Returns `SignatureMismatch` if they don't match.
-    async fn verify(
-        &self,
-        record: &SignedAuditRecord,
-    ) -> Result<bool, AuditPostingError>;
+    async fn verify(&self, record: &SignedAuditRecord) -> Result<bool, AuditPostingError>;
 }
 
 /// Factory for constructing `AuditBackend` instances.
@@ -71,7 +68,5 @@ pub trait AuditBackendFactory: Send + Sync {
     /// Create the default filesystem-based audit backend.
     ///
     /// Uses the configured filesystem path or a sensible default.
-    async fn create_default(
-        &self,
-    ) -> Result<Box<dyn AuditBackend>, AuditPostingError>;
+    async fn create_default(&self) -> Result<Box<dyn AuditBackend>, AuditPostingError>;
 }

--- a/actions/src/audit_posting/application/service.rs
+++ b/actions/src/audit_posting/application/service.rs
@@ -18,9 +18,8 @@ use async_trait::async_trait;
 use crate::audit_posting::domain::AuditPostingError;
 
 use super::dto::{
-    CreateRecordInput, CreateRecordOutput, PostRecordInput,
-    PostRecordOutput, QueueRecordInput, QueueRecordOutput, SignRecordInput, SignRecordOutput,
-    VerifyRecordInput, VerifyRecordOutput,
+    CreateRecordInput, CreateRecordOutput, PostRecordInput, PostRecordOutput, QueueRecordInput,
+    QueueRecordOutput, SignRecordInput, SignRecordOutput, VerifyRecordInput, VerifyRecordOutput,
 };
 
 /// Central service for posting HMAC-signed audit records.
@@ -94,7 +93,10 @@ pub trait AuditRecordQueue: Send + Sync {
     /// Enqueue a failed record for later retry.
     ///
     /// Returns `QueueFull` error if the queue is at capacity.
-    async fn enqueue(&self, input: QueueRecordInput) -> Result<QueueRecordOutput, AuditPostingError>;
+    async fn enqueue(
+        &self,
+        input: QueueRecordInput,
+    ) -> Result<QueueRecordOutput, AuditPostingError>;
 
     /// Dequeue the next pending record (FIFO order).
     ///

--- a/actions/src/audit_posting/domain/error.rs
+++ b/actions/src/audit_posting/domain/error.rs
@@ -55,7 +55,9 @@ pub enum AuditPostingError {
     },
 
     /// HMAC signature verification failed on a retrieved record.
-    #[error("Audit record HMAC signature verification failed: expected {expected_prefix}, got {received_prefix}")]
+    #[error(
+        "Audit record HMAC signature verification failed: expected {expected_prefix}, got {received_prefix}"
+    )]
     SignatureMismatch {
         /// Expected signature prefix (truncated for display).
         expected_prefix: String,

--- a/actions/src/audit_posting/infrastructure/filesystem_audit_backend.rs
+++ b/actions/src/audit_posting/infrastructure/filesystem_audit_backend.rs
@@ -49,17 +49,13 @@ impl FilesystemAuditBackendImpl {
     /// Atomically write content to a file using write-rename pattern.
     fn atomic_write(path: &Path, content: &str) -> Result<(), AuditPostingError> {
         let temp_path = path.with_extension("tmp");
-        std::fs::write(&temp_path, content).map_err(|e| {
-            AuditPostingError::FilesystemError {
-                detail: format!("Failed to write temp file: {e}"),
-                os_error: e.raw_os_error(),
-            }
+        std::fs::write(&temp_path, content).map_err(|e| AuditPostingError::FilesystemError {
+            detail: format!("Failed to write temp file: {e}"),
+            os_error: e.raw_os_error(),
         })?;
-        std::fs::rename(&temp_path, path).map_err(|e| {
-            AuditPostingError::FilesystemError {
-                detail: format!("Failed to rename temp file: {e}"),
-                os_error: e.raw_os_error(),
-            }
+        std::fs::rename(&temp_path, path).map_err(|e| AuditPostingError::FilesystemError {
+            detail: format!("Failed to rename temp file: {e}"),
+            os_error: e.raw_os_error(),
         })?;
         Ok(())
     }
@@ -101,12 +97,12 @@ impl AuditBackend for FilesystemAuditBackendImpl {
             });
         }
 
-        let content = tokio::fs::read_to_string(&path)
-            .await
-            .map_err(|e| AuditPostingError::FilesystemError {
+        let content = tokio::fs::read_to_string(&path).await.map_err(|e| {
+            AuditPostingError::FilesystemError {
                 detail: format!("Failed to read record: {e}"),
                 os_error: e.raw_os_error(),
-            })?;
+            }
+        })?;
 
         let record: SignedAuditRecord =
             serde_json::from_str(&content).map_err(|e| AuditPostingError::SerializationFailed {
@@ -137,20 +133,22 @@ impl AuditBackend for FilesystemAuditBackendImpl {
         let mut records = Vec::new();
         let max = limit.unwrap_or(100) as usize;
 
-        let mut dir = tokio::fs::read_dir(&self.storage_dir)
-            .await
-            .map_err(|e| AuditPostingError::FilesystemError {
+        let mut dir = tokio::fs::read_dir(&self.storage_dir).await.map_err(|e| {
+            AuditPostingError::FilesystemError {
                 detail: format!("Failed to read directory: {e}"),
                 os_error: e.raw_os_error(),
-            })?;
+            }
+        })?;
 
         let mut sorted_entries: Vec<PathBuf> = Vec::new();
-        while let Some(entry) = dir.next_entry().await.map_err(|e| {
-            AuditPostingError::FilesystemError {
-                detail: format!("Failed to read directory entry: {e}"),
-                os_error: e.raw_os_error(),
-            }
-        })? {
+        while let Some(entry) =
+            dir.next_entry()
+                .await
+                .map_err(|e| AuditPostingError::FilesystemError {
+                    detail: format!("Failed to read directory entry: {e}"),
+                    os_error: e.raw_os_error(),
+                })?
+        {
             let path = entry.path();
             if path.extension().is_some_and(|ext| ext == "json") {
                 sorted_entries.push(path);
@@ -169,12 +167,12 @@ impl AuditBackend for FilesystemAuditBackendImpl {
                 break;
             }
 
-            let content = tokio::fs::read_to_string(&path)
-                .await
-                .map_err(|e| AuditPostingError::FilesystemError {
+            let content = tokio::fs::read_to_string(&path).await.map_err(|e| {
+                AuditPostingError::FilesystemError {
                     detail: format!("Failed to read record: {e}"),
                     os_error: e.raw_os_error(),
-                })?;
+                }
+            })?;
 
             if let Ok(record) = serde_json::from_str::<SignedAuditRecord>(&content) {
                 // Apply date filters
@@ -199,12 +197,12 @@ impl AuditBackend for FilesystemAuditBackendImpl {
     async fn delete(&self, execution_id: &uuid::Uuid) -> Result<(), AuditPostingError> {
         let path = self.record_path_internal(execution_id);
         if path.exists() {
-            tokio::fs::remove_file(&path)
-                .await
-                .map_err(|e| AuditPostingError::FilesystemError {
+            tokio::fs::remove_file(&path).await.map_err(|e| {
+                AuditPostingError::FilesystemError {
                     detail: format!("Failed to delete record: {e}"),
                     os_error: e.raw_os_error(),
-                })?;
+                }
+            })?;
         }
         Ok(())
     }
@@ -227,22 +225,27 @@ impl AuditBackend for FilesystemAuditBackendImpl {
     }
 
     #[tracing::instrument(skip_all)]
-    async fn prune(&self, older_than: chrono::DateTime<chrono::Utc>) -> Result<u64, AuditPostingError> {
+    async fn prune(
+        &self,
+        older_than: chrono::DateTime<chrono::Utc>,
+    ) -> Result<u64, AuditPostingError> {
         let mut deleted = 0u64;
 
-        let mut dir = tokio::fs::read_dir(&self.storage_dir)
-            .await
-            .map_err(|e| AuditPostingError::FilesystemError {
+        let mut dir = tokio::fs::read_dir(&self.storage_dir).await.map_err(|e| {
+            AuditPostingError::FilesystemError {
                 detail: format!("Failed to read directory: {e}"),
                 os_error: e.raw_os_error(),
-            })?;
-
-        while let Some(entry) = dir.next_entry().await.map_err(|e| {
-            AuditPostingError::FilesystemError {
-                detail: format!("Failed to read directory entry: {e}"),
-                os_error: e.raw_os_error(),
             }
-        })? {
+        })?;
+
+        while let Some(entry) =
+            dir.next_entry()
+                .await
+                .map_err(|e| AuditPostingError::FilesystemError {
+                    detail: format!("Failed to read directory entry: {e}"),
+                    os_error: e.raw_os_error(),
+                })?
+        {
             let path = entry.path();
             if path.extension().is_some_and(|ext| ext == "json") {
                 let content = tokio::fs::read_to_string(&path).await.unwrap_or_default();
@@ -272,18 +275,14 @@ impl FilesystemAuditBackend for FilesystemAuditBackendImpl {
     }
 
     fn serialize_record(&self, record: &SignedAuditRecord) -> Result<String, AuditPostingError> {
-        serde_json::to_string_pretty(record).map_err(|e| {
-            AuditPostingError::SerializationFailed {
-                detail: e.to_string(),
-            }
+        serde_json::to_string_pretty(record).map_err(|e| AuditPostingError::SerializationFailed {
+            detail: e.to_string(),
         })
     }
 
     fn deserialize_record(&self, json: &str) -> Result<SignedAuditRecord, AuditPostingError> {
-        serde_json::from_str(json).map_err(|e| {
-            AuditPostingError::SerializationFailed {
-                detail: e.to_string(),
-            }
+        serde_json::from_str(json).map_err(|e| AuditPostingError::SerializationFailed {
+            detail: e.to_string(),
         })
     }
 }
@@ -330,7 +329,10 @@ mod tests {
         };
         let load_output = backend.load(load_input).await.unwrap();
         assert!(load_output.record.is_some());
-        assert_eq!(load_output.record.unwrap().execution_id, record.execution_id);
+        assert_eq!(
+            load_output.record.unwrap().execution_id,
+            record.execution_id
+        );
     }
 
     #[tokio::test]

--- a/actions/src/audit_posting/infrastructure/http_audit_backend.rs
+++ b/actions/src/audit_posting/infrastructure/http_audit_backend.rs
@@ -51,10 +51,7 @@ impl HttpAuditBackend {
     }
 
     /// Create a new HTTP audit backend with a custom timeout.
-    pub fn with_timeout(
-        default_backend_url: Option<String>,
-        default_timeout_secs: u64,
-    ) -> Self {
+    pub fn with_timeout(default_backend_url: Option<String>, default_timeout_secs: u64) -> Self {
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(default_timeout_secs))
             .build()

--- a/actions/src/audit_posting/infrastructure/repository/mod.rs
+++ b/actions/src/audit_posting/infrastructure/repository/mod.rs
@@ -25,7 +25,7 @@ use async_trait::async_trait;
 use crate::audit_posting::domain::{AuditPostingError, SignedAuditRecord};
 
 use crate::audit_posting::application::dto::{
-    PostRecordInput, PostRecordOutput, LoadRecordInput, LoadRecordOutput,
+    LoadRecordInput, LoadRecordOutput, PostRecordInput, PostRecordOutput,
 };
 
 // ---------------------------------------------------------------------------
@@ -95,7 +95,10 @@ pub trait AuditBackend: Send + Sync + std::fmt::Debug {
     /// Delete records older than the given timestamp.
     ///
     /// Returns the number of deleted records.
-    async fn prune(&self, older_than: chrono::DateTime<chrono::Utc>) -> Result<u64, AuditPostingError>;
+    async fn prune(
+        &self,
+        older_than: chrono::DateTime<chrono::Utc>,
+    ) -> Result<u64, AuditPostingError>;
 }
 
 // ---------------------------------------------------------------------------

--- a/actions/src/lib.rs
+++ b/actions/src/lib.rs
@@ -43,11 +43,11 @@ pub mod shared;
 
 // ── Phase 1: Contract Freeze — interface-only declarations ──
 // ── Phase 5: action_entrypoint — interface-only (contract frozen) ──
+pub mod action_entrypoint;
 pub mod action_input;
 pub mod action_output;
+pub mod audit_posting; // Phase 1: Contract Freeze (issue-contract-freeze)
 pub mod ci_integration;
 pub mod diff_analyzer; // Phase 1: Contract Freeze (issue-contract-freeze)
 pub mod policy_evaluator;
-pub mod security_config; // Phase 1: Contract Freeze (issue-contract-freeze) // Phase 1: Contract Freeze (issue-contract-freeze) // Phase 1: Contract Freeze (issue-contract-freeze)
-pub mod audit_posting;      // Phase 1: Contract Freeze (issue-contract-freeze)
-pub mod action_entrypoint;  // Phase 1: Contract Freeze (issue-contract-freeze)
+pub mod security_config; // Phase 1: Contract Freeze (issue-contract-freeze) // Phase 1: Contract Freeze (issue-contract-freeze) // Phase 1: Contract Freeze (issue-contract-freeze) // Phase 1: Contract Freeze (issue-contract-freeze)


### PR DESCRIPTION
## ActionContext Implementation

GitHub Actions environment parsed into a typed context.

### Implementation

- **ContextBuilderImpl** — builds ActionContext from GITHUB_* env vars and event payloads
- **ContextRepositoryImpl** — reads real env vars (std::env::var) and filesystem (tokio::fs)
- Event payload parsing for: workflow_dispatch, issue_comment, pull_request, push, unknown
- Mode resolution: explicit INPUT_MODE > event type heuristic > fallback
- Intent injection from INPUT_INTENT
- All optional config fields supported (max iterations, LLM limits, profile, permission)

### Tests (14 unit tests)

Full coverage of all event types, mode overrides, intent injection, env overrides,
error handling, and configuration parsing.

### Verification
- All 409 tests pass
- Build compiles cleanly

Closes #615