### PR TITLE
[Issue #701] Implement IdentityClaim — is_valid, redacted_summary, envelope identity block

### DIFF
--- a/actions/src/action_entrypoint/application/router_impl.rs
+++ b/actions/src/action_entrypoint/application/router_impl.rs
@@ -74,6 +74,7 @@ impl ActionRouterImpl {
             enforcement_preset: None,
             repository: ctx.repository.clone(),
             author: ctx.author.clone(),
+            identity: None, // TODO(identity epic): attest from action context
         };
 
         let output = self

--- a/cli/src/cli_boundary/dispatch.rs
+++ b/cli/src/cli_boundary/dispatch.rs
@@ -142,6 +142,9 @@ async fn handle_run(
             .unwrap_or_default(),
         repository: detect_git_repository(),
         author: detect_git_author(),
+        // Identity attestation arrives via the MCP auth module (ADR-012);
+        // the CLI run path is legacy self-asserted author.
+        identity: None,
         enforcement_preset: enforcement,
     };
     match orch.run(input).await {

--- a/cli/src/tui/mod.rs
+++ b/cli/src/tui/mod.rs
@@ -699,6 +699,7 @@ async fn handle_action(
                     enforcement_preset: None,
                     repository: None,
                     author: None,
+                    identity: None,
                 };
                 match orch.run(input).await {
                     Ok(output) => {

--- a/cli/src/tui/orchestrator_spawner.rs
+++ b/cli/src/tui/orchestrator_spawner.rs
@@ -152,6 +152,7 @@ impl OrchestratorSpawner for OrchestratorSpawnerImpl {
                         enforcement_preset: None,
                         repository: None,
                         author: None,
+                        identity: None,
                     };
                     match orch.run(input).await {
                         Ok(output) => {

--- a/engine/src/audit/application/audit_queue_impl.rs
+++ b/engine/src/audit/application/audit_queue_impl.rs
@@ -160,6 +160,7 @@ mod tests {
             signature: None,
             repository: None,
             author: None,
+            identity: None,
         }
     }
 

--- a/engine/src/audit/application/audit_sender_impl.rs
+++ b/engine/src/audit/application/audit_sender_impl.rs
@@ -281,6 +281,7 @@ mod tests {
             signature: None,
             repository: None,
             author: None,
+            identity: None,
         }
     }
 

--- a/engine/src/audit/application/audit_service_impl.rs
+++ b/engine/src/audit/application/audit_service_impl.rs
@@ -239,6 +239,7 @@ mod tests {
             sign: false,
             repository: None,
             author: None,
+            identity: None,
         }
     }
 

--- a/engine/src/audit/application/dto/mod.rs
+++ b/engine/src/audit/application/dto/mod.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::audit::domain::{AuditEnvelope, ExecutionEventRef};
+use crate::identity::domain::IdentityRef;
 
 // ---------------------------------------------------------------------------
 // Build Envelope DTOs
@@ -47,6 +48,10 @@ pub struct BuildEnvelopeInput {
 
     /// Identity of the user or bot that triggered the execution.
     pub author: Option<String>,
+
+    /// Attributed identity of author/approver — redacted ref for the envelope
+    /// identity block (never the raw token).
+    pub identity: Option<IdentityRef>,
 
     /// Total number of LLM tokens consumed during this execution.
     pub total_tokens: u32,

--- a/engine/src/audit/application/envelope_factory_impl.rs
+++ b/engine/src/audit/application/envelope_factory_impl.rs
@@ -89,6 +89,7 @@ impl AuditEnvelopeFactory for AuditEnvelopeFactoryImpl {
             source: input.source,
             repository: input.repository,
             author: input.author,
+            identity: input.identity,
             total_tokens: input.total_tokens,
             duration_ms: input.duration_ms,
             git_commit: input.git_commit,
@@ -168,6 +169,7 @@ mod tests {
             sign: false,
             repository: None,
             author: None,
+            identity: None,
         }
     }
 

--- a/engine/src/audit/domain/envelope.rs
+++ b/engine/src/audit/domain/envelope.rs
@@ -16,6 +16,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::identity::domain::IdentityRef;
+
 /// Typed envelope containing execution audit data.
 ///
 /// Built at execution completion by the orchestration layer and sent to
@@ -45,6 +47,14 @@ pub struct AuditEnvelope {
 
     /// Identity of the user or bot that triggered the execution.
     pub author: Option<String>,
+
+    /// Attributed human identity of author/approver (see identity module).
+    ///
+    /// Redacted summary — subject/issuer/source/authority/expiry — never the
+    /// raw token (`.pi/architecture/modules/audit.md` identity block).
+    /// Additive and serde-defaulted: absent in pre-identity envelopes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity: Option<IdentityRef>,
 
     /// Total number of LLM tokens consumed during this execution.
     ///

--- a/engine/src/audit/infrastructure/local_audit_repository.rs
+++ b/engine/src/audit/infrastructure/local_audit_repository.rs
@@ -242,6 +242,7 @@ mod tests {
             signature: None,
             repository: None,
             author: None,
+            identity: None,
         }
     }
 

--- a/engine/src/identity/domain/claim.rs
+++ b/engine/src/identity/domain/claim.rs
@@ -56,25 +56,35 @@ impl IdentityClaim {
     /// - `false` once `expires_at` is in the past (expired claims must be
     ///   rejected at approval binding)
     ///
-    /// # TODO
-    /// Implemented in ISSUE-IDENTITY-1 (IdentityClaim). This body is a
-    /// contract stub — behavior lands with the implementation issue.
+    /// Implemented in ISSUE-IDENTITY-1 (IdentityClaim).
     pub fn is_valid(&self) -> bool {
-        todo!("ISSUE-IDENTITY-1 (IdentityClaim): implement is_valid() across the expiry boundary")
+        match self.expires_at {
+            None => true,
+            Some(expires_at) => expires_at > Utc::now(),
+        }
     }
 
     /// Redacted rendering for logs and envelope summaries.
     ///
     /// # Contract
     /// - Renders subject, issuer, source, and lifetime
-    /// - Never contains the raw token or its value
+    /// - Never contains the raw token, its reference locator, or the
+    ///   `token_ref` field name
     /// - Follows the SpanPrivacy pattern (api_key/token/secret fields never logged)
     ///
-    /// # TODO
-    /// Implemented in ISSUE-IDENTITY-1 (IdentityClaim). This body is a
-    /// contract stub — behavior lands with the implementation issue.
+    /// Implemented in ISSUE-IDENTITY-1 (IdentityClaim).
     pub fn redacted_summary(&self) -> String {
-        todo!("ISSUE-IDENTITY-1 (IdentityClaim): implement redacted_summary() without raw token")
+        format!(
+            "identity[subject={}, issuer={}, source={}, authority={}, auth_method={}, expires_at={}]",
+            self.subject,
+            self.issuer,
+            self.source,
+            self.authority.as_deref().unwrap_or("none"),
+            self.auth_method.as_deref().unwrap_or("none"),
+            self.expires_at
+                .map(|t| t.to_rfc3339())
+                .unwrap_or_else(|| "none".to_string()),
+        )
     }
 }
 
@@ -92,6 +102,60 @@ pub enum IdentitySource {
     LocalPrincipal,
     /// No identity presented or IdP unreachable — explicitly degraded.
     Unverified,
+}
+
+impl std::fmt::Display for IdentitySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Matches the frozen serde snake_case representation.
+        let rendered = match self {
+            IdentitySource::IdpToken => "idp_token",
+            IdentitySource::LocalPrincipal => "local_principal",
+            IdentitySource::Unverified => "unverified",
+        };
+        f.write_str(rendered)
+    }
+}
+
+/// Redacted envelope representation of an identity claim.
+///
+/// The audit envelope carries this ref in its `identity` block (see
+/// `.pi/architecture/modules/audit.md`): subject, issuer, source, authority,
+/// and expiry — **redacted, never the raw token**. Raw tokens are preserved by
+/// reference (`token_ref`) in the full claim, never embedded here.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityRef {
+    /// Subject — the human's unique identifier at the IdP.
+    pub subject: String,
+    /// Issuer — who vouches for the subject.
+    pub issuer: String,
+    /// How the identity was established (degradation marker preserved).
+    pub source: IdentitySource,
+    /// Roles / authority presented (captured fact, not judgment).
+    pub authority: Option<String>,
+    /// When the claim expires (`None` = no expiry).
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
+impl IdentityRef {
+    /// Build a redacted ref from a claim.
+    ///
+    /// Deliberately copies only the summary fields — `token_ref`, `auth_method`
+    /// and the raw token are never carried into the envelope.
+    pub fn from_claim(claim: &IdentityClaim) -> Self {
+        Self {
+            subject: claim.subject.clone(),
+            issuer: claim.issuer.clone(),
+            source: claim.source.clone(),
+            authority: claim.authority.clone(),
+            expires_at: claim.expires_at,
+        }
+    }
+}
+
+impl From<&IdentityClaim> for IdentityRef {
+    fn from(claim: &IdentityClaim) -> Self {
+        Self::from_claim(claim)
+    }
 }
 
 #[cfg(test)]
@@ -175,5 +239,86 @@ mod tests {
             let restored: IdentitySource = serde_json::from_str(&json).expect("deserialize source");
             assert_eq!(source, restored);
         }
+    }
+
+    // ── ISSUE-IDENTITY-1 behavior tests (Red → Green) ────────────────────────
+
+    #[test]
+    fn is_valid_none_expiry_is_valid() {
+        let claim = IdentityClaim {
+            expires_at: None,
+            ..sample_claim()
+        };
+        assert!(claim.is_valid(), "no expiry => always valid");
+    }
+
+    #[test]
+    fn is_valid_future_expiry_is_valid() {
+        let claim = IdentityClaim {
+            expires_at: Some(Utc::now() + chrono::Duration::seconds(60)),
+            ..sample_claim()
+        };
+        assert!(claim.is_valid(), "future expiry => valid");
+    }
+
+    #[test]
+    fn is_valid_past_expiry_is_invalid() {
+        let claim = IdentityClaim {
+            expires_at: Some(Utc::now() - chrono::Duration::seconds(60)),
+            ..sample_claim()
+        };
+        assert!(!claim.is_valid(), "past expiry => invalid (expired)");
+    }
+
+    #[test]
+    fn redacted_summary_contains_subject_but_never_raw_token() {
+        let raw_token = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyQG9yZyJ9.signature";
+        let claim = IdentityClaim {
+            token_ref: Some("keychain://default/rigorix/idp-token".to_string()),
+            ..sample_claim()
+        };
+        let summary = claim.redacted_summary();
+        assert!(summary.contains("user@org"), "subject rendered");
+        assert!(
+            !summary.contains("keychain"),
+            "token_ref locator must never appear: {summary}"
+        );
+        assert!(
+            !summary.contains("token_ref"),
+            "token_ref field name must never appear: {summary}"
+        );
+        assert!(
+            !summary.contains(&raw_token[0..20]),
+            "raw token payload must never appear: {summary}"
+        );
+    }
+
+    #[test]
+    fn identity_ref_from_claim_redacts_token_ref() {
+        let claim = sample_claim(); // token_ref = Some("keychain://.../idp-token")
+        let reference = IdentityRef::from(&claim);
+        assert_eq!(reference.subject, "user@org");
+        assert_eq!(reference.issuer, "https://idp.example.com");
+        assert_eq!(reference.source, IdentitySource::IdpToken);
+        assert_eq!(reference.authority, Some("admin".to_string()));
+        assert_eq!(
+            reference.expires_at,
+            Some(Utc.with_ymd_and_hms(2026, 8, 28, 10, 15, 0).unwrap())
+        );
+        // Redacted: no token_ref field, no token locator in the serialized ref.
+        let json = serde_json::to_string(&reference).expect("serialize identity ref");
+        assert!(
+            !json.contains("token_ref"),
+            "IdentityRef must not carry token_ref: {json}"
+        );
+        assert!(!json.contains("keychain"));
+    }
+
+    #[test]
+    fn identity_ref_serde_round_trip() {
+        let reference = IdentityRef::from(&sample_claim());
+        let json = serde_json::to_string(&reference).expect("serialize identity ref");
+        let restored: IdentityRef = serde_json::from_str(&json).expect("deserialize identity ref");
+        assert_eq!(reference, restored);
     }
 }

