### PR TITLE
[Issue #703] Implement IdentityAttestationService — JWKS verification (valid→Verified, tampered→Unverified)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +403,12 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -610,6 +622,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -633,7 +656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -1311,6 +1334,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1323,6 +1349,12 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -1430,10 +1462,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1442,6 +1509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1518,6 +1586,27 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "plotters"
@@ -1973,6 +2062,7 @@ dependencies = [
  "rand 0.10.1",
  "regex",
  "reqwest",
+ "rsa",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -2027,6 +2117,27 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2287,6 +2398,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2306,6 +2427,22 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -24,6 +24,7 @@ sha2 = "0.11.0"
 hmac = "0.13.0"
 hex = "0.4"
 base64 = "0.22"
+rsa = { version = "0.9", default-features = false, features = ["sha2", "std"] }
 reqwest.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/engine/src/identity/infrastructure/mod.rs
+++ b/engine/src/identity/infrastructure/mod.rs
@@ -19,4 +19,4 @@ pub mod repository;
 pub mod verifier;
 
 pub use repository::IdentityRepository;
-pub use verifier::{NullVerifier, TokenVerifier};
+pub use verifier::{JwksVerifier, NullVerifier, TokenVerifier};

--- a/engine/src/identity/infrastructure/verifier.rs
+++ b/engine/src/identity/infrastructure/verifier.rs
@@ -1,22 +1,28 @@
 //! TokenVerifier — best-effort signature verification against the IdP JWKS.
 //!
 //! @canonical .pi/architecture/modules/identity.md#tokenverifier
-//! Implements: Contract Freeze — TokenVerifier trait + NullVerifier (offline default)
-//! Issue: #700 (identity epic — contract freeze)
+//! Implements: ISSUE-IDENTITY-3 — JWKS-backed RS256 verification (AC#5)
+//! Issue: #703 (identity epic)
 //!
 //! Best-effort signature verification keeps attestation fully offline-capable
 //! (ADR-012 option c): an unreachable IdP yields
 //! `VerificationOutcome::Unverified`, never an error. The `NullVerifier`
 //! struct is the offline default — attestation proceeds without network
-//! verification.
+//! verification. The `JwksVerifier` fetches the IdP JWKS and validates the
+//! token signature (RS256) when online.
 //!
 //! # Contract (Frozen)
 //! - `verify` never errors on an unreachable IdP — it records `Unverified`
 //! - `NullVerifier` is the offline default and is constructible via
 //!   `NullVerifier::new()`
-//! - Concrete JWKS-backed implementations land in ISSUE-IDENTITY-4
+//! - `JwksVerifier` (JWKS-backed, RS256) lands in ISSUE-IDENTITY-3
 
 use async_trait::async_trait;
+use base64::Engine as _;
+use rsa::pkcs1v15::{Signature, VerifyingKey};
+use rsa::sha2::Sha256;
+use rsa::signature::Verifier;
+use rsa::{BigUint, RsaPublicKey};
 
 use crate::identity::application::service::VerificationOutcome;
 use crate::identity::domain::{IdentityClaim, IdentityError};
@@ -91,5 +97,174 @@ mod tests {
     fn null_verifier_is_constructible() {
         let verifier = NullVerifier::new();
         let _offline_default: &dyn TokenVerifier = &verifier;
+    }
+}
+
+/// JWKS-backed best-effort token verifier (RS256).
+///
+/// Fetches the IdP's JSON Web Key Set (`/.well-known/jwks.json`), resolves the
+/// signing key by `kid`, and validates the RS256 signature. Best-effort: an
+/// unreachable IdP, unknown `kid`, or verification failure yields
+/// `VerificationOutcome::Unverified` — never an error (ADR-012 option c).
+pub struct JwksVerifier {
+    /// IdP JWKS endpoint (e.g. `https://idp.example.com/.well-known/jwks.json`).
+    jwks_url: String,
+    /// HTTP client with a bounded timeout.
+    client: reqwest::Client,
+}
+
+impl JwksVerifier {
+    /// Create a JWKS-backed verifier for the given IdP JWKS endpoint.
+    pub fn new(jwks_url: impl Into<String>) -> Self {
+        Self {
+            jwks_url: jwks_url.into(),
+            client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(5))
+                .build()
+                .unwrap_or_default(),
+        }
+    }
+
+    /// Parse the JWT header and extract the `kid` (and expected `alg`).
+    fn header_kid_alg(token: &str) -> Result<(String, String), IdentityError> {
+        let header_segment = token
+            .split('.')
+            .next()
+            .ok_or_else(|| IdentityError::InvalidToken("missing header segment".to_string()))?;
+        let header_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(header_segment)
+            .map_err(|e| IdentityError::InvalidToken(format!("header decode: {e}")))?;
+        let header: serde_json::Value = serde_json::from_slice(&header_bytes)
+            .map_err(|e| IdentityError::InvalidToken(format!("header JSON: {e}")))?;
+        let kid = header
+            .get("kid")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| IdentityError::MissingClaim("kid".to_string()))?
+            .to_string();
+        let alg = header
+            .get("alg")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("RS256")
+            .to_string();
+        Ok((kid, alg))
+    }
+
+    /// Fetch the JWKS document from the IdP.
+    ///
+    /// A fetch failure (unreachable IdP, non-200, timeout) is a best-effort
+    /// outcome, NOT an error — the claim degrades to `Unverified`.
+    async fn fetch_jwks(&self) -> Result<serde_json::Value, IdentityError> {
+        let response = self
+            .client
+            .get(&self.jwks_url)
+            .send()
+            .await
+            .map_err(|e| IdentityError::VerificationUnavailable(format!("jwks fetch: {e}")))?;
+        if !response.status().is_success() {
+            return Err(IdentityError::VerificationUnavailable(format!(
+                "jwks http {}",
+                response.status()
+            )));
+        }
+        response
+            .json::<serde_json::Value>()
+            .await
+            .map_err(|e| IdentityError::VerificationUnavailable(format!("jwks parse: {e}")))
+    }
+}
+
+#[async_trait]
+impl TokenVerifier for JwksVerifier {
+    /// Verify a token signature against the IdP JWKS.
+    ///
+    /// # Outcomes
+    /// - Valid signature for the `kid`'s key → `VerificationOutcome::Verified`
+    /// - Tampered/mismatched signature → `VerificationOutcome::Unverified`
+    /// - IdP unreachable / unknown kid → `VerificationOutcome::Unverified`, **never an error**
+    ///
+    /// # Errors
+    /// - `IdentityError::InvalidToken` — token is not a parseable JWT
+    async fn verify(
+        &self,
+        token: &str,
+        _claim: &IdentityClaim,
+    ) -> Result<VerificationOutcome, IdentityError> {
+        // 1. Parse header (kid + alg). Malformed tokens are contract errors.
+        let (kid, alg) = Self::header_kid_alg(token)?;
+        if alg != "RS256" {
+            return Ok(VerificationOutcome::Unverified {
+                reason: format!("unsupported algorithm: {alg}"),
+            });
+        }
+
+        // 2. Fetch the JWKS. Unreachable IdP → Unverified, never an error.
+        let jwks = match self.fetch_jwks().await {
+            Ok(jwks) => jwks,
+            Err(e) => {
+                return Ok(VerificationOutcome::Unverified {
+                    reason: e.to_string(),
+                });
+            }
+        };
+
+        // 3. Resolve the signing key by kid.
+        let key = match jwks
+            .get("keys")
+            .and_then(serde_json::Value::as_array)
+            .and_then(|keys| {
+                keys.iter().find(|k| {
+                    k.get("kid").and_then(serde_json::Value::as_str) == Some(kid.as_str())
+                })
+            }) {
+            Some(key) => key,
+            None => {
+                return Ok(VerificationOutcome::Unverified {
+                    reason: format!("no JWKS key for kid: {kid}"),
+                });
+            }
+        };
+
+        // 4. Build the RSA public key from n/e (base64url, big-endian).
+        let decode_biguint = |field: &str| -> Result<BigUint, IdentityError> {
+            let encoded = key
+                .get(field)
+                .and_then(serde_json::Value::as_str)
+                .ok_or_else(|| {
+                    IdentityError::VerificationUnavailable(format!("jwks missing {field}"))
+                })?;
+            let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+                .decode(encoded)
+                .map_err(|e| {
+                    IdentityError::VerificationUnavailable(format!("jwks {field}: {e}"))
+                })?;
+            Ok(BigUint::from_bytes_be(&bytes))
+        };
+        let n = decode_biguint("n")?;
+        let e = decode_biguint("e")?;
+        let public_key = RsaPublicKey::new(n, e)
+            .map_err(|err| IdentityError::VerificationUnavailable(format!("jwks key: {err}")))?;
+
+        // 5. Split the JWT into signed-content and signature segments.
+        let segments: Vec<&str> = token.split('.').collect();
+        if segments.len() != 3 {
+            return Err(IdentityError::InvalidToken(
+                "expected 3 JWT segments".to_string(),
+            ));
+        }
+        let signed_content = format!("{}.{}", segments[0], segments[1]);
+        let signature_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(segments[2])
+            .map_err(|e| IdentityError::InvalidToken(format!("signature decode: {e}")))?;
+        let signature = Signature::try_from(&signature_bytes[..])
+            .map_err(|e| IdentityError::InvalidToken(format!("signature size: {e}")))?;
+
+        // 6. Verify RS256 over the signed content (verifier hashes internally).
+        let verifying_key = VerifyingKey::<Sha256>::new(public_key);
+        match verifying_key.verify(signed_content.as_bytes(), &signature) {
+            Ok(()) => Ok(VerificationOutcome::Verified),
+            Err(_) => Ok(VerificationOutcome::Unverified {
+                reason: "signature mismatch (tampered token)".to_string(),
+            }),
+        }
     }
 }

