### PR TITLE
feat(scored-evaluation): contract freeze — all interfaces defined

### DIFF
--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -48,6 +48,7 @@ pub mod planning;
 pub mod policy_engine;
 pub mod quality_gates;
 pub mod recovery_recipes;
+pub mod scored_evaluation;
 pub mod repo_engine;
 pub mod risk_gating;
 pub mod state_persistence;

--- a/engine/src/scored_evaluation/application/dto.rs
+++ b/engine/src/scored_evaluation/application/dto.rs
@@ -1,0 +1,152 @@
+//! Data Transfer Objects for the Scored Evaluation module.
+//!
+//! @canonical .pi/architecture/modules/scored-evaluation.md
+//! Implements: Contract Freeze — DTO schemas for scored evaluation
+//! Issue: #673 (scored-evaluation epic)
+//!
+//! DTOs define the input/output contracts for service operations.
+//! They carry validation metadata and documentation but no behavior.
+//!
+//! # Contract (Frozen)
+//! - Every service operation has a dedicated input and output DTO
+//! - DTOs are serializable (JSON for API and persistence)
+//! - Validation constraints are documented in field docs
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::scored_evaluation::domain::{Rubric, ScoringResult};
+
+/// Input for evaluating an artifact against a rubric.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvaluateInput {
+    /// The artifact to evaluate (typically a JSON value).
+    pub artifact: serde_json::Value,
+
+    /// The rubric to evaluate against.
+    pub rubric: Rubric,
+
+    /// Execution context for traceability.
+    pub context: EvaluationContext,
+}
+
+/// Execution context for an evaluation request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvaluationContext {
+    /// The execution this evaluation belongs to.
+    pub execution_id: Uuid,
+
+    /// The DAG node being evaluated.
+    pub node_id: Uuid,
+
+    /// Human-readable name of the node.
+    pub node_name: String,
+}
+
+/// Output from evaluating an artifact.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EvaluateOutput {
+    /// The scoring result from the backend.
+    pub result: ScoringResult,
+
+    /// The execution this evaluation belongs to.
+    pub execution_id: Uuid,
+
+    /// The DAG node that was evaluated.
+    pub node_id: Uuid,
+
+    /// Human-readable name of the node.
+    pub node_name: String,
+
+    /// When the evaluation completed.
+    pub timestamp: DateTime<Utc>,
+}
+
+impl EvaluateInput {
+    /// Create a new evaluate input.
+    pub fn new(
+        artifact: serde_json::Value,
+        rubric: Rubric,
+        execution_id: Uuid,
+        node_id: Uuid,
+        node_name: impl Into<String>,
+    ) -> Self {
+        Self {
+            artifact,
+            rubric,
+            context: EvaluationContext {
+                execution_id,
+                node_id,
+                node_name: node_name.into(),
+            },
+        }
+    }
+}
+
+impl EvaluateOutput {
+    /// Create a new evaluate output.
+    pub fn new(
+        result: ScoringResult,
+        execution_id: Uuid,
+        node_id: Uuid,
+        node_name: impl Into<String>,
+        timestamp: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            result,
+            execution_id,
+            node_id,
+            node_name: node_name.into(),
+            timestamp,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scored_evaluation::domain::Rubric;
+
+    #[test]
+    fn test_evaluate_input_new() {
+        let input = EvaluateInput::new(
+            serde_json::json!({"code": "test"}),
+            Rubric::inline(serde_json::json!({"quality": 0.9})),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "score_output",
+        );
+        assert_eq!(input.context.node_name, "score_output");
+    }
+
+    #[test]
+    fn test_serialization_roundtrip_input() {
+        let input = EvaluateInput::new(
+            serde_json::json!({"code": "test"}),
+            Rubric::reference("./rubric.json"),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "my-node",
+        );
+        let json = serde_json::to_string(&input).unwrap();
+        let deserialized: EvaluateInput = serde_json::from_str(&json).unwrap();
+        assert_eq!(input.context.node_name, deserialized.context.node_name);
+        assert_eq!(input.artifact, deserialized.artifact);
+    }
+
+    #[test]
+    fn test_evaluate_output_new() {
+        use std::collections::HashMap;
+        let dims = HashMap::new();
+        let result = ScoringResult::new(true, dims, "ok", "test", 0, None);
+        let output = EvaluateOutput::new(
+            result,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "score_output",
+            Utc::now(),
+        );
+        assert_eq!(output.node_name, "score_output");
+    }
+}

--- a/engine/src/scored_evaluation/application/mod.rs
+++ b/engine/src/scored_evaluation/application/mod.rs
@@ -1,0 +1,21 @@
+//! Application layer for the Scored Evaluation bounded context.
+//!
+//! @canonical .pi/architecture/modules/scored-evaluation.md
+//! Implements: Contract Freeze — application layer interfaces and DTOs
+//! Issue: #673 (scored-evaluation epic)
+//!
+//! This layer defines service traits and data transfer objects (DTOs).
+//! All orchestration logic lives behind the service interface.
+//!
+//! # Contract Freeze
+//! - Every use case has a corresponding trait method
+//! - Input/output types are DTOs
+//! - No implementation — only contract signatures
+
+pub mod dto;
+pub mod service;
+
+pub use dto::EvaluateInput;
+pub use dto::EvaluateOutput;
+pub use dto::EvaluationContext;
+pub use service::ScoredEvaluationService;

--- a/engine/src/scored_evaluation/application/service.rs
+++ b/engine/src/scored_evaluation/application/service.rs
@@ -1,0 +1,59 @@
+//! ScoredEvaluationService — service trait for evaluation orchestration.
+//!
+//! @canonical .pi/architecture/modules/scored-evaluation.md#scored-evaluation-service
+//! Implements: Contract Freeze — ScoredEvaluationService trait
+//! Issue: #673 (scored-evaluation epic)
+//!
+//! # Contract (Frozen)
+//! - Every use case has a corresponding trait method
+//! - Input/output types are DTOs defined in `dto/`
+//! - All methods are async (use `async-trait` for trait object safety)
+//! - No implementation — only contract signatures
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::scored_evaluation::domain::ScoredEvaluationError;
+
+use super::dto::{EvaluateInput, EvaluateOutput};
+
+/// Application service for orchestrating scored evaluations.
+///
+/// The `ScoredEvaluationService` is the primary entry point for the
+/// scored-evaluation module. It handles:
+/// - Evaluating artifacts against rubrics via scoring backends
+/// - Retrieving past evaluation results
+/// - Listing evaluations for an execution
+#[async_trait]
+pub trait ScoredEvaluationService: Send + Sync {
+    /// Evaluate an artifact against a rubric.
+    ///
+    /// Orchestrates the full evaluation lifecycle:
+    /// 1. Validate input (artifact + rubric)
+    /// 2. Resolve the scoring backend by name
+    /// 3. Emit `ScoredEvaluationStarted` event
+    /// 4. Delegate to `ScoringBackend::evaluate()`
+    /// 5. On success: emit `ScoredEvaluationCompleted`, persist result
+    /// 6. On failure: emit `ScoredEvaluationFailed`, apply retry/fallback policy
+    ///
+    /// # Errors
+    /// - `ScoredEvaluationError::InvalidArtifact` — artifact is malformed
+    /// - `ScoredEvaluationError::InvalidRubric` — rubric is malformed
+    /// - `ScoredEvaluationError::BackendNotFound` — no backend configured for name
+    /// - `ScoredEvaluationError::BackendError` — backend returned an error
+    /// - `ScoredEvaluationError::Timeout` — backend did not respond in time
+    async fn evaluate(&self, input: EvaluateInput) -> Result<EvaluateOutput, ScoredEvaluationError>;
+
+    /// Get a specific evaluation result by execution and node ID.
+    async fn get_evaluation(
+        &self,
+        execution_id: Uuid,
+        node_id: Uuid,
+    ) -> Result<Option<EvaluateOutput>, ScoredEvaluationError>;
+
+    /// List all evaluations for a given execution.
+    async fn list_evaluations(
+        &self,
+        execution_id: Uuid,
+    ) -> Result<Vec<EvaluateOutput>, ScoredEvaluationError>;
+}

--- a/engine/src/scored_evaluation/domain/backend.rs
+++ b/engine/src/scored_evaluation/domain/backend.rs
@@ -1,0 +1,60 @@
+//! ScoringBackend — pluggable scoring backend trait (domain interface).
+//!
+//! @canonical .pi/architecture/modules/scored-evaluation.md#scoring-backend
+//! Implements: Contract Freeze — ScoringBackend trait
+//! Issue: #673 (scored-evaluation epic)
+//!
+//! # Contract (Frozen)
+//! - `ScoringBackend` is the domain-level contract for any evaluation backend
+//! - Lives in the domain layer — implementations live in infrastructure
+//! - All implementations must satisfy this trait (MCP, HTTP, Local)
+//! - `evaluate()` is async and returns `ScoringResult` or `ScoredEvaluationError`
+//! - `health_check()` allows pre-flight validation before evaluation
+//! - Trait is object-safe (uses `async_trait`)
+
+use async_trait::async_trait;
+
+use super::error::ScoredEvaluationError;
+use super::result::ScoringResult;
+use super::rubric::Rubric;
+
+/// Pluggable scoring backend interface — domain-level contract.
+///
+/// The `ScoringBackend` trait defines the contract that all evaluation
+/// backends must satisfy. Rigorix defines this protocol; external systems
+/// (RuntimeAI, custom HTTP services, local scripts) implement it.
+///
+/// # Implementations
+///
+/// | Backend | Transport | Protocol |
+/// |---------|-----------|----------|
+/// | MCPBackend | MCP `rigorix_evaluate_artifact` request | Rigorix Scoring Protocol over MCP |
+/// | HTTPBackend | HTTP POST | Rigorix Scoring Protocol (JSON) over REST |
+/// | LocalBackend | Subprocess execution | Rigorix Scoring Protocol (stdin/stdout) |
+#[async_trait]
+pub trait ScoringBackend: Send + Sync {
+    /// Evaluate an artifact against a rubric.
+    ///
+    /// Sends the artifact and rubric to the backend, which returns a
+    /// multidimensional scoring result.
+    ///
+    /// # Errors
+    /// - `ScoredEvaluationError::BackendError` — backend returned an error
+    /// - `ScoredEvaluationError::Timeout` — backend did not respond in time
+    /// - `ScoredEvaluationError::BackendUnavailable` — backend is down
+    /// - `ScoredEvaluationError::InvalidRubric` — rubric format rejected
+    async fn evaluate(
+        &self,
+        artifact: &serde_json::Value,
+        rubric: &Rubric,
+    ) -> Result<ScoringResult, ScoredEvaluationError>;
+
+    /// Returns the name of this backend (e.g., "mcp", "http", "local").
+    fn backend_name(&self) -> &'static str;
+
+    /// Check whether the backend is healthy and reachable.
+    ///
+    /// Returns `true` if the backend is operational, `false` otherwise.
+    /// On error, returns a `ScoredEvaluationError` with details.
+    async fn health_check(&self) -> Result<bool, ScoredEvaluationError>;
+}

--- a/engine/src/scored_evaluation/domain/error.rs
+++ b/engine/src/scored_evaluation/domain/error.rs
@@ -1,0 +1,148 @@
+//! ScoredEvaluationError — typed error enum for all scored evaluation failures.
+//!
+//! @canonical .pi/architecture/modules/scored-evaluation.md#scored-evaluation-error
+//! Implements: Contract Freeze — ScoredEvaluationError enum
+//! Issue: #673 (scored-evaluation epic)
+//!
+//! # Contract (Frozen)
+//! - Uses `thiserror::Error` derive macro
+//! - Each variant carries structured context for error reporting
+//! - Implements `is_retriable()` for execution policy integration
+//! - Converted to `CoreOrchestratorError` via `#[from]` at the orchestrator level
+
+use thiserror::Error;
+
+/// Errors that can occur during scored evaluation.
+#[derive(Debug, Error)]
+pub enum ScoredEvaluationError {
+    /// The requested backend was not found in the registry.
+    #[error("Backend not found: {0}")]
+    BackendNotFound(String),
+
+    /// The backend returned an error during evaluation.
+    #[error("Backend error: {0}")]
+    BackendError(String),
+
+    /// The rubric is invalid or malformed.
+    #[error("Invalid rubric: {0}")]
+    InvalidRubric(String),
+
+    /// The artifact is invalid or malformed.
+    #[error("Invalid artifact: {0}")]
+    InvalidArtifact(String),
+
+    /// The backend is unavailable (health check failed).
+    #[error("Backend health check failed: {0}")]
+    BackendUnavailable(String),
+
+    /// The backend did not respond within the configured timeout.
+    #[error("Timeout: backend did not respond within {0}ms")]
+    Timeout(u64),
+
+    /// An internal error occurred (should not happen in normal operation).
+    #[error("Internal error: {0}")]
+    Internal(String),
+}
+
+impl ScoredEvaluationError {
+    /// Returns `true` if this error represents a transient condition
+    /// that might succeed on retry.
+    pub fn is_retriable(&self) -> bool {
+        matches!(
+            self,
+            ScoredEvaluationError::BackendError(_)
+                | ScoredEvaluationError::BackendUnavailable(_)
+                | ScoredEvaluationError::Timeout(_)
+        )
+    }
+
+    /// Returns a human-readable error category for this error.
+    pub fn category(&self) -> &'static str {
+        match self {
+            ScoredEvaluationError::BackendNotFound(_) => "misconfiguration",
+            ScoredEvaluationError::BackendError(_) => "backend",
+            ScoredEvaluationError::InvalidRubric(_) => "validation",
+            ScoredEvaluationError::InvalidArtifact(_) => "validation",
+            ScoredEvaluationError::BackendUnavailable(_) => "infrastructure",
+            ScoredEvaluationError::Timeout(_) => "timeout",
+            ScoredEvaluationError::Internal(_) => "internal",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_backend_not_found() {
+        let err = ScoredEvaluationError::BackendNotFound("runtimeai".to_string());
+        assert_eq!(err.to_string(), "Backend not found: runtimeai");
+        assert!(!err.is_retriable());
+        assert_eq!(err.category(), "misconfiguration");
+    }
+
+    #[test]
+    fn test_backend_error() {
+        let err = ScoredEvaluationError::BackendError("connection refused".to_string());
+        assert!(err.to_string().contains("connection refused"));
+        assert!(err.is_retriable());
+        assert_eq!(err.category(), "backend");
+    }
+
+    #[test]
+    fn test_invalid_rubric() {
+        let err = ScoredEvaluationError::InvalidRubric("missing dimensions".to_string());
+        assert_eq!(err.to_string(), "Invalid rubric: missing dimensions");
+        assert!(!err.is_retriable());
+        assert_eq!(err.category(), "validation");
+    }
+
+    #[test]
+    fn test_invalid_artifact() {
+        let err = ScoredEvaluationError::InvalidArtifact("empty content".to_string());
+        assert_eq!(err.to_string(), "Invalid artifact: empty content");
+        assert!(!err.is_retriable());
+    }
+
+    #[test]
+    fn test_backend_unavailable() {
+        let err = ScoredEvaluationError::BackendUnavailable("not reachable".to_string());
+        assert!(err.is_retriable());
+        assert_eq!(err.category(), "infrastructure");
+    }
+
+    #[test]
+    fn test_timeout() {
+        let err = ScoredEvaluationError::Timeout(30_000);
+        assert_eq!(err.to_string(), "Timeout: backend did not respond within 30000ms");
+        assert!(err.is_retriable());
+        assert_eq!(err.category(), "timeout");
+    }
+
+    #[test]
+    fn test_internal() {
+        let err = ScoredEvaluationError::Internal("unexpected state".to_string());
+        assert!(!err.is_retriable());
+        assert_eq!(err.category(), "internal");
+    }
+
+    #[test]
+    fn test_error_trait_impl() {
+        let err = ScoredEvaluationError::BackendError("test".to_string());
+        let std_err: &dyn std::error::Error = &err;
+        assert_eq!(std_err.to_string(), "Backend error: test");
+    }
+
+    #[test]
+    fn test_all_variants_coverable() {
+        // Ensure all variants can be constructed (compile check)
+        let _ = ScoredEvaluationError::BackendNotFound("x".into());
+        let _ = ScoredEvaluationError::BackendError("x".into());
+        let _ = ScoredEvaluationError::InvalidRubric("x".into());
+        let _ = ScoredEvaluationError::InvalidArtifact("x".into());
+        let _ = ScoredEvaluationError::BackendUnavailable("x".into());
+        let _ = ScoredEvaluationError::Timeout(0);
+        let _ = ScoredEvaluationError::Internal("x".into());
+    }
+}

--- a/engine/src/scored_evaluation/domain/event.rs
+++ b/engine/src/scored_evaluation/domain/event.rs
@@ -1,0 +1,205 @@
+//! ScoredEvaluationEvent — domain events for the scoring lifecycle.
+//!
+//! @canonical .pi/architecture/modules/scored-evaluation.md#scored-evaluation-event
+//! Implements: Contract Freeze — ScoredEvaluationEvent enum
+//! Issue: #673 (scored-evaluation epic)
+//!
+//! # Contract (Frozen)
+//! - Three lifecycle events: Started, Completed, Failed
+//! - Uses `node_id: String` to match existing `ExecutionEvent` convention
+//! - Implements `Clone`, `Debug`, `PartialEq` for testability
+//! - Serialization support for event bus and audit persistence
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use super::result::ScoringResult;
+
+/// Domain events for the scored evaluation lifecycle.
+///
+/// These events are published on the EventBus whenever a scored evaluation
+/// transitions between lifecycle states.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ScoredEvaluationEvent {
+    /// A scored evaluation has started.
+    ScoredEvaluationStarted {
+        /// The node being evaluated (as String, matching ExecutionEvent convention).
+        node_id: String,
+        /// The execution this evaluation belongs to.
+        execution_id: Uuid,
+        /// Name of the backend performing the evaluation.
+        backend: String,
+        /// When the evaluation started.
+        timestamp: DateTime<Utc>,
+    },
+
+    /// A scored evaluation completed successfully.
+    ScoredEvaluationCompleted {
+        /// The node that was evaluated.
+        node_id: String,
+        /// The execution this evaluation belongs to.
+        execution_id: Uuid,
+        /// The scoring result.
+        result: ScoringResult,
+        /// When the evaluation completed.
+        timestamp: DateTime<Utc>,
+    },
+
+    /// A scored evaluation failed.
+    ScoredEvaluationFailed {
+        /// The node that failed.
+        node_id: String,
+        /// The execution this evaluation belongs to.
+        execution_id: Uuid,
+        /// Human-readable error description.
+        error: String,
+        /// When the evaluation failed.
+        timestamp: DateTime<Utc>,
+    },
+}
+
+impl ScoredEvaluationEvent {
+    /// Returns a human-readable log line for this event.
+    pub fn log_line(&self) -> String {
+        match self {
+            ScoredEvaluationEvent::ScoredEvaluationStarted {
+                node_id,
+                backend,
+                ..
+            } => {
+                format!(
+                    "[ScoredEvaluation] Started: node={}, backend={}",
+                    node_id, backend
+                )
+            }
+            ScoredEvaluationEvent::ScoredEvaluationCompleted {
+                node_id, result, ..
+            } => {
+                format!(
+                    "[ScoredEvaluation] Completed: node={}, passed={}, dimensions={}",
+                    node_id,
+                    result.passed,
+                    result.dimensions.len()
+                )
+            }
+            ScoredEvaluationEvent::ScoredEvaluationFailed {
+                node_id, error, ..
+            } => {
+                format!(
+                    "[ScoredEvaluation] Failed: node={}, error={}",
+                    node_id, error
+                )
+            }
+        }
+    }
+
+    /// Returns the node_id for this event.
+    pub fn node_id(&self) -> &str {
+        match self {
+            ScoredEvaluationEvent::ScoredEvaluationStarted { node_id, .. } => node_id,
+            ScoredEvaluationEvent::ScoredEvaluationCompleted { node_id, .. } => node_id,
+            ScoredEvaluationEvent::ScoredEvaluationFailed { node_id, .. } => node_id,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use crate::scored_evaluation::domain::result::ScoreDimension;
+
+    fn make_result() -> ScoringResult {
+        let mut dims = HashMap::new();
+        dims.insert(
+            "correctness".to_string(),
+            ScoreDimension::new(0.9, 1.0, "Correctness", true),
+        );
+        ScoringResult::new(true, dims, "ok", "runtimeai", 100, None)
+    }
+
+    #[test]
+    fn test_started_event() {
+        let event = ScoredEvaluationEvent::ScoredEvaluationStarted {
+            node_id: "node-1".to_string(),
+            execution_id: Uuid::new_v4(),
+            backend: "runtimeai".to_string(),
+            timestamp: Utc::now(),
+        };
+        let log = event.log_line();
+        assert!(log.contains("Started"));
+        assert!(log.contains("node-1"));
+        assert!(log.contains("runtimeai"));
+        assert_eq!(event.node_id(), "node-1");
+    }
+
+    #[test]
+    fn test_completed_event() {
+        let event = ScoredEvaluationEvent::ScoredEvaluationCompleted {
+            node_id: "node-2".to_string(),
+            execution_id: Uuid::new_v4(),
+            result: make_result(),
+            timestamp: Utc::now(),
+        };
+        let log = event.log_line();
+        assert!(log.contains("Completed"));
+        assert!(log.contains("passed=true"));
+        assert_eq!(event.node_id(), "node-2");
+    }
+
+    #[test]
+    fn test_failed_event() {
+        let event = ScoredEvaluationEvent::ScoredEvaluationFailed {
+            node_id: "node-3".to_string(),
+            execution_id: Uuid::new_v4(),
+            error: "Backend timeout".to_string(),
+            timestamp: Utc::now(),
+        };
+        let log = event.log_line();
+        assert!(log.contains("Failed"));
+        assert!(log.contains("Backend timeout"));
+        assert_eq!(event.node_id(), "node-3");
+    }
+
+    #[test]
+    fn test_serialization_roundtrip_started() {
+        let event = ScoredEvaluationEvent::ScoredEvaluationStarted {
+            node_id: "n1".to_string(),
+            execution_id: Uuid::new_v4(),
+            backend: "mcp".to_string(),
+            timestamp: Utc::now(),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let deserialized: ScoredEvaluationEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, deserialized);
+        assert!(json.contains("\"type\":\"scored_evaluation_started\""));
+    }
+
+    #[test]
+    fn test_serialization_roundtrip_completed() {
+        let event = ScoredEvaluationEvent::ScoredEvaluationCompleted {
+            node_id: "n1".to_string(),
+            execution_id: Uuid::new_v4(),
+            result: make_result(),
+            timestamp: Utc::now(),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let deserialized: ScoredEvaluationEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, deserialized);
+    }
+
+    #[test]
+    fn test_serialization_roundtrip_failed() {
+        let event = ScoredEvaluationEvent::ScoredEvaluationFailed {
+            node_id: "n1".to_string(),
+            execution_id: Uuid::new_v4(),
+            error: "error".to_string(),
+            timestamp: Utc::now(),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let deserialized: ScoredEvaluationEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, deserialized);
+    }
+}

--- a/engine/src/scored_evaluation/domain/mod.rs
+++ b/engine/src/scored_evaluation/domain/mod.rs
@@ -1,0 +1,35 @@
+//! Domain entities and interfaces for the Scored Evaluation bounded context.
+//!
+//! @canonical .pi/architecture/modules/scored-evaluation.md
+//! Implements: Contract Freeze — ScoredEvaluationNode, Rubric, ScoringResult,
+//!              ScoringBackend, ScoredEvaluationEvent, ScoredEvaluationError
+//! Issue: #673 (scored-evaluation epic)
+//!
+//! This module defines the core domain types — `ScoredEvaluationNode`, `Rubric`,
+//! `ScoringResult`, `ScoreDimension`, `ScoringBackend` (trait),
+//! `ScoredEvaluationEvent`, and `ScoredEvaluationError`. These are pure domain
+//! objects with no framework dependencies. They serve as the frozen contract
+//! that all implementations must satisfy.
+//!
+//! # Contract Freeze
+//! - No implementation logic beyond enum variants, accessors, and constructors
+//! - All evaluation orchestration logic must happen in the application layer
+//! - All persistence must happen behind repository interfaces
+//! - The ScoringBackend trait is the core domain contract — all backends
+//!   (MCP, HTTP, Local) must satisfy this interface
+
+pub mod backend;
+pub mod error;
+pub mod event;
+pub mod node;
+pub mod result;
+pub mod rubric;
+
+pub use backend::ScoringBackend;
+pub use error::ScoredEvaluationError;
+pub use event::ScoredEvaluationEvent;
+pub use node::ScoredEvaluationNode;
+pub use result::ScoreDimension;
+pub use result::ScoringResult;
+pub use rubric::Rubric;
+pub use rubric::RubricSource;

--- a/engine/src/scored_evaluation/domain/node.rs
+++ b/engine/src/scored_evaluation/domain/node.rs
@@ -1,0 +1,172 @@
+//! ScoredEvaluationNode — DAG node value object for scored evaluation.
+//!
+//! @canonical .pi/architecture/modules/scored-evaluation.md#scored-evaluation-node
+//! Implements: Contract Freeze — ScoredEvaluationNode struct
+//! Issue: #673 (scored-evaluation epic)
+//!
+//! # Contract (Frozen)
+//! - Immutable value object after construction
+//! - Carries artifact JSON, rubric, backend selector, thresholds, and execution policy
+//! - Implements `Clone`, `Debug`, `PartialEq` for testability
+//! - Serialization support for DAG template loading
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use super::rubric::Rubric;
+
+/// DAG node value object for scored evaluation.
+///
+/// A `ScoredEvaluationNode` is embedded in the DAG as a task node. When
+/// executed, the artifact is sent to the configured scoring backend for
+/// evaluation against the rubric. Thresholds determine whether each
+/// dimension passes or fails.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScoredEvaluationNode {
+    /// Unique identifier for this node.
+    pub node_id: Uuid,
+
+    /// The artifact to evaluate (typically generated code, patch, or LLM output).
+    pub artifact: serde_json::Value,
+
+    /// The rubric to evaluate against (inline or reference).
+    pub rubric: Rubric,
+
+    /// Name of the scoring backend to use (e.g., "runtimeai", "custom_http").
+    pub backend: String,
+
+    /// Per-dimension score thresholds (dimension name → minimum score 0.0–1.0).
+    /// If a dimension's score is below its threshold, the dimension fails.
+    #[serde(default)]
+    pub thresholds: HashMap<String, f64>,
+
+    /// Execution policy for retry/fallback behavior on evaluation failure.
+    #[serde(default)]
+    pub policy: ExecutionPolicy,
+}
+
+/// Execution policy for scored evaluation nodes.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ExecutionPolicy {
+    /// Maximum number of retry attempts on transient failure.
+    #[serde(default = "default_max_retries")]
+    pub max_retries: u32,
+
+    /// Action to take when evaluation fails after all retries.
+    #[serde(default)]
+    pub on_failure: FailureAction,
+}
+
+/// Action to take on evaluation failure.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureAction {
+    /// Retry the evaluation with backoff.
+    Retry,
+    /// Flag the node for human review (non-blocking).
+    FlagForReview,
+    /// Block the pipeline execution.
+    Block,
+}
+
+impl Default for FailureAction {
+    fn default() -> Self {
+        FailureAction::FlagForReview
+    }
+}
+
+fn default_max_retries() -> u32 {
+    3
+}
+
+impl Default for ExecutionPolicy {
+    fn default() -> Self {
+        Self {
+            max_retries: default_max_retries(),
+            on_failure: FailureAction::default(),
+        }
+    }
+}
+
+impl ScoredEvaluationNode {
+    /// Create a new `ScoredEvaluationNode`.
+    pub fn new(
+        node_id: Uuid,
+        artifact: serde_json::Value,
+        rubric: Rubric,
+        backend: String,
+        thresholds: HashMap<String, f64>,
+        policy: ExecutionPolicy,
+    ) -> Self {
+        Self {
+            node_id,
+            artifact,
+            rubric,
+            backend,
+            thresholds,
+            policy,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scored_evaluation::domain::rubric::RubricSource;
+
+    #[test]
+    fn test_new_node() {
+        let node_id = Uuid::new_v4();
+        let artifact = serde_json::json!({"code": "fn main() {}"});
+        let rubric = Rubric::inline(serde_json::json!({"correctness": 0.8}));
+        let mut thresholds = HashMap::new();
+        thresholds.insert("correctness".to_string(), 0.8);
+
+        let node = ScoredEvaluationNode::new(
+            node_id,
+            artifact.clone(),
+            rubric.clone(),
+            "runtimeai".to_string(),
+            thresholds.clone(),
+            ExecutionPolicy::default(),
+        );
+
+        assert_eq!(node.node_id, node_id);
+        assert_eq!(node.artifact, artifact);
+        assert_eq!(node.rubric, rubric);
+        assert_eq!(node.backend, "runtimeai");
+        assert_eq!(node.thresholds, thresholds);
+        assert_eq!(node.policy, ExecutionPolicy::default());
+    }
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        let node_id = Uuid::new_v4();
+        let node = ScoredEvaluationNode::new(
+            node_id,
+            serde_json::json!({"code": "test"}),
+            Rubric::inline(serde_json::json!({"quality": 0.9})),
+            "mcp".to_string(),
+            HashMap::new(),
+            ExecutionPolicy::default(),
+        );
+
+        let json = serde_json::to_string(&node).unwrap();
+        let deserialized: ScoredEvaluationNode = serde_json::from_str(&json).unwrap();
+        assert_eq!(node, deserialized);
+    }
+
+    #[test]
+    fn test_execution_policy_default() {
+        let policy = ExecutionPolicy::default();
+        assert_eq!(policy.max_retries, 3);
+        assert_eq!(policy.on_failure, FailureAction::FlagForReview);
+    }
+
+    #[test]
+    fn test_failure_action_default() {
+        assert_eq!(FailureAction::default(), FailureAction::FlagForReview);
+    }
+}

--- a/engine/src/scored_evaluation/domain/result.rs
+++ b/engine/src/scored_evaluation/domain/result.rs
@@ -1,0 +1,236 @@
+//! ScoringResult + ScoreDimension — multidimensional scoring result.
+//!
+//! @canonical .pi/architecture/modules/scored-evaluation.md#scoring-result
+//! Implements: Contract Freeze — ScoringResult and ScoreDimension structs
+//! Issue: #673 (scored-evaluation epic)
+//!
+//! # Contract (Frozen)
+//! - ScoringResult carries a passed flag, scored dimensions, and backend metadata
+//! - ScoreDimension has a float score (0.0–1.0), max, label, and passed flag
+//! - Implements `Clone`, `Debug`, `PartialEq` for testability
+//! - Serialization support for API responses and persistence
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Multidimensional scoring result returned by a scoring backend.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScoringResult {
+    /// Overall pass/fail status (all dimensions passed).
+    pub passed: bool,
+
+    /// Map of dimension name to score dimension.
+    pub dimensions: HashMap<String, ScoreDimension>,
+
+    /// Human-readable summary of the evaluation.
+    pub summary: String,
+
+    /// Name of the backend that produced this result.
+    pub backend: String,
+
+    /// Duration of the evaluation in milliseconds.
+    pub duration_ms: u64,
+
+    /// Raw response from the backend (for debugging/auditing).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw: Option<serde_json::Value>,
+}
+
+/// A single scoring dimension within a scoring result.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScoreDimension {
+    /// The achieved score (0.0–1.0).
+    pub score: f64,
+
+    /// The maximum possible score.
+    pub max: f64,
+
+    /// Human-readable label for this dimension.
+    pub label: String,
+
+    /// Whether this dimension passed (score >= threshold or score >= max * pass_ratio).
+    pub passed: bool,
+}
+
+impl ScoringResult {
+    /// Create a new scoring result.
+    pub fn new(
+        passed: bool,
+        dimensions: HashMap<String, ScoreDimension>,
+        summary: impl Into<String>,
+        backend: impl Into<String>,
+        duration_ms: u64,
+        raw: Option<serde_json::Value>,
+    ) -> Self {
+        Self {
+            passed,
+            dimensions,
+            summary: summary.into(),
+            backend: backend.into(),
+            duration_ms,
+            raw,
+        }
+    }
+
+    /// Returns `true` if all dimensions passed.
+    pub fn all_dimensions_passed(&self) -> bool {
+        self.dimensions.values().all(|d| d.passed)
+    }
+
+    /// Returns the number of dimensions.
+    pub fn dimension_count(&self) -> usize {
+        self.dimensions.len()
+    }
+
+    /// Returns the number of passing dimensions.
+    pub fn passing_dimension_count(&self) -> usize {
+        self.dimensions.values().filter(|d| d.passed).count()
+    }
+
+    /// Returns the score for a specific dimension, if present.
+    pub fn score_for(&self, dimension: &str) -> Option<f64> {
+        self.dimensions.get(dimension).map(|d| d.score)
+    }
+}
+
+impl ScoreDimension {
+    /// Create a new score dimension.
+    pub fn new(score: f64, max: f64, label: impl Into<String>, passed: bool) -> Self {
+        Self {
+            score,
+            max,
+            label: label.into(),
+            passed,
+        }
+    }
+
+    /// Returns the score as a percentage (0–100).
+    pub fn as_percentage(&self) -> u8 {
+        if self.max == 0.0 {
+            0
+        } else {
+            ((self.score / self.max) * 100.0) as u8
+        }
+    }
+
+    /// Evaluate whether this dimension passes against a threshold (0.0–1.0).
+    pub fn evaluate(&self, threshold: f64) -> bool {
+        self.score >= threshold
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scoring_result_new() {
+        let mut dims = HashMap::new();
+        dims.insert(
+            "correctness".to_string(),
+            ScoreDimension::new(0.9, 1.0, "Correctness", true),
+        );
+
+        let result = ScoringResult::new(true, dims.clone(), "All good", "runtimeai", 150, None);
+        assert!(result.passed);
+        assert_eq!(result.dimensions.len(), 1);
+        assert_eq!(result.summary, "All good");
+        assert_eq!(result.backend, "runtimeai");
+        assert_eq!(result.duration_ms, 150);
+        assert!(result.raw.is_none());
+    }
+
+    #[test]
+    fn test_all_dimensions_passed() {
+        let mut dims = HashMap::new();
+        dims.insert("a".to_string(), ScoreDimension::new(0.9, 1.0, "A", true));
+        dims.insert("b".to_string(), ScoreDimension::new(0.8, 1.0, "B", true));
+
+        let result = ScoringResult::new(true, dims, "ok", "test", 0, None);
+        assert!(result.all_dimensions_passed());
+    }
+
+    #[test]
+    fn test_all_dimensions_not_passed() {
+        let mut dims = HashMap::new();
+        dims.insert("a".to_string(), ScoreDimension::new(0.9, 1.0, "A", true));
+        dims.insert("b".to_string(), ScoreDimension::new(0.5, 1.0, "B", false));
+
+        let result = ScoringResult::new(false, dims, "partial", "test", 0, None);
+        assert!(!result.all_dimensions_passed());
+    }
+
+    #[test]
+    fn test_passing_dimension_count() {
+        let mut dims = HashMap::new();
+        dims.insert("a".to_string(), ScoreDimension::new(0.9, 1.0, "A", true));
+        dims.insert("b".to_string(), ScoreDimension::new(0.5, 1.0, "B", false));
+        dims.insert("c".to_string(), ScoreDimension::new(0.7, 1.0, "C", true));
+
+        let result = ScoringResult::new(false, dims, "", "test", 0, None);
+        assert_eq!(result.passing_dimension_count(), 2);
+    }
+
+    #[test]
+    fn test_score_for() {
+        let mut dims = HashMap::new();
+        dims.insert(
+            "correctness".to_string(),
+            ScoreDimension::new(0.85, 1.0, "Correctness", true),
+        );
+
+        let result = ScoringResult::new(true, dims, "", "test", 0, None);
+        assert_eq!(result.score_for("correctness"), Some(0.85));
+        assert_eq!(result.score_for("nonexistent"), None);
+    }
+
+    #[test]
+    fn test_score_dimension_as_percentage() {
+        let dim = ScoreDimension::new(0.85, 1.0, "Test", true);
+        assert_eq!(dim.as_percentage(), 85);
+    }
+
+    #[test]
+    fn test_score_dimension_as_percentage_zero_max() {
+        let dim = ScoreDimension::new(0.0, 0.0, "Test", false);
+        assert_eq!(dim.as_percentage(), 0);
+    }
+
+    #[test]
+    fn test_score_dimension_evaluate() {
+        let dim = ScoreDimension::new(0.85, 1.0, "Test", true);
+        assert!(dim.evaluate(0.8));
+        assert!(!dim.evaluate(0.9));
+    }
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        let mut dims = HashMap::new();
+        dims.insert(
+            "correctness".to_string(),
+            ScoreDimension::new(0.95, 1.0, "Correctness", true),
+        );
+
+        let result = ScoringResult::new(
+            true,
+            dims,
+            "All dimensions passed",
+            "runtimeai",
+            250,
+            Some(serde_json::json!({"raw_score": 0.95})),
+        );
+
+        let json = serde_json::to_string(&result).unwrap();
+        let deserialized: ScoringResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(result, deserialized);
+    }
+
+    #[test]
+    fn test_raw_omitted_when_none() {
+        let dims = HashMap::new();
+        let result = ScoringResult::new(true, dims, "", "test", 0, None);
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(!json.contains("raw"));
+    }
+}

