### PR TITLE
[Issue #702] Implement IdentitySource — attestation degradation to Unverified (explicit, no error)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1963,6 +1963,7 @@ name = "rigorix-engine"
 version = "1.2.0"
 dependencies = [
  "async-trait",
+ "base64",
  "chrono",
  "criterion",
  "hex",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -23,6 +23,7 @@ chrono.workspace = true
 sha2 = "0.11.0"
 hmac = "0.13.0"
 hex = "0.4"
+base64 = "0.22"
 reqwest.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/engine/src/identity/application/mod.rs
+++ b/engine/src/identity/application/mod.rs
@@ -19,6 +19,8 @@
 
 pub mod dto;
 pub mod service;
+pub mod service_impl;
 
 pub use dto::{AttestInput, AttestOutput};
 pub use service::{IdentityAttestationService, VerificationOutcome};
+pub use service_impl::IdentityAttestationServiceImpl;

--- a/engine/src/identity/application/service_impl.rs
+++ b/engine/src/identity/application/service_impl.rs
@@ -1,0 +1,270 @@
+//! IdentityAttestationServiceImpl — converts presented credentials into attested claims.
+//!
+//! @canonical .pi/architecture/modules/identity.md#identityattestationservice
+//! Implements: ISSUE-IDENTITY-2 — attestation with explicit `Unverified` degradation
+//! Issue: #702 (identity epic)
+//!
+//! Converts a presented IdP token (or local principal) into a structured,
+//! time-bound `IdentityClaim`, with best-effort signature verification.
+//!
+//! # Degradation Contract (AC#4)
+//!
+//! Attestation **never fails closed on identity** (ADR-012): when the IdP is
+//! unreachable (or verification is unavailable/disabled), the claim degrades
+//! to `IdentitySource::Unverified` — an explicit, never-silent marker — and
+//! `attest` returns `Ok(claim)`, **not an error**. The default verifier
+//! (`NullVerifier`) is the offline default and yields `Unverified`.
+//!
+//! # OSS Attests / Enterprise Authorizes (ADR-012)
+//!
+//! This implementation makes **no authorization judgment** — it only records
+//! who was presented as acting and marks the verification outcome.
+
+use async_trait::async_trait;
+use base64::Engine as _;
+
+use crate::identity::application::dto::AttestInput;
+use crate::identity::application::service::{IdentityAttestationService, VerificationOutcome};
+use crate::identity::domain::{IdentityClaim, IdentityError, IdentitySource};
+use crate::identity::infrastructure::verifier::{NullVerifier, TokenVerifier};
+
+/// Default implementation of `IdentityAttestationService`.
+///
+/// Verification is best-effort via an injected `TokenVerifier`; the default is
+/// `NullVerifier` (offline — attestation proceeds without network verification).
+pub struct IdentityAttestationServiceImpl {
+    /// Best-effort signature verifier (JWKS-backed when online).
+    verifier: Box<dyn TokenVerifier>,
+}
+
+impl IdentityAttestationServiceImpl {
+    /// Create the service with the offline default verifier (`NullVerifier`).
+    pub fn new() -> Self {
+        Self {
+            verifier: Box::new(NullVerifier::new()),
+        }
+    }
+
+    /// Create the service with a custom verifier (e.g. JWKS-backed).
+    pub fn with_verifier(verifier: Box<dyn TokenVerifier>) -> Self {
+        Self { verifier }
+    }
+}
+
+impl Default for IdentityAttestationServiceImpl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl IdentityAttestationService for IdentityAttestationServiceImpl {
+    async fn attest(&self, input: AttestInput) -> Result<IdentityClaim, IdentityError> {
+        // 1. Build the initial claim from the presented credential.
+        let mut claim = match (input.token.as_deref(), input.principal.as_deref()) {
+            (Some(token), _) => self.extract_claims(token)?,
+            (None, Some(principal)) => IdentityClaim {
+                subject: principal.to_string(),
+                issuer: input.issuer.clone().unwrap_or_else(|| "local".to_string()),
+                authority: None,
+                source: IdentitySource::LocalPrincipal,
+                auth_method: input.auth_method.clone(),
+                issued_at: chrono::Utc::now(),
+                expires_at: None,
+                token_ref: None,
+            },
+            (None, None) => {
+                return Err(IdentityError::MissingClaim(
+                    "presented identity: token or principal".to_string(),
+                ));
+            }
+        };
+
+        // 2. Best-effort verification — an unreachable IdP degrades the claim,
+        //    it never turns attestation into an error (ADR-012 offline policy).
+        if let Some(token) = input.token.as_deref() {
+            match self.verify(&claim, token).await {
+                Ok(VerificationOutcome::Verified) => {}
+                Ok(VerificationOutcome::Unverified { .. }) => {
+                    // Explicit degraded marker — never silent.
+                    claim.source = IdentitySource::Unverified;
+                    // Roles presented in an unverified token are not evidence.
+                    claim.authority = None;
+                }
+                Err(_) => {
+                    // Non-fatal for attestation: verification unavailability
+                    // degrades the claim instead of failing the run/approval.
+                    claim.source = IdentitySource::Unverified;
+                    claim.authority = None;
+                }
+            }
+        }
+
+        Ok(claim)
+    }
+
+    /// Extract standard JWT claims (`sub`, `iss`, `exp`, `roles`) WITHOUT
+    /// signature verification. Used for attestation; verification is separate
+    /// and best-effort.
+    fn extract_claims(&self, token: &str) -> Result<IdentityClaim, IdentityError> {
+        // JWT shape: header.payload.signature (all base64url segments).
+        let segments: Vec<&str> = token.split('.').collect();
+        if segments.len() != 3 {
+            return Err(IdentityError::InvalidToken(format!(
+                "expected 3 JWT segments, found {}",
+                segments.len()
+            )));
+        }
+
+        // Decode the payload segment (base64url, unpadded).
+        let payload_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(segments[1])
+            .map_err(|e| IdentityError::InvalidToken(format!("payload decode: {e}")))?;
+
+        let claims: serde_json::Value = serde_json::from_slice(&payload_bytes)
+            .map_err(|e| IdentityError::InvalidToken(format!("payload JSON: {e}")))?;
+
+        let subject = claims
+            .get("sub")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| IdentityError::MissingClaim("sub".to_string()))?
+            .to_string();
+
+        let issuer = claims
+            .get("iss")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| IdentityError::MissingClaim("iss".to_string()))?
+            .to_string();
+
+        // `exp` is a numeric date (seconds since epoch). Expired claims are
+        // rejected at extraction — re-authentication is required.
+        let expires_at = claims
+            .get("exp")
+            .and_then(serde_json::Value::as_i64)
+            .map(|ts| chrono::DateTime::<chrono::Utc>::from_timestamp(ts, 0));
+        if let Some(Some(exp)) = expires_at
+            && exp <= chrono::Utc::now()
+        {
+            return Err(IdentityError::Expired);
+        }
+
+        // `roles` (standard JWT claim) → authority (captured fact, not judgment).
+        let authority = match claims.get("roles") {
+            Some(serde_json::Value::Array(roles)) => {
+                let rendered: Vec<String> = roles
+                    .iter()
+                    .filter_map(serde_json::Value::as_str)
+                    .map(String::from)
+                    .collect();
+                if rendered.is_empty() {
+                    None
+                } else {
+                    Some(rendered.join(", "))
+                }
+            }
+            Some(serde_json::Value::String(role)) => Some(role.clone()),
+            _ => None,
+        };
+
+        let issued_at = claims
+            .get("iat")
+            .and_then(serde_json::Value::as_i64)
+            .and_then(|ts| chrono::DateTime::<chrono::Utc>::from_timestamp(ts, 0))
+            .unwrap_or_else(chrono::Utc::now);
+
+        Ok(IdentityClaim {
+            subject,
+            issuer,
+            authority,
+            source: IdentitySource::IdpToken,
+            auth_method: claims
+                .get("auth_method")
+                .and_then(serde_json::Value::as_str)
+                .map(String::from),
+            issued_at,
+            expires_at: expires_at.flatten(),
+            token_ref: None,
+        })
+    }
+
+    /// Best-effort signature verification against the IdP JWKS.
+    ///
+    /// Delegates to the injected `TokenVerifier` (default `NullVerifier` =
+    /// offline). An unreachable IdP yields `VerificationOutcome::Unverified`,
+    /// never an error.
+    async fn verify(
+        &self,
+        claim: &IdentityClaim,
+        token: &str,
+    ) -> Result<VerificationOutcome, IdentityError> {
+        self.verifier.verify(token, claim).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine as _;
+
+    /// Build an unsigned JWT string from a claims payload (for extraction tests).
+    fn make_jwt(claims: serde_json::Value) -> String {
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(r#"{"alg":"none","typ":"JWT"}"#);
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&claims).expect("claims JSON"));
+        format!("{header}.{payload}.signature-placeholder")
+    }
+
+    #[test]
+    fn extract_claims_decodes_standard_claims() {
+        let token = make_jwt(serde_json::json!({
+            "sub": "user@org",
+            "iss": "https://idp.example.com",
+            "exp": chrono::Utc::now().timestamp() + 600,
+            "roles": ["admin", "dev"],
+            "auth_method": "device_code",
+        }));
+        let service = IdentityAttestationServiceImpl::new();
+        let claim = service.extract_claims(&token).expect("extract claims");
+
+        assert_eq!(claim.subject, "user@org");
+        assert_eq!(claim.issuer, "https://idp.example.com");
+        assert_eq!(claim.source, IdentitySource::IdpToken);
+        assert_eq!(claim.authority.as_deref(), Some("admin, dev"));
+        assert_eq!(claim.auth_method.as_deref(), Some("device_code"));
+        assert!(claim.is_valid());
+    }
+
+    #[test]
+    fn extract_claims_rejects_malformed_token() {
+        let service = IdentityAttestationServiceImpl::new();
+        assert!(matches!(
+            service.extract_claims("not-a-jwt"),
+            Err(IdentityError::InvalidToken(_))
+        ));
+    }
+
+    #[test]
+    fn extract_claims_rejects_missing_required_claims() {
+        let token = make_jwt(serde_json::json!({ "sub": "user@org" })); // no iss
+        let service = IdentityAttestationServiceImpl::new();
+        assert!(matches!(
+            service.extract_claims(&token),
+            Err(IdentityError::MissingClaim(ref c)) if c == "iss"
+        ));
+    }
+
+    #[test]
+    fn extract_claims_rejects_expired_token() {
+        let token = make_jwt(serde_json::json!({
+            "sub": "user@org",
+            "iss": "https://idp.example.com",
+            "exp": chrono::Utc::now().timestamp() - 60,
+        }));
+        let service = IdentityAttestationServiceImpl::new();
+        assert!(matches!(
+            service.extract_claims(&token),
+            Err(IdentityError::Expired)
+        ));
+    }
+}