--- a/engine/src/identity/domain/mod.rs
+++ b/engine/src/identity/domain/mod.rs
@@ -25,5 +25,5 @@ pub mod claim;
 pub mod error;
 
 pub use authority::Authority;
-pub use claim::{IdentityClaim, IdentitySource};
+pub use claim::{IdentityClaim, IdentityRef, IdentitySource};
 pub use error::IdentityError;

--- a/engine/src/orchestrator/application/builder_impl.rs
+++ b/engine/src/orchestrator/application/builder_impl.rs
@@ -299,6 +299,7 @@ mod tests {
                 enforcement_preset: None,
                 repository: None,
                 author: None,
+                identity: None,
             })
             .await;
         assert!(result.is_ok(), "run should succeed: {:?}", result.err());

--- a/engine/src/orchestrator/application/dto/mod.rs
+++ b/engine/src/orchestrator/application/dto/mod.rs
@@ -15,6 +15,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::identity::domain::IdentityClaim;
 use crate::orchestrator::domain::record::{ExecutionRecord, ExecutionStatus};
 
 // ---------------------------------------------------------------------------
@@ -38,6 +39,12 @@ pub struct RunInput {
 
     /// Author identity for audit (e.g. email or username).
     pub author: Option<String>,
+
+    /// Attributed identity claim for the run author (see identity module).
+    /// Supersedes the self-asserted `author` string when present — flows into
+    /// the audit envelope's redacted `identity` block.
+    #[serde(default)]
+    pub identity: Option<IdentityClaim>,
 
     /// Optional enforcement preset override.
     pub enforcement_preset: Option<String>,

--- a/engine/src/orchestrator/application/orchestrator_impl.rs
+++ b/engine/src/orchestrator/application/orchestrator_impl.rs
@@ -36,6 +36,7 @@ use crate::code_graph::application::service::CodeGraphFormatter as CodeGraphForm
 use crate::code_graph::application::service_impl::CodeGraphFormatterImpl;
 use crate::event_system::application as event_app;
 use crate::execution_engine::application::{dto as exec_dto, service as exec_svc};
+use crate::identity::domain::IdentityRef;
 use crate::plan_validation::application::dto::ValidateInput;
 use crate::plan_validation::application::service::ValidationLoopService;
 use crate::plan_validation::domain::loop_config::ValidationLoopConfig;
@@ -874,6 +875,7 @@ impl OrchestratorService for OrchestratorServiceImpl {
                     sign: false,
                     repository: input.repository.clone(),
                     author: input.author.clone(),
+                    identity: input.identity.as_ref().map(IdentityRef::from_claim),
                 })
                 .await;
         }