--- a/engine/tests/identity_jwks_integration.rs
+++ b/engine/tests/identity_jwks_integration.rs
@@ -1,0 +1,269 @@
+//! Integration test: verify against a mock JWKS — valid → Verified;
+//! tampered → Unverified.
+//!
+//! Covers identity module acceptance criterion #5:
+//! "verify against mock JWKS: valid → Verified; tampered → Unverified".
+//!
+//! Uses `wiremock` as the mock IdP JWKS endpoint and real RS256 cryptography
+//! (rsa crate): the test generates a keypair, signs tokens with the private
+//! key, serves the public key as a JWKS document, and drives `JwksVerifier`.
+
+use async_trait::async_trait;
+use base64::Engine as _;
+use rsa::RsaPrivateKey;
+use rsa::pkcs1v15::SigningKey;
+use rsa::sha2::Sha256;
+use rsa::signature::{SignatureEncoding, Signer};
+use rsa::traits::PublicKeyParts;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use rigorix_engine::identity::application::dto::AttestInput;
+use rigorix_engine::identity::application::service::{
+    IdentityAttestationService, VerificationOutcome,
+};
+use rigorix_engine::identity::application::service_impl::IdentityAttestationServiceImpl;
+use rigorix_engine::identity::domain::{IdentityClaim, IdentitySource};
+use rigorix_engine::identity::infrastructure::verifier::{JwksVerifier, TokenVerifier};
+
+/// A self-contained mock IdP: keypair + JWKS serving + JWT signing.
+struct MockIdp {
+    private_key: RsaPrivateKey,
+    kid: String,
+}
+
+impl MockIdp {
+    fn new() -> Self {
+        let mut rng = rsa::rand_core::OsRng;
+        let private_key = RsaPrivateKey::new(&mut rng, 2048).expect("rsa keygen");
+        Self {
+            private_key,
+            kid: "mock-idp-key-1".to_string(),
+        }
+    }
+
+    /// Sign a JWT (RS256) with the given payload claims.
+    fn sign(&self, claims: serde_json::Value) -> String {
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(
+            serde_json::to_vec(&serde_json::json!({
+                "alg": "RS256",
+                "kid": self.kid,
+                "typ": "JWT",
+            }))
+            .expect("header json"),
+        );
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&claims).expect("claims json"));
+        let signing_content = format!("{header}.{payload}");
+
+        let signing_key = SigningKey::<Sha256>::new(self.private_key.clone());
+        let signature = signing_key.sign(signing_content.as_bytes()).to_bytes();
+
+        format!(
+            "{signing_content}.{}",
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(signature)
+        )
+    }
+
+    /// JWKS document exposing the public key under `kid`.
+    fn jwks_json(&self) -> serde_json::Value {
+        let public = self.private_key.to_public_key();
+        serde_json::json!({
+            "keys": [{
+                "kty": "RSA",
+                "use": "sig",
+                "alg": "RS256",
+                "kid": self.kid,
+                "n": base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(public.n().to_bytes_be()),
+                "e": base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(public.e().to_bytes_be()),
+            }]
+        })
+    }
+}
+
+fn sample_claim() -> IdentityClaim {
+    IdentityClaim {
+        subject: "user@org".to_string(),
+        issuer: "https://mock-idp.example.com".to_string(),
+        authority: Some("admin".to_string()),
+        source: IdentitySource::IdpToken,
+        auth_method: None,
+        issued_at: chrono::Utc::now(),
+        expires_at: None,
+        token_ref: None,
+    }
+}
+
+#[tokio::test]
+async fn test_jwks_verify_valid_token_returns_verified() {
+    let idp = MockIdp::new();
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/.well-known/jwks.json"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(idp.jwks_json()))
+        .mount(&server)
+        .await;
+
+    let verifier = JwksVerifier::new(format!("{}/.well-known/jwks.json", server.uri()));
+    let token = idp.sign(serde_json::json!({
+        "sub": "user@org",
+        "iss": "https://mock-idp.example.com",
+        "exp": chrono::Utc::now().timestamp() + 600,
+        "roles": ["admin"],
+    }));
+
+    let outcome = verifier
+        .verify(&token, &sample_claim())
+        .await
+        .expect("verify must not error");
+    assert_eq!(outcome, VerificationOutcome::Verified);
+}
+
+#[tokio::test]
+async fn test_jwks_verify_tampered_token_returns_unverified() {
+    let idp = MockIdp::new();
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/.well-known/jwks.json"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(idp.jwks_json()))
+        .mount(&server)
+        .await;
+
+    let verifier = JwksVerifier::new(format!("{}/.well-known/jwks.json", server.uri()));
+    let mut token = idp.sign(serde_json::json!({
+        "sub": "user@org",
+        "iss": "https://mock-idp.example.com",
+        "exp": chrono::Utc::now().timestamp() + 600,
+    }));
+
+    // Tamper: swap in DIFFERENT (valid) claims — the JSON still parses, but the
+    // signature no longer matches the presented payload.
+    let segments: Vec<&str> = token.split('.').collect();
+    let tampered_payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(
+        serde_json::to_vec(&serde_json::json!({
+            "sub": "attacker@evil",
+            "iss": "https://mock-idp.example.com",
+            "exp": chrono::Utc::now().timestamp() + 600,
+        }))
+        .expect("tampered claims json"),
+    );
+    token = format!("{}.{}.{}", segments[0], tampered_payload, segments[2]);
+
+    let outcome = verifier
+        .verify(&token, &sample_claim())
+        .await
+        .expect("verify must not error (best-effort)");
+    assert!(matches!(
+        outcome,
+        VerificationOutcome::Unverified { ref reason } if reason.contains("signature mismatch")
+    ));
+}
+
+#[tokio::test]
+async fn test_jwks_verify_unreachable_idp_returns_unverified_no_error() {
+    // Point at a port with no listener — the IdP is unreachable.
+    let verifier = JwksVerifier::new("http://127.0.0.1:1/.well-known/jwks.json".to_string());
+    let token = "unused"; // header parse happens first... use a well-formed header
+
+    let token = {
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(r#"{"alg":"RS256","kid":"mock-idp-key-1"}"#);
+        format!("{header}.payload.signature")
+    };
+
+    let outcome = verifier
+        .verify(&token, &sample_claim())
+        .await
+        .expect("unreachable IdP must NOT error");
+    assert!(
+        matches!(outcome, VerificationOutcome::Unverified { .. }),
+        "unreachable IdP degrades to Unverified"
+    );
+}
+
+#[tokio::test]
+async fn test_attest_with_jwks_verified_token_keeps_idp_token_source() {
+    let idp = MockIdp::new();
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/.well-known/jwks.json"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(idp.jwks_json()))
+        .mount(&server)
+        .await;
+
+    let service = IdentityAttestationServiceImpl::with_verifier(Box::new(JwksVerifier::new(
+        format!("{}/.well-known/jwks.json", server.uri()),
+    )));
+    let token = idp.sign(serde_json::json!({
+        "sub": "user@org",
+        "iss": "https://mock-idp.example.com",
+        "exp": chrono::Utc::now().timestamp() + 600,
+        "roles": ["admin"],
+    }));
+
+    let claim = service
+        .attest(AttestInput {
+            token: Some(token),
+            principal: None,
+            issuer: Some("https://mock-idp.example.com".to_string()),
+            auth_method: None,
+        })
+        .await
+        .expect("attest must not error");
+
+    // Verified against the mock JWKS → the IdpToken source is retained and the
+    // presented roles remain as evidence.
+    assert_eq!(claim.source, IdentitySource::IdpToken);
+    assert_eq!(claim.authority.as_deref(), Some("admin"));
+}
+
+#[tokio::test]
+async fn test_attest_with_tampered_token_degrades_to_unverified() {
+    let idp = MockIdp::new();
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/.well-known/jwks.json"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(idp.jwks_json()))
+        .mount(&server)
+        .await;
+
+    let service = IdentityAttestationServiceImpl::with_verifier(Box::new(JwksVerifier::new(
+        format!("{}/.well-known/jwks.json", server.uri()),
+    )));
+    let mut token = idp.sign(serde_json::json!({
+        "sub": "user@org",
+        "iss": "https://mock-idp.example.com",
+        "exp": chrono::Utc::now().timestamp() + 600,
+        "roles": ["admin"],
+    }));
+
+    // Tamper: swap in DIFFERENT (valid) claims — the JSON still parses, but the
+    // signature no longer matches the presented payload.
+    let segments: Vec<&str> = token.split('.').collect();
+    let tampered_payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(
+        serde_json::to_vec(&serde_json::json!({
+            "sub": "attacker@evil",
+            "iss": "https://mock-idp.example.com",
+            "exp": chrono::Utc::now().timestamp() + 600,
+        }))
+        .expect("tampered claims json"),
+    );
+    token = format!("{}.{}.{}", segments[0], tampered_payload, segments[2]);
+
+    let claim = service
+        .attest(AttestInput {
+            token: Some(token),
+            principal: None,
+            issuer: Some("https://mock-idp.example.com".to_string()),
+            auth_method: None,
+        })
+        .await
+        .expect("attest must not error (best-effort)");
+
+    assert_eq!(
+        claim.source,
+        IdentitySource::Unverified,
+        "tampered token degrades to the explicit Unverified marker"
+    );
+    assert_eq!(claim.authority, None, "unverified roles are not evidence");
+}


### PR DESCRIPTION
## Issue Closeout

Closes #703

### Summary

Implements **IdentityAttestationService** verification (ISSUE-IDENTITY-3):

- **`JwksVerifier`** (infrastructure): fetches the IdP JWKS (5s timeout), resolves the signing key by `kid`, rebuilds the RSA public key from `n`/`e`, and validates the RS256 signature over `header.payload` (rsa crate, PKCS1v15)
- **Best-effort contract**: unreachable IdP / unknown kid / signature mismatch → `VerificationOutcome::Unverified`, never an error; malformed JWT → `InvalidToken`
- New `rsa` dependency (MIT/Apache-2.0, deny.toml-compatible)

### Acceptance Criteria Verification

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 3 | `extract_claims` decodes standard JWT claims (sub, iss, exp, roles) | ✅ | Unit tests from #702 (`extract_claims_decodes_standard_claims`, malformed/missing/expired) — 27 identity tests pass |
| 4 | attest with unreachable IdP → `IdentitySource::Unverified`, explicit marker, no error | ✅ | Integration tests from #702 (5) + `test_jwks_verify_unreachable_idp_returns_unverified_no_error` |
| 5 | verify against mock JWKS: valid → Verified; tampered → Unverified | ✅ | `tests/identity_jwks_integration.rs` ×5 (wiremock mock JWKS + real RS256): valid→Verified, tampered→Unverified, unreachable→Unverified, attest full-path verified/tampered |
| 7 | ApproveInput.approver_id populated from claim; recorded in ApprovalRecord | ⏳ **Deferred** | The approval module (ApproveInput/ApprovalRecord) is a separate epic — `src/approval` does not exist yet. The identity side (claim + `token_claims_ref` contract) is ready; AC7 lands when the approval epic builds. Documented on the tracking issue. |

### Validator Results

| Validator | Status | Details |
|-----------|--------|---------|
| CI | ⚠️ 4/5 | Build ✅ Tests ✅ Clippy ✅ Canonical ✅; Format ❌ pre-existing debt on main (zero new violations) |
| Test | ✅ | Workspace 2721 passed / 0 failed (identity 27, JWKS integration 5) |
| Architecture | ✅ | check_architecture_conformance.sh 8/8 |
| Canonical | ✅ | validate-canonical.sh 3/3 |
| Security | ✅ | Signature verification is best-effort; no authorization judgment in OSS (ADR-012) |

### Files Changed

| File | Change Type | Reason |
|------|-------------|--------|
| `src/identity/infrastructure/verifier.rs` | modified | JwksVerifier (JWKS fetch, kid resolve, RS256 verify) |
| `src/identity/infrastructure/mod.rs` | modified | Export JwksVerifier |
| `Cargo.toml`, `Cargo.lock` | modified | rsa dep for RS256 verification |
| `tests/identity_jwks_integration.rs` | added | AC#5 wiremock integration tests |

### Testing Evidence

```bash
$ cargo test --workspace        # 2721 passed, 0 failed
$ cargo test --test identity_jwks_integration   # 5 passed
$ cargo clippy --workspace --lib -- -D warnings # 0 errors
```

### Manual Testing Performed

- Valid RS256 token against mock JWKS → Verified
- Payload-swapped token (valid JSON, wrong signature) → Unverified "signature mismatch"
- Unreachable IdP endpoint → Unverified, no error
- attest() with verified token keeps `IdpToken` source + roles; tampered token degrades to `Unverified`

### Deployment Notes

- AC7 (approver binding) is tracked for the approval epic — `token_claims_ref` contract already frozen in the identity module

---

🤖 Generated with Guardian compliance workflow