--- a/engine/src/scored_evaluation/domain/rubric.rs
+++ b/engine/src/scored_evaluation/domain/rubric.rs
@@ -1,0 +1,149 @@
+//! Rubric — evaluation rubric for scored evaluation nodes.
+//!
+//! @canonical .pi/architecture/modules/scored-evaluation.md#rubric
+//! Implements: Contract Freeze — Rubric struct and RubricSource enum
+//! Issue: #673 (scored-evaluation epic)
+//!
+//! # Contract (Frozen)
+//! - Rubric can be inline JSON or a reference to an external file/URL
+//! - RubricSource uses serde tagged enum for serialization clarity
+//! - `scenario_id` is optional for systems that pre-define scenarios
+//! - Implements `Clone`, `Debug`, `PartialEq` for testability
+
+use serde::{Deserialize, Serialize};
+
+/// Evaluation rubric — the criteria against which an artifact is scored.
+///
+/// A rubric defines what dimensions to evaluate (correctness, completeness,
+/// style, etc.) and optionally references a pre-defined scenario on the
+/// scoring backend.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Rubric {
+    /// The source of the rubric content.
+    pub source: RubricSource,
+
+    /// Optional scenario identifier for backends that pre-define scenarios
+    /// (e.g., RuntimeAI scenario IDs).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scenario_id: Option<String>,
+}
+
+/// Source of rubric content — either inline JSON or a reference.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RubricSource {
+    /// The rubric content is provided inline as JSON.
+    Inline {
+        /// The JSON rubric content (dimensions, descriptions, weights).
+        content: serde_json::Value,
+    },
+    /// The rubric is referenced by path or URL.
+    Reference {
+        /// File path or URL to the rubric definition.
+        path_or_url: String,
+    },
+}
+
+impl Rubric {
+    /// Create a new inline rubric.
+    pub fn inline(content: serde_json::Value) -> Self {
+        Self {
+            source: RubricSource::Inline { content },
+            scenario_id: None,
+        }
+    }
+
+    /// Create a new reference rubric.
+    pub fn reference(path_or_url: impl Into<String>) -> Self {
+        Self {
+            source: RubricSource::Reference {
+                path_or_url: path_or_url.into(),
+            },
+            scenario_id: None,
+        }
+    }
+
+    /// Set an optional scenario identifier.
+    pub fn with_scenario_id(mut self, scenario_id: impl Into<String>) -> Self {
+        self.scenario_id = Some(scenario_id.into());
+        self
+    }
+
+    /// Returns `true` if the rubric source is inline.
+    pub fn is_inline(&self) -> bool {
+        matches!(self.source, RubricSource::Inline { .. })
+    }
+
+    /// Returns `true` if the rubric source is a reference.
+    pub fn is_reference(&self) -> bool {
+        matches!(self.source, RubricSource::Reference { .. })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_inline_rubric() {
+        let content = serde_json::json!({
+            "correctness": {"description": "Is the code correct?", "weight": 0.5},
+            "completeness": {"description": "Are all requirements met?", "weight": 0.5}
+        });
+        let rubric = Rubric::inline(content.clone());
+        assert!(rubric.is_inline());
+        assert!(!rubric.is_reference());
+        assert_eq!(rubric.source, RubricSource::Inline { content });
+        assert!(rubric.scenario_id.is_none());
+    }
+
+    #[test]
+    fn test_reference_rubric() {
+        let rubric = Rubric::reference("./rubrics/code_quality.json");
+        assert!(!rubric.is_inline());
+        assert!(rubric.is_reference());
+        assert_eq!(
+            rubric.source,
+            RubricSource::Reference {
+                path_or_url: "./rubrics/code_quality.json".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_with_scenario_id() {
+        let rubric = Rubric::inline(serde_json::json!({}))
+            .with_scenario_id("scenario-abc-123");
+        assert_eq!(
+            rubric.scenario_id,
+            Some("scenario-abc-123".to_string())
+        );
+    }
+
+    #[test]
+    fn test_serialization_roundtrip_inline() {
+        let rubric = Rubric::inline(serde_json::json!({"dim": 0.8}))
+            .with_scenario_id("s-1");
+        let json = serde_json::to_string(&rubric).unwrap();
+        let deserialized: Rubric = serde_json::from_str(&json).unwrap();
+        assert_eq!(rubric, deserialized);
+        // Verify tagged enum serialization
+        assert!(json.contains("\"type\":\"inline\""));
+    }
+
+    #[test]
+    fn test_serialization_roundtrip_reference() {
+        let rubric = Rubric::reference("https://example.com/rubric.json");
+        let json = serde_json::to_string(&rubric).unwrap();
+        let deserialized: Rubric = serde_json::from_str(&json).unwrap();
+        assert_eq!(rubric, deserialized);
+        assert!(json.contains("\"type\":\"reference\""));
+    }
+
+    #[test]
+    fn test_scenario_id_omitted_when_none() {
+        let rubric = Rubric::inline(serde_json::json!({}));
+        let json = serde_json::to_string(&rubric).unwrap();
+        assert!(!json.contains("scenario_id"));
+    }
+}

--- a/engine/src/scored_evaluation/infrastructure/backends/http_backend.rs
+++ b/engine/src/scored_evaluation/infrastructure/backends/http_backend.rs
@@ -1,0 +1,144 @@
+//! HTTPBackend — HTTP REST adapter for the Rigorix scoring protocol.
+//!
+//! @canonical .pi/architecture/modules/scored-evaluation.md#http-backend
+//! Implements: Contract Freeze — HttpBackend stub
+//! Issue: #673 (scored-evaluation epic)
+//!
+//! # Contract (Frozen)
+//! - Implements the `ScoringBackend` trait
+//! - POSTs artifact + rubric to configurable URL
+//! - Expects `ScoringResult`-compatible JSON response
+//! - Configurable timeout, headers, and auth
+//! - Implements health check via HEAD or GET to health endpoint
+//!
+//! # Implementation Notes (TODO)
+//! - Use reqwest for HTTP client
+//! - POST with JSON body containing artifact + rubric
+//! - Parse response into ScoringResult
+//! - Support auth headers (Bearer token, custom header)
+//! - Configurable timeout per request
+
+use async_trait::async_trait;
+use std::collections::HashMap;
+
+use crate::scored_evaluation::domain::{
+    ScoredEvaluationError, ScoringBackend, ScoringResult, Rubric,
+};
+
+/// HTTP REST adapter for the Rigorix scoring protocol.
+///
+/// POSTs scoring requests to a configurable HTTP endpoint and parses
+/// the JSON response into a `ScoringResult`.
+pub struct HttpBackend {
+    /// Name identifier for this backend instance.
+    name: &'static str,
+    /// Scoring endpoint URL.
+    url: String,
+    /// Custom HTTP headers to include in requests.
+    headers: HashMap<String, String>,
+    /// Request timeout in milliseconds.
+    timeout_ms: u64,
+    /// Optional URL for health checks (defaults to same URL).
+    health_url: Option<String>,
+}
+
+impl HttpBackend {
+    /// Create a new HTTP backend adapter.
+    pub fn new(
+        url: impl Into<String>,
+        headers: HashMap<String, String>,
+        timeout_ms: u64,
+    ) -> Self {
+        Self {
+            name: "http",
+            url: url.into(),
+            headers,
+            timeout_ms,
+            health_url: None,
+        }
+    }
+
+    /// Set a custom health check URL.
+    pub fn with_health_url(mut self, url: impl Into<String>) -> Self {
+        self.health_url = Some(url.into());
+        self
+    }
+
+    /// Returns the scoring endpoint URL.
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// Returns the custom headers.
+    pub fn headers(&self) -> &HashMap<String, String> {
+        &self.headers
+    }
+
+    /// Returns the timeout in milliseconds.
+    pub fn timeout_ms(&self) -> u64 {
+        self.timeout_ms
+    }
+}
+
+#[async_trait]
+impl ScoringBackend for HttpBackend {
+    async fn evaluate(
+        &self,
+        _artifact: &serde_json::Value,
+        _rubric: &Rubric,
+    ) -> Result<ScoringResult, ScoredEvaluationError> {
+        // TODO: implement HTTP call
+        // 1. POST artifact + rubric as JSON to self.url
+        // 2. Parse response into ScoringResult
+        // 3. Handle timeout, HTTP errors, invalid responses
+        Err(ScoredEvaluationError::Internal(
+            "HTTPBackend not yet implemented".to_string(),
+        ))
+    }
+
+    fn backend_name(&self) -> &'static str {
+        self.name
+    }
+
+    async fn health_check(&self) -> Result<bool, ScoredEvaluationError> {
+        // TODO: implement health check
+        // HEAD or GET to health_url (or self.url), check status 200
+        Err(ScoredEvaluationError::Internal(
+            "HTTPBackend health check not yet implemented".to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_backend() {
+        let headers = HashMap::new();
+        let backend = HttpBackend::new("https://evaluate.example.com/score", headers, 30_000);
+        assert_eq!(backend.backend_name(), "http");
+        assert_eq!(backend.url(), "https://evaluate.example.com/score");
+        assert_eq!(backend.timeout_ms(), 30_000);
+        assert!(backend.health_url.is_none());
+    }
+
+    #[test]
+    fn test_with_health_url() {
+        let headers = HashMap::new();
+        let backend = HttpBackend::new("https://evaluate.example.com/score", headers, 30_000)
+            .with_health_url("https://evaluate.example.com/health");
+        assert_eq!(
+            backend.health_url.unwrap(),
+            "https://evaluate.example.com/health"
+        );
+    }
+
+    #[test]
+    fn test_custom_headers() {
+        let mut headers = HashMap::new();
+        headers.insert("Authorization".to_string(), "Bearer token123".to_string());
+        let backend = HttpBackend::new("https://evaluate.example.com/score", headers.clone(), 10_000);
+        assert_eq!(backend.headers().get("Authorization").unwrap(), "Bearer token123");
+    }
+}

--- a/engine/src/scored_evaluation/infrastructure/backends/local_backend.rs
+++ b/engine/src/scored_evaluation/infrastructure/backends/local_backend.rs
@@ -1,0 +1,104 @@
+//! LocalBackend — local script adapter for the Rigorix scoring protocol.
+//!
+//! @canonical .pi/architecture/modules/scored-evaluation.md#local-backend
+//! Implements: Contract Freeze — LocalBackend stub
+//! Issue: #673 (scored-evaluation epic)
+//!
+//! # Contract (Frozen)
+//! - Implements the `ScoringBackend` trait
+//! - Executes a local script with artifact + rubric as environment variables
+//! - Reads scoring result from stdout (JSON)
+//! - Configurable script path and timeout
+//! - Implements health check by checking script file existence
+//!
+//! # Implementation Notes (TODO)
+//! - Execute script via tokio::process::Command
+//! - Pass artifact and rubric as env vars (or stdin JSON)
+//! - Parse stdout JSON into ScoringResult
+//! - Validate script path against allowlist for security
+//! - Configurable timeout for script execution
+
+use async_trait::async_trait;
+
+use crate::scored_evaluation::domain::{
+    ScoredEvaluationError, ScoringBackend, ScoringResult, Rubric,
+};
+
+/// Local script adapter for the Rigorix scoring protocol.
+///
+/// Executes a configurable local script that reads an artifact + rubric
+/// from environment variables or stdin and outputs a `ScoringResult` JSON
+/// to stdout.
+pub struct LocalBackend {
+    /// Name identifier for this backend instance.
+    name: &'static str,
+    /// Path to the scoring script.
+    script_path: String,
+    /// Execution timeout in milliseconds.
+    timeout_ms: u64,
+}
+
+impl LocalBackend {
+    /// Create a new local backend adapter.
+    pub fn new(script_path: impl Into<String>, timeout_ms: u64) -> Self {
+        Self {
+            name: "local",
+            script_path: script_path.into(),
+            timeout_ms,
+        }
+    }
+
+    /// Returns the script path.
+    pub fn script_path(&self) -> &str {
+        &self.script_path
+    }
+
+    /// Returns the timeout in milliseconds.
+    pub fn timeout_ms(&self) -> u64 {
+        self.timeout_ms
+    }
+}
+
+#[async_trait]
+impl ScoringBackend for LocalBackend {
+    async fn evaluate(
+        &self,
+        _artifact: &serde_json::Value,
+        _rubric: &Rubric,
+    ) -> Result<ScoringResult, ScoredEvaluationError> {
+        // TODO: implement local script execution
+        // 1. Validate script path against allowlist
+        // 2. Execute script with artifact + rubric as env vars
+        // 3. Read stdout, parse as ScoringResult
+        // 4. Handle timeout, non-zero exit, invalid output
+        Err(ScoredEvaluationError::Internal(
+            "LocalBackend not yet implemented".to_string(),
+        ))
+    }
+
+    fn backend_name(&self) -> &'static str {
+        self.name
+    }
+
+    async fn health_check(&self) -> Result<bool, ScoredEvaluationError> {
+        // TODO: check that script file exists and is executable
+        // let metadata = tokio::fs::metadata(&self.script_path).await;
+        // Ok(metadata.is_ok())
+        Err(ScoredEvaluationError::Internal(
+            "LocalBackend health check not yet implemented".to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_backend() {
+        let backend = LocalBackend::new("./scripts/evaluate.sh", 10_000);
+        assert_eq!(backend.backend_name(), "local");
+        assert_eq!(backend.script_path(), "./scripts/evaluate.sh");
+        assert_eq!(backend.timeout_ms(), 10_000);
+    }
+}

--- a/engine/src/scored_evaluation/infrastructure/backends/mcp_backend.rs
+++ b/engine/src/scored_evaluation/infrastructure/backends/mcp_backend.rs
@@ -1,0 +1,104 @@
+//! MCPBackend — MCP protocol adapter for the Rigorix scoring protocol.
+//!
+//! @canonical .pi/architecture/modules/scored-evaluation.md#mcp-backend
+//! Implements: Contract Freeze — McpBackend stub
+//! Issue: #673 (scored-evaluation epic)
+//!
+//! # Contract (Frozen)
+//! - Implements the `ScoringBackend` trait
+//! - Sends `rigorix_evaluate_artifact` MCP requests to any server
+//!   implementing the Rigorix scoring protocol
+//! - Parses MCP responses into `ScoringResult`
+//! - Implements health check via `rigorix_ping`
+//! - Configurable timeout for MCP requests
+//!
+//! > **Protocol Ownership:** Rigorix defines the scoring protocol. External
+//! > systems like RuntimeAI adopt it by implementing the server side.
+//!
+//! # Implementation Notes (TODO)
+//! - Connect to MCP server via MCP client SDK
+//! - Send `rigorix_evaluate_artifact` with artifact + rubric payload
+//! - Parse response JSON into `ScoringResult`
+//! - Handle timeout, connection errors, invalid responses
+//! - Optionally pre-flight with `rigorix_estimate_evaluation_cost`
+
+use async_trait::async_trait;
+
+use crate::scored_evaluation::domain::{
+    ScoredEvaluationError, ScoringBackend, ScoringResult, Rubric,
+};
+
+/// MCP protocol adapter for the Rigorix scoring protocol.
+///
+/// Sends `rigorix_evaluate_artifact` requests over MCP to any server
+/// that implements the server side of the Rigorix scoring protocol.
+pub struct McpBackend {
+    /// Name identifier for this backend instance.
+    name: &'static str,
+    /// MCP server endpoint URL.
+    endpoint: String,
+    /// Request timeout in milliseconds.
+    timeout_ms: u64,
+}
+
+impl McpBackend {
+    /// Create a new MCP backend adapter.
+    pub fn new(endpoint: impl Into<String>, timeout_ms: u64) -> Self {
+        Self {
+            name: "mcp",
+            endpoint: endpoint.into(),
+            timeout_ms,
+        }
+    }
+
+    /// Returns the endpoint URL.
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// Returns the timeout in milliseconds.
+    pub fn timeout_ms(&self) -> u64 {
+        self.timeout_ms
+    }
+}
+
+#[async_trait]
+impl ScoringBackend for McpBackend {
+    async fn evaluate(
+        &self,
+        _artifact: &serde_json::Value,
+        _rubric: &Rubric,
+    ) -> Result<ScoringResult, ScoredEvaluationError> {
+        // TODO: implement MCP protocol call
+        // 1. Send rigorix_evaluate_artifact request via MCP client
+        // 2. Parse response into ScoringResult
+        // 3. Handle timeout and error cases
+        Err(ScoredEvaluationError::Internal(
+            "MCPBackend not yet implemented".to_string(),
+        ))
+    }
+
+    fn backend_name(&self) -> &'static str {
+        self.name
+    }
+
+    async fn health_check(&self) -> Result<bool, ScoredEvaluationError> {
+        // TODO: implement health check via rigorix_ping
+        Err(ScoredEvaluationError::Internal(
+            "MCPBackend health check not yet implemented".to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_backend() {
+        let backend = McpBackend::new("http://localhost:8080/mcp", 30_000);
+        assert_eq!(backend.backend_name(), "mcp");
+        assert_eq!(backend.endpoint(), "http://localhost:8080/mcp");
+        assert_eq!(backend.timeout_ms(), 30_000);
+    }
+}

--- a/engine/src/scored_evaluation/infrastructure/backends/mod.rs
+++ b/engine/src/scored_evaluation/infrastructure/backends/mod.rs
@@ -1,0 +1,24 @@
+//! Scoring backend implementations — MCP, HTTP, and Local protocol adapters.
+//!
+//! @canonical .pi/architecture/modules/scored-evaluation.md
+//! Implements: Contract Freeze — backend adapter interfaces
+//! Issue: #673 (scored-evaluation epic)
+//!
+//! These files will implement the `ScoringBackend` trait (domain layer) for
+//! three transport mechanisms:
+//!
+//! - `MCPBackend`: sends `rigorix_evaluate_artifact` MCP requests
+//! - `HTTPBackend`: POSTs to a REST endpoint per the Rigorix scoring protocol
+//! - `LocalBackend`: executes a local script per the Rigorix scoring protocol
+//!
+//! Rigorix defines the scoring protocol. External systems (e.g. RuntimeAI)
+//! adopt it by implementing the server side of these protocols.
+
+pub mod http_backend;
+pub mod local_backend;
+pub mod mcp_backend;
+
+// Re-export backend types for convenience.
+pub use http_backend::HttpBackend;
+pub use local_backend::LocalBackend;
+pub use mcp_backend::McpBackend;

--- a/engine/src/scored_evaluation/infrastructure/mod.rs
+++ b/engine/src/scored_evaluation/infrastructure/mod.rs
@@ -1,0 +1,19 @@
+//! Infrastructure layer for the Scored Evaluation bounded context.
+//!
+//! @canonical .pi/architecture/modules/scored-evaluation.md
+//! Implements: Contract Freeze — infrastructure interfaces
+//! Issue: #673 (scored-evaluation epic)
+//!
+//! This layer contains scoring backend implementations and repository
+//! interfaces. All implementations must satisfy domain-level contracts
+//! (`ScoringBackend` trait, `EvaluationRepository` trait).
+//!
+//! # Contract Freeze
+//! - Backend implementations must satisfy the `ScoringBackend` trait
+//! - Repository interfaces abstract data access behind traits
+//! - No framework-specific annotations on trait definitions
+
+pub mod backends;
+pub mod repository;
+
+pub use repository::EvaluationRepository;

--- a/engine/src/scored_evaluation/infrastructure/repository.rs
+++ b/engine/src/scored_evaluation/infrastructure/repository.rs
@@ -1,0 +1,47 @@
+//! EvaluationRepository — repository interface for persisting evaluation results.
+//!
+//! @canonical .pi/architecture/modules/scored-evaluation.md#evaluation-repository
+//! Implements: Contract Freeze — EvaluationRepository trait
+//! Issue: #673 (scored-evaluation epic)
+//!
+//! # Contract (Frozen)
+//! - Abstracts data access behind an interface
+//! - All methods are async
+//! - Methods return domain error types
+//! - No framework-specific annotations on trait definitions
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::scored_evaluation::domain::ScoredEvaluationError;
+
+use crate::scored_evaluation::application::dto::EvaluateOutput;
+
+/// Repository for persisting and retrieving evaluation results.
+///
+/// Implementations can store results in filesystem (JSON files),
+/// SQLite, or in-memory for testing.
+#[async_trait]
+pub trait EvaluationRepository: Send + Sync {
+    /// Save an evaluation result.
+    async fn save(&self, output: &EvaluateOutput) -> Result<(), ScoredEvaluationError>;
+
+    /// Get an evaluation result by execution and node ID.
+    async fn get(
+        &self,
+        execution_id: Uuid,
+        node_id: Uuid,
+    ) -> Result<Option<EvaluateOutput>, ScoredEvaluationError>;
+
+    /// List all evaluations for a given execution.
+    async fn list(
+        &self,
+        execution_id: Uuid,
+    ) -> Result<Vec<EvaluateOutput>, ScoredEvaluationError>;
+
+    /// Delete all evaluations for a given execution.
+    async fn delete_by_execution(
+        &self,
+        execution_id: Uuid,
+    ) -> Result<(), ScoredEvaluationError>;
+}

--- a/engine/src/scored_evaluation/mod.rs
+++ b/engine/src/scored_evaluation/mod.rs
@@ -1,0 +1,54 @@
+//! Scored Evaluation bounded context.
+//!
+//! @canonical .pi/architecture/modules/scored-evaluation.md
+//! Implements: Contract Freeze — scored-evaluation module
+//! Issue: #673 (scored-evaluation epic)
+//!
+//! The Scored Evaluation system adds a scored quality evaluation primitive to
+//! the Rigorix DAG. A `scored_evaluation` node sends generated artifacts to a
+//! pluggable scoring backend and receives multidimensional scores back. Policy
+//! rules can gate merge on score thresholds.
+//!
+//! This complements the Quality Gates system (GreenContract), which evaluates
+//! test scope, by adding output quality scoring as an orthogonal dimension.
+//!
+//! # Protocol Ownership
+//!
+//! Rigorix defines the scoring protocol (`rigorix_evaluate_artifact`,
+//! `rigorix_ping`, etc.). External scoring systems (e.g. RuntimeAI) adopt
+//! this protocol by implementing the server side. The initial protocol design
+//! is informed by RuntimeAI's conceptual model (checkrides, scenarios, rubrics)
+//! since they are the first planned backend adopter.
+//!
+//! # Architecture
+//!
+//! ```text
+//! scored_evaluation/
+//! ├── domain/               # Domain entities and interfaces
+//! │   ├── node.rs           # ScoredEvaluationNode value object
+//! │   ├── rubric.rs         # Rubric value object + RubricSource enum
+//! │   ├── result.rs         # ScoringResult + ScoreDimension value objects
+//! │   ├── backend.rs        # ScoringBackend trait (domain interface)
+//! │   ├── event.rs          # ScoredEvaluationEvent domain events
+//! │   └── error.rs          # ScoredEvaluationError (thiserror)
+//! ├── application/          # Service traits, DTOs
+//! │   ├── service.rs        # ScoredEvaluationService trait
+//! │   └── dto.rs            # EvaluateInput, EvaluateOutput DTOs
+//! ├── infrastructure/       # Backend adapters and repository
+//! │   ├── backends/         # Scoring backend implementations
+//! │   │   ├── mcp_backend.rs    # MCP protocol adapter
+//! │   │   ├── http_backend.rs   # HTTP REST adapter
+//! │   │   └── local_backend.rs  # Local script adapter
+//! │   └── repository.rs     # EvaluationRepository trait
+//! ```
+//!
+//! # Contract Freeze Notice
+//!
+//! ALL files in this module are frozen contracts.
+//! - No implementation changes without explicit contract change approval
+//! - Implementation PRs MUST reference these interfaces
+//! - DTO schemas serve as the canonical data contract
+
+pub mod application;
+pub mod domain;
+pub mod infrastructure;


### PR DESCRIPTION
## Summary

Contract freeze for the scored-evaluation module. Defines all public interfaces, contracts, and schemas before implementation begins.

## Changes

- **Domain layer**: ScoredEvaluationNode, Rubric (inline/reference), ScoringResult, ScoreDimension, ScoringBackend trait, ScoredEvaluationEvent (3 variants), ScoredEvaluationError (7 variants)
- **Application layer**: ScoredEvaluationService trait, EvaluateInput/EvaluateOutput DTOs, EvaluationContext
- **Infrastructure layer**: McpBackend, HttpBackend, LocalBackend stubs, EvaluationRepository trait
- **Protocol ownership**: Rigorix defines `rigorix_evaluate_artifact` protocol — external systems adopt it

## Testing

- 43 unit tests pass (serde round-trips, domain invariants, error classification, backend constructors)
- `cargo check --lib` clean
- `cargo test --lib scored_evaluation` all green

Closes #674