@@ -1189,8 +1191,7 @@ impl OrchestratorService for OrchestratorServiceImpl {
             state.status = crate::state_persistence::domain::ExecutionStatus::Pending;
             state.graph = Some(graph_for_resume);
             state.approved = Vec::new();
-            state.exec_node_states =
-                Some(exec_output.result.execution_states.clone());
+            state.exec_node_states = Some(exec_output.result.execution_states.clone());
             self.state_manager
                 .save_state(state_dto::SaveStateInput { state })
                 .await
@@ -1389,6 +1390,9 @@ impl OrchestratorService for OrchestratorServiceImpl {
                     sign: false,
                     repository: input.repository.clone(),
                     author: input.author.clone(),
+                    // run_from_template is the MCP auth-module path — the attested
+                    // claim lands here once the auth flow feeds it (identity epic).
+                    identity: None,
                 })
                 .await;
         }
@@ -1458,44 +1462,40 @@ impl OrchestratorService for OrchestratorServiceImpl {
                 %node_id,
                 "approve_execution: session not in this process — hydrating from persisted state"
             );
-                let loaded = self
-                    .state_manager
-                    .load_state(state_dto::LoadStateInput {
-                        execution_id: input.execution_id,
-                    })
-                    .await
-                    .map_err(|e| OrchestratorError::Internal {
-                        detail: format!("Failed to load paused execution state: {e}"),
-                        source_module: "orchestrator".into(),
-                    })?;
-                let Some(graph) = loaded.state.graph.clone() else {
-                    return Err(OrchestratorError::Internal {
-                        detail: format!(
-                            "Execution {} has no resumable graph in state",
-                            input.execution_id
-                        ),
-                        source_module: "orchestrator".into(),
-                    });
-                };
-                let node_states = loaded
-                    .state
-                    .exec_node_states
-                    .clone()
-                    .unwrap_or_default();
-                let approved: std::collections::HashSet<uuid::Uuid> =
-                    loaded.state.approved.iter().copied().collect();
-                self.execution_service
-                    .hydrate_execution(exec_dto::HydrateExecutionInput {
-                        dag_id: input.execution_id,
-                        graph,
-                        node_states,
-                        approved,
-                    })
-                    .await
-                    .map_err(|e| OrchestratorError::Internal {
-                        detail: format!("Failed to hydrate execution session: {e}"),
-                        source_module: "orchestrator".into(),
-                    })?;
+            let loaded = self
+                .state_manager
+                .load_state(state_dto::LoadStateInput {
+                    execution_id: input.execution_id,
+                })
+                .await
+                .map_err(|e| OrchestratorError::Internal {
+                    detail: format!("Failed to load paused execution state: {e}"),
+                    source_module: "orchestrator".into(),
+                })?;
+            let Some(graph) = loaded.state.graph.clone() else {
+                return Err(OrchestratorError::Internal {
+                    detail: format!(
+                        "Execution {} has no resumable graph in state",
+                        input.execution_id
+                    ),
+                    source_module: "orchestrator".into(),
+                });
+            };
+            let node_states = loaded.state.exec_node_states.clone().unwrap_or_default();
+            let approved: std::collections::HashSet<uuid::Uuid> =
+                loaded.state.approved.iter().copied().collect();
+            self.execution_service
+                .hydrate_execution(exec_dto::HydrateExecutionInput {
+                    dag_id: input.execution_id,
+                    graph,
+                    node_states,
+                    approved,
+                })
+                .await
+                .map_err(|e| OrchestratorError::Internal {
+                    detail: format!("Failed to hydrate execution session: {e}"),
+                    source_module: "orchestrator".into(),
+                })?;
         }
 
         // 1. Record approval in the execution engine session (by step name;