--- a/engine/src/identity/infrastructure/verifier.rs
+++ b/engine/src/identity/infrastructure/verifier.rs
@@ -68,16 +68,18 @@ impl Default for NullVerifier {
 
 #[async_trait]
 impl TokenVerifier for NullVerifier {
-    /// # TODO
-    /// Offline default: returns `VerificationOutcome::Unverified` with an
-    /// explicit reason (no IdP reachable). Implemented in ISSUE-IDENTITY-4
-    /// (TokenVerifier). Contract stub — behavior lands with the implementation.
+    /// Offline default (ADR-012 option c): no IdP is reachable, so verification
+    /// is unavailable and the outcome is explicitly `Unverified` — never an
+    /// error. Attestation degrades the claim to `IdentitySource::Unverified`.
+    /// Implemented in ISSUE-IDENTITY-2 (the offline default's stated contract).
     async fn verify(
         &self,
         _token: &str,
         _claim: &IdentityClaim,
     ) -> Result<VerificationOutcome, IdentityError> {
-        todo!("ISSUE-IDENTITY-4 (TokenVerifier): implement NullVerifier offline default")
+        Ok(VerificationOutcome::Unverified {
+            reason: "verification disabled — offline default (NullVerifier)".to_string(),
+        })
     }
 }
 

--- a/engine/tests/identity_attestation_integration.rs
+++ b/engine/tests/identity_attestation_integration.rs
@@ -1,0 +1,163 @@
+//! Integration test: attestation with an unreachable IdP degrades to
+//! `IdentitySource::Unverified` — explicit marker, no error.
+//!
+//! Covers identity module acceptance criterion #4:
+//! "attest with unreachable IdP → `IdentitySource::Unverified`, explicit marker,
+//! no error".
+//!
+//! Offline-first policy (ADR-012): an unreachable IdP (or the offline default
+//! `NullVerifier`) degrades the claim to `Unverified` — the run/approval never
+//! fails because the IdP is down.
+
+use async_trait::async_trait;
+use base64::Engine as _;
+
+use rigorix_engine::identity::application::dto::AttestInput;
+use rigorix_engine::identity::application::service::{
+    IdentityAttestationService, VerificationOutcome,
+};
+use rigorix_engine::identity::application::service_impl::IdentityAttestationServiceImpl;
+use rigorix_engine::identity::domain::{IdentityClaim, IdentityError, IdentitySource};
+use rigorix_engine::identity::infrastructure::verifier::{NullVerifier, TokenVerifier};
+
+/// Build a well-formed (unsigned) JWT with standard claims — signature
+/// verification is a separate concern (best-effort).
+fn make_jwt() -> String {
+    let header =
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(r#"{"alg":"none","typ":"JWT"}"#);
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(
+        serde_json::to_vec(&serde_json::json!({
+            "sub": "user@org",
+            "iss": "https://idp.example.com",
+            "exp": chrono::Utc::now().timestamp() + 600,
+            "roles": ["admin"],
+            "auth_method": "device_code",
+        }))
+        .expect("claims JSON"),
+    );
+    format!("{header}.{payload}.signature-placeholder")
+}
+
+/// Simulates an IdP that is unreachable on the network — verification is
+/// attempted and cannot run, so the outcome is `Unverified` with a reason.
+struct UnreachableIdpVerifier;
+
+#[async_trait]
+impl TokenVerifier for UnreachableIdpVerifier {
+    async fn verify(
+        &self,
+        _token: &str,
+        _claim: &IdentityClaim,
+    ) -> Result<VerificationOutcome, IdentityError> {
+        Ok(VerificationOutcome::Unverified {
+            reason: "idp unreachable: connection refused".to_string(),
+        })
+    }
+}
+
+#[tokio::test]
+async fn test_attest_with_unreachable_idp_degrades_to_unverified_no_error() {
+    let service = IdentityAttestationServiceImpl::with_verifier(Box::new(UnreachableIdpVerifier));
+
+    let result = service
+        .attest(AttestInput {
+            token: Some(make_jwt()),
+            principal: None,
+            issuer: Some("https://idp.example.com".to_string()),
+            auth_method: Some("device_code".to_string()),
+        })
+        .await;
+
+    // Explicit marker, no error — attestation never fail-closes on identity.
+    let claim = result.expect("attest must NOT error when the IdP is unreachable");
+    assert_eq!(
+        claim.source,
+        IdentitySource::Unverified,
+        "claim must carry the explicit Unverified marker"
+    );
+    // Roles presented in an unverified token are not evidence.
+    assert_eq!(claim.authority, None);
+}
+
+#[tokio::test]
+async fn test_attest_offline_default_degrades_to_unverified() {
+    // The offline default (NullVerifier) means no IdP is reachable.
+    let service = IdentityAttestationServiceImpl::new();
+
+    let claim = service
+        .attest(AttestInput {
+            token: Some(make_jwt()),
+            principal: None,
+            issuer: Some("https://idp.example.com".to_string()),
+            auth_method: None,
+        })
+        .await
+        .expect("attest must not error");
+
+    assert_eq!(
+        claim.source,
+        IdentitySource::Unverified,
+        "offline default marks the IdP-token claim Unverified explicitly"
+    );
+    assert_eq!(claim.subject, "user@org");
+    assert_eq!(claim.authority, None, "unverified roles are not evidence");
+}
+
+#[tokio::test]
+async fn test_attest_local_principal_stays_local_principal() {
+    // A local principal is attributed locally — no IdP verification applies,
+    // so the honest marker is LocalPrincipal (not Unverified).
+    let service = IdentityAttestationServiceImpl::new();
+    let claim = service
+        .attest(AttestInput {
+            token: None,
+            principal: Some("os-user".to_string()),
+            issuer: Some("local".to_string()),
+            auth_method: None,
+        })
+        .await
+        .expect("attest must not error");
+    assert_eq!(claim.source, IdentitySource::LocalPrincipal);
+    assert_eq!(claim.subject, "os-user");
+}
+
+#[tokio::test]
+async fn test_attest_without_any_credential_is_an_error() {
+    let service = IdentityAttestationServiceImpl::new();
+    let result = service
+        .attest(AttestInput {
+            token: None,
+            principal: None,
+            issuer: None,
+            auth_method: None,
+        })
+        .await;
+    assert!(
+        matches!(result, Err(IdentityError::MissingClaim(_))),
+        "no presented identity => MissingClaim"
+    );
+}
+
+#[test]
+fn test_null_verifier_is_offline_default_and_returns_unverified() {
+    // The offline default must be constructible and must yield Unverified
+    // (never panic, never error) — this is what keeps attestation offline-capable.
+    let verifier = NullVerifier::new();
+    let runtime = tokio::runtime::Runtime::new().expect("runtime");
+    let outcome = runtime
+        .block_on(verifier.verify(
+            "token",
+            &IdentityClaim {
+                subject: "user@org".to_string(),
+                issuer: "https://idp.example.com".to_string(),
+                authority: None,
+                source: IdentitySource::IdpToken,
+                auth_method: None,
+                issued_at: chrono::Utc::now(),
+                expires_at: None,
+                token_ref: None,
+            },
+        ))
+        .expect("NullVerifier never errors");
+    assert!(matches!(outcome, VerificationOutcome::Unverified { .. }));
+}


### PR DESCRIPTION
## Issue Closeout

Closes #702

### Summary

Implements **IdentitySource** degradation behavior (ISSUE-IDENTITY-2, AC#4):

**attest with unreachable IdP → `IdentitySource::Unverified`, explicit marker, no error**

- `IdentityAttestationServiceImpl` (new): `attest()` builds a claim from a presented token (`extract_claims`) or local principal, runs best-effort verification, and **degrades to `Unverified` when the IdP is unreachable — never returning an error** (ADR-012 offline-first policy; never fail-closed on identity for a local dev tool)
- `extract_claims()`: decodes standard JWT claims (sub, iss, exp, roles → authority, auth_method, iat) — base64url payload, `MissingClaim`/`Expired` errors
- `verify()`: delegates to injected `TokenVerifier`
- `NullVerifier::verify` implemented: offline default returns `VerificationOutcome::Unverified { reason }` — never panics, never errors
- New `base64` dependency (MIT/Apache-2.0, allowed by deny.toml)

The degradation marker is **explicit, never silent** — consumers see `source: "unverified"` in every serialized claim.

### Acceptance Criteria Verification

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 4 | attest with unreachable IdP → `IdentitySource::Unverified`, explicit marker, no error | ✅ | `tests/identity_attestation_integration.rs` ×5: unreachable-IdP verifier no-error, offline default (NullVerifier), local principal stays LocalPrincipal, missing credential → MissingClaim, NullVerifier offline |

### Design Notes

- **Token attestation** with unreachable IdP → `Unverified` + authority cleared (unverified roles are not evidence)
- **Principal attestation** → stays `LocalPrincipal` (local attribution needs no IdP verification)
- **Malformed token** → `InvalidToken` error (contract: not retriable, reject presented identity)
- **No credential** → `MissingClaim` error

### Validator Results

| Validator | Status | Details |
|-----------|--------|---------|
| CI | ⚠️ 4/5 | Build ✅ Tests ✅ Clippy ✅ Canonical ✅; Format ❌ pre-existing debt on main (zero new violations) |
| Test | ✅ | Workspace 2716 passed / 0 failed (identity 27, attestation integration 5) |
| Architecture | ✅ | check_architecture_conformance.sh 8/8 |
| Canonical | ✅ | validate-canonical.sh 3/3 |
| Security | ✅ | No raw tokens in claims; degradation explicit |

### Files Changed

| File | Change Type | Reason |
|------|-------------|--------|
| `src/identity/application/service_impl.rs` | added | IdentityAttestationServiceImpl — attest/extract_claims/verify + unit tests |
| `src/identity/infrastructure/verifier.rs` | modified | NullVerifier::verify offline default (Unverified, no error) |
| `src/identity/application/mod.rs` | modified | Export IdentityAttestationServiceImpl |
| `Cargo.toml`, `Cargo.lock` | modified | Add base64 dep for JWT payload decode |
| `tests/identity_attestation_integration.rs` | added | AC#4 integration coverage |

### Testing Evidence

```bash
$ cargo test --workspace        # 2716 passed, 0 failed
$ cargo test --test identity_attestation_integration   # 5 passed
$ cargo clippy --workspace --lib -- -D warnings        # 0 errors
```

---

🤖 Generated with Guardian compliance workflow