@@ -1588,6 +1588,125 @@ impl OrchestratorService for OrchestratorServiceImpl {
 mod tests {
     use super::*;
 
+    /// Captures the `BuildEnvelopeInput` the orchestrator sends to audit.
+    ///
+    /// Used by the identity AC#6 test — verifies `RunInput.identity` flows
+    /// into the envelope identity block (redacted).
+    struct CapturingAuditService {
+        captured: Arc<std::sync::Mutex<Option<audit_app::BuildEnvelopeInput>>>,
+    }
+
+    #[async_trait]
+    impl audit_app::AuditService for CapturingAuditService {
+        async fn build_and_send(
+            &self,
+            input: audit_app::BuildEnvelopeInput,
+        ) -> Result<audit_app::BuildEnvelopeOutput, crate::audit::domain::AuditError> {
+            *self.captured.lock().unwrap() = Some(input);
+            Ok(audit_app::BuildEnvelopeOutput {
+                envelope: crate::audit::domain::AuditEnvelope {
+                    execution_id: Uuid::new_v4(),
+                    timestamp: chrono::Utc::now(),
+                    template_id: "captured".into(),
+                    planning_hash: "hash".into(),
+                    source: None,
+                    repository: None,
+                    author: None,
+                    identity: None,
+                    total_tokens: 0,
+                    duration_ms: 0,
+                    git_commit: None,
+                    git_branch: None,
+                    model_version: None,
+                    planning_prompt: None,
+                    file_paths: vec![],
+                    events: vec![],
+                    scoring_results: std::collections::HashMap::new(),
+                    signature: None,
+                },
+                signed: false,
+                event_count: 0,
+            })
+        }
+
+        async fn retry_pending(
+            &self,
+        ) -> Result<audit_app::RetryPendingOutput, crate::audit::domain::AuditError> {
+            Ok(audit_app::RetryPendingOutput {
+                delivered: 0,
+                still_pending: 0,
+                dropped: 0,
+            })
+        }
+
+        async fn status(
+            &self,
+        ) -> Result<audit_app::AuditStatusOutput, crate::audit::domain::AuditError> {
+            Ok(audit_app::AuditStatusOutput {
+                pending_count: 0,
+                circuit_breaker_state: crate::audit::domain::CircuitBreakerState::Closed,
+                backend_available: false,
+            })
+        }
+    }
+
+    /// Identity AC#6: `RunInput.identity` flows into the envelope identity
+    /// block (redacted) through the real run pipeline.
+    #[tokio::test]
+    async fn test_run_input_identity_flows_into_envelope_identity_block() {
+        let captured = Arc::new(std::sync::Mutex::new(None));
+        let orch = OrchestratorServiceImpl::default_test().with_audit_service(Arc::new(
+            CapturingAuditService {
+                captured: captured.clone(),
+            },
+        ));
+
+        let claim = crate::identity::domain::IdentityClaim {
+            subject: "user@org".to_string(),
+            issuer: "https://idp.example.com".to_string(),
+            authority: Some("admin".to_string()),
+            source: crate::identity::domain::IdentitySource::IdpToken,
+            auth_method: Some("device_code".to_string()),
+            issued_at: chrono::Utc::now(),
+            expires_at: Some(chrono::Utc::now() + chrono::Duration::minutes(15)),
+            token_ref: Some("keychain://default/rigorix/idp-token".to_string()),
+        };
+
+        orch.run(RunInput {
+            intent: "test identity attestation".to_string(),
+            config: serde_json::json!({}),
+            repo_root: "/tmp/t".to_string(),
+            author: Some("legacy-author".to_string()),
+            identity: Some(claim),
+            repository: None,
+            enforcement_preset: None,
+        })
+        .await
+        .expect("run should succeed with mock services");
+
+        let envelope_input = captured
+            .lock()
+            .unwrap()
+            .take()
+            .expect("audit service must receive the built envelope input");
+
+        let identity_ref = envelope_input
+            .identity
+            .expect("envelope identity block must be populated from RunInput.identity");
+        assert_eq!(identity_ref.subject, "user@org");
+        assert_eq!(identity_ref.issuer, "https://idp.example.com");
+        assert_eq!(
+            identity_ref.source,
+            crate::identity::domain::IdentitySource::IdpToken
+        );
+        assert_eq!(identity_ref.authority, Some("admin".to_string()));
+
+        // Redacted: no token_ref and no token locator survive into the block.
+        let json = serde_json::to_string(&identity_ref).expect("serialize identity ref");
+        assert!(!json.contains("token_ref"));
+        assert!(!json.contains("keychain"));
+    }
+
     #[tokio::test]
     async fn test_run_returns_execution_id() {
         let orch = OrchestratorServiceImpl::default_test();
@@ -1597,6 +1716,7 @@ mod tests {
                 config: serde_json::json!({}),
                 repo_root: "/tmp/t".into(),
                 author: None,
+                identity: None,
                 repository: None,
                 enforcement_preset: None,
             })
@@ -1616,6 +1736,7 @@ mod tests {
                 config: serde_json::json!({}),
                 repo_root: "/tmp/t".into(),
                 author: None,
+                identity: None,
                 repository: None,
                 enforcement_preset: None,
             })
@@ -1634,6 +1755,7 @@ mod tests {
                 config: serde_json::json!({}),
                 repo_root: "/tmp/t".into(),
                 author: None,
+                identity: None,
                 repository: None,
                 enforcement_preset: None,
             })
@@ -1651,6 +1773,7 @@ mod tests {
                 config: serde_json::json!({}),
                 repo_root: "/tmp/repo".into(),
                 author: None,
+                identity: None,
                 repository: None,
                 enforcement_preset: None,
             })
@@ -1695,6 +1818,7 @@ mod tests {
                 config: serde_json::json!({}),
                 repo_root: "/tmp/t".into(),
                 author: None,
+                identity: None,
                 repository: None,
                 enforcement_preset: None,
             })
@@ -1806,6 +1930,7 @@ mod tests {
                 config: serde_json::json!({}),
                 repo_root: "/tmp/t".into(),
                 author: None,
+                identity: None,
                 repository: None,
                 enforcement_preset: None,
             })

--- a/engine/src/orchestrator/application/orchestrator_mocks.rs
+++ b/engine/src/orchestrator/application/orchestrator_mocks.rs
@@ -235,10 +235,8 @@ impl exec_svc::ParallelExecutionService for MockExecutionService {
     async fn hydrate_execution(
         &self,
         _: exec_dto::HydrateExecutionInput,
-    ) -> Result<
-        exec_dto::HydrateExecutionOutput,
-        crate::execution_engine::domain::ExecutionError,
-    > {
+    ) -> Result<exec_dto::HydrateExecutionOutput, crate::execution_engine::domain::ExecutionError>
+    {
         unimplemented!("MockExecutionService::hydrate_execution not needed by current tests")
     }
     async fn abort_execution(
@@ -505,6 +503,7 @@ impl crate::audit::application::AuditService for MockAuditService {
                 signature: None,
                 repository: None,
                 author: None,
+                identity: None,
             },
             signed: false,
             event_count: 0,

--- a/engine/tests/audit_trail_integration.rs
+++ b/engine/tests/audit_trail_integration.rs
@@ -40,6 +40,7 @@ async fn test_audit_envelope_has_hmac_signature() {
         sign: true,
         repository: None,
         author: None,
+        identity: None,
     };
 
     let envelope = factory.build_envelope(input).await.unwrap();

--- a/engine/tests/identity_envelope_integration.rs
+++ b/engine/tests/identity_envelope_integration.rs
@@ -1,0 +1,118 @@
+//! Integration test: identity flows into the envelope identity block (redacted).
+//!
+//! Covers identity module acceptance criterion #6:
+//! "RunInput.identity flows into envelope identity block (redacted)".
+//!
+//! Uses the REAL envelope factory (`AuditEnvelopeFactoryImpl`) and the real
+//! redaction mapping (`IdentityRef::from_claim`) — the same types the
+//! orchestrator wires on the run path. The full orchestrator run-path
+//! equivalent lives in `orchestrator_impl.rs` tests (crate-internal mocks).
+
+use rigorix_engine::audit::application::dto::BuildEnvelopeInput;
+use rigorix_engine::audit::application::envelope_factory_impl::AuditEnvelopeFactoryImpl;
+use rigorix_engine::audit::application::factory::AuditEnvelopeFactory;
+use rigorix_engine::identity::domain::{IdentityClaim, IdentityRef, IdentitySource};
+
+/// Attested sample claim — token preserved only by reference.
+fn sample_claim() -> IdentityClaim {
+    IdentityClaim {
+        subject: "user@org".to_string(),
+        issuer: "https://idp.example.com".to_string(),
+        authority: Some("admin".to_string()),
+        source: IdentitySource::IdpToken,
+        auth_method: Some("device_code".to_string()),
+        issued_at: chrono::Utc::now(),
+        expires_at: Some(chrono::Utc::now() + chrono::Duration::minutes(15)),
+        token_ref: Some("keychain://default/rigorix/idp-token".to_string()),
+    }
+}
+
+fn envelope_input(identity: Option<IdentityRef>) -> BuildEnvelopeInput {
+    BuildEnvelopeInput {
+        execution_id: uuid::Uuid::new_v4(),
+        template_id: "test-template".to_string(),
+        planning_prompt: "Read src/lib.rs".to_string(),
+        events: vec![],
+        source: None,
+        repository: None,
+        author: Some("legacy-author".to_string()),
+        identity,
+        total_tokens: 0,
+        duration_ms: 0,
+        git_commit: None,
+        git_branch: None,
+        model_version: None,
+        planning_prompt_content: None,
+        file_paths: vec![],
+        metadata: None,
+        scoring_results: std::collections::HashMap::new(),
+        sign: false,
+    }
+}
+
+#[tokio::test]
+async fn test_envelope_factory_populates_identity_block_from_input() {
+    let factory = AuditEnvelopeFactoryImpl::new(None);
+    let claim = sample_claim();
+
+    let envelope = factory
+        .build_envelope(envelope_input(Some(IdentityRef::from_claim(&claim))))
+        .await
+        .expect("envelope builds");
+
+    let identity_ref = envelope
+        .identity
+        .expect("envelope identity block must be populated");
+    assert_eq!(identity_ref.subject, "user@org");
+    assert_eq!(identity_ref.issuer, "https://idp.example.com");
+    assert_eq!(identity_ref.source, IdentitySource::IdpToken);
+    assert_eq!(identity_ref.authority, Some("admin".to_string()));
+}
+
+#[tokio::test]
+async fn test_envelope_without_identity_keeps_block_absent() {
+    let factory = AuditEnvelopeFactoryImpl::new(None);
+    let envelope = factory
+        .build_envelope(envelope_input(None))
+        .await
+        .expect("envelope builds");
+    assert!(
+        envelope.identity.is_none(),
+        "no identity => no identity block"
+    );
+    // Backward compatible: field is serde-defaulted and skipped when absent.
+    let json = serde_json::to_string(&envelope).expect("serialize envelope");
+    assert!(
+        !json.contains("\"identity\""),
+        "absent block must be skipped: {json}"
+    );
+}
+
+#[test]
+fn test_identity_ref_redaction_never_leaks_token() {
+    let claim = sample_claim();
+    let identity_ref = IdentityRef::from(&claim);
+
+    let ref_json = serde_json::to_string(&identity_ref).expect("serialize ref");
+    assert!(
+        !ref_json.contains("token_ref"),
+        "identity ref must not carry token_ref: {ref_json}"
+    );
+    assert!(
+        !ref_json.contains("keychain"),
+        "token locator leaked: {ref_json}"
+    );
+    assert!(
+        !ref_json.contains("eyJhbGci"),
+        "raw token payload leaked: {ref_json}"
+    );
+
+    // Full envelope serialization with the identity block present.
+    let envelope_json = serde_json::to_string(&serde_json::json!({
+        "execution_id": uuid::Uuid::new_v4(),
+        "identity": identity_ref,
+    }))
+    .expect("serialize envelope shape");
+    assert!(!envelope_json.contains("keychain"));
+    assert!(!envelope_json.contains("token_ref"));
+}

--- a/mcp/src/execution_tools/infrastructure/engine_facade_impl.rs
+++ b/mcp/src/execution_tools/infrastructure/engine_facade_impl.rs
@@ -417,6 +417,9 @@ impl EngineFacade for EngineFacadeImpl {
             repo_root: self.config.repo_root.clone(),
             repository,
             author,
+            // Identity attestation arrives with the MCP auth module (ADR-012):
+            // the engine facade receives the attested claim from the auth flow.
+            identity: None,
             enforcement_preset: None,
         };
 


### PR DESCRIPTION
## Issue Closeout

Closes #701

### Summary

Implements **IdentityClaim** (ISSUE-IDENTITY-1) — the shared identity value type
for the identity epic, plus the AC#6 cross-module wiring:

1. **`is_valid()`** — correct across the expiry boundary (no expiry → valid; future expiry → valid; past expiry → invalid)
2. **`redacted_summary()`** — SpanPrivacy pattern: subject/issuer/source/authority rendered; `token_ref` and raw token never appear
3. **`IdentityRef`** — new redacted envelope ref (subject, issuer, source, authority, expires_at) with `From<&IdentityClaim>`; deliberately drops `token_ref`
4. **AC#6 wiring** — `RunInput.identity: Option<IdentityClaim>` → envelope factory → `AuditEnvelope.identity: Option<IdentityRef>` (serde-defaulted, skip-if-none — backward compatible). Redaction happens at the boundary: raw token never leaves the claim.

### Acceptance Criteria Verification

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Serde round-trip preserves all fields; `redacted_summary()` never contains raw token | ✅ | `redacted_summary_contains_subject_but_never_raw_token`, `identity_ref_from_claim_redacts_token_ref`, `identity_ref_serde_round_trip` — 23 identity unit tests pass |
| 2 | `is_valid()` correct across expiry boundary | ✅ | `is_valid_none_expiry_is_valid`, `is_valid_future_expiry_is_valid`, `is_valid_past_expiry_is_invalid` |
| 6 | RunInput.identity flows into envelope identity block (redacted) | ✅ | `tests/identity_envelope_integration.rs` (3 tests, real envelope factory) + E2E `test_run_input_identity_flows_into_envelope_identity_block` (real run pipeline, capturing audit service) |

### Validator Results

| Validator | Status | Details |
|-----------|--------|---------|
| CI | ⚠️ 4/5 | Build ✅ Tests ✅ Clippy ✅ Canonical ✅; Format ❌ pre-existing on main (unchanged debt, identity files fmt-clean) |
| Test | ✅ | Workspace 2707 passed / 0 failed; identity 23; integration 3; E2E run-flow 1 (validate-tests.sh "integration" failure = pre-existing script bug: no test target named `integration` in this repo) |
| Architecture | ✅ | check_architecture_conformance.sh 8/8; DDD dependency direction clean |
| Canonical | ✅ | validate-canonical.sh 3/3 (487/502 files) |
| Security | ✅ | Raw token leakage prevented at the redaction boundary; SpanPrivacy documented |

### Files Changed

| File | Change Type | Reason |
|------|-------------|--------|
| `src/identity/domain/claim.rs` | modified | `is_valid()`/`redacted_summary()` implementations, `IdentitySource` Display, new `IdentityRef` |
| `src/audit/domain/envelope.rs` | modified | Additive `identity: Option<IdentityRef>` block (serde default + skip) |
| `src/audit/application/{dto,factory,queue,sender,service}*.rs`, `local_audit_repository.rs` | modified | `BuildEnvelopeInput.identity`, factory wiring, construction sites |
| `src/orchestrator/application/{dto,orchestrator_impl,orchestrator_mocks,builder_impl}.rs` | modified | `RunInput.identity`, run-path mapping `IdentityRef::from_claim`, E2E test |
| `mcp`, `actions`, `cli` RunInput sites | modified | Additive `identity: None` (auth module integration later) |
| `tests/identity_envelope_integration.rs` | added | AC#6 integration coverage |

### Testing Evidence

```bash
$ cargo test --workspace        # 2707 passed, 0 failed
$ cargo test --test identity_envelope_integration   # 3 passed
$ cargo clippy --workspace --lib -- -D warnings     # 0 errors
$ cargo build --workspace        # clean
```

### Manual Testing Performed

- Expiry boundary: None/future/past assertions pass
- `redacted_summary()` contains subject; rejects `token_ref`, locator, and JWT payload
- Envelope serialization with identity block never contains `keychain` or `token_ref`
- Absent identity → envelope block skipped (backward compatible)

### Deployment Notes

- No migrations, no config changes — additive serde-defaulted fields
- `run_from_template` (MCP auth path) wired `identity: None` until the auth module attests claims (identity epic)

---

🤖 Generated with Guardian compliance workflow
