### PR TITLE
[Issue #706] Implement IdentityError — recovery semantics + CoreOrchestratorError wiring

### DIFF
--- a/engine/src/error.rs
+++ b/engine/src/error.rs
@@ -32,6 +32,7 @@ use crate::enforcement::domain::EnforcementError;
 use crate::event_system::domain::EventSystemError;
 use crate::execution_engine::domain::ExecutionError;
 use crate::failure_classification::domain::FailureClassificationError;
+use crate::identity::domain::IdentityError;
 use crate::llm_step::domain::LlmStepError;
 use crate::orchestrator::domain::OrchestratorError;
 use crate::planning::domain::PlanningError;
@@ -132,6 +133,10 @@ pub enum CoreOrchestratorError {
     #[error("Failure classification error: {0}")]
     FailureClassification(#[from] FailureClassificationError),
 
+    /// Identity attestation error — invalid/missing claims, verification.
+    #[error("Identity error: {0}")]
+    Identity(#[from] IdentityError),
+
     // ------------------------------------------------------------------ /
     // Standard library wrappers (via #[from])
     // ------------------------------------------------------------------ /
@@ -201,6 +206,9 @@ impl CoreOrchestratorError {
             CoreOrchestratorError::Recovery(e) => e.is_retriable(),
             CoreOrchestratorError::QualityGate(e) => e.is_retriable(),
             CoreOrchestratorError::FailureClassification(e) => e.is_retriable(),
+            // Identity errors are never retriable in the retry sense —
+            // reject the presented identity, re-authenticate, or degrade.
+            CoreOrchestratorError::Identity(_) => false,
             // JSON deserialization errors are not retriable — the input is malformed
             CoreOrchestratorError::Json(_) => false,
             // Cancellation is intentional, not transient
@@ -229,6 +237,7 @@ impl CoreOrchestratorError {
             CoreOrchestratorError::Recovery(_) => "RECOVERY_ERROR",
             CoreOrchestratorError::QualityGate(_) => "QUALITY_GATE_ERROR",
             CoreOrchestratorError::FailureClassification(_) => "FAILURE_CLASSIFICATION_ERROR",
+            CoreOrchestratorError::Identity(_) => "IDENTITY_ERROR",
             CoreOrchestratorError::Io(_) => "IO_ERROR",
             CoreOrchestratorError::Json(_) => "JSON_ERROR",
             CoreOrchestratorError::Cancelled(_) => "CANCELLED",
@@ -257,6 +266,7 @@ impl CoreOrchestratorError {
             CoreOrchestratorError::Recovery(_) => 500,
             CoreOrchestratorError::QualityGate(_) => 500,
             CoreOrchestratorError::FailureClassification(_) => 500,
+            CoreOrchestratorError::Identity(_) => 400, // invalid/missing claims, expired
             CoreOrchestratorError::Io(_) => 500,
             CoreOrchestratorError::Json(_) => 400,
             CoreOrchestratorError::Cancelled(_) => 499,

--- a/engine/src/identity/domain/error.rs
+++ b/engine/src/identity/domain/error.rs
@@ -48,6 +48,28 @@ pub enum IdentityError {
     Internal(String),
 }
 
+impl IdentityError {
+    /// Whether attestation must reject the presented identity outright.
+    ///
+    /// # Recovery (canonical `.pi/architecture/modules/identity.md#error-handling`)
+    /// - `InvalidToken` / `MissingClaim`: not retriable — reject, degrade to `Unverified`
+    /// - `Expired`: not retriable — re-authenticate
+    /// - `VerificationUnavailable`: **non-fatal for attestation** — degrade to
+    ///   `Unverified` and record the outcome, never fail the run/approval
+    /// - `Internal`: unexpected — treat as fatal for the operation
+    pub fn is_fatal_for_attestation(&self) -> bool {
+        !matches!(self, IdentityError::VerificationUnavailable(_))
+    }
+
+    /// Whether the operation should be retried with backoff.
+    ///
+    /// Identity errors are never retriable in the retry sense — the recovery
+    /// path is reject / re-authenticate / degrade, not retry.
+    pub fn is_retriable(&self) -> bool {
+        false
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -77,5 +99,37 @@ mod tests {
     fn error_implements_std_error() {
         fn assert_error<E: std::error::Error>() {}
         assert_error::<IdentityError>();
+    }
+
+    #[test]
+    fn verification_unavailable_is_non_fatal_for_attestation() {
+        assert!(
+            !IdentityError::VerificationUnavailable("idp unreachable".to_string())
+                .is_fatal_for_attestation(),
+            "VerificationUnavailable degrades the claim, never fails attestation"
+        );
+        assert!(IdentityError::InvalidToken("x".to_string()).is_fatal_for_attestation());
+        assert!(IdentityError::MissingClaim("sub".to_string()).is_fatal_for_attestation());
+        assert!(IdentityError::Expired.is_fatal_for_attestation());
+    }
+
+    #[test]
+    fn identity_errors_are_never_retriable() {
+        assert!(!IdentityError::InvalidToken("x".to_string()).is_retriable());
+        assert!(!IdentityError::VerificationUnavailable("x".to_string()).is_retriable());
+        assert!(!IdentityError::Expired.is_retriable());
+    }
+
+    #[test]
+    fn converts_into_core_orchestrator_error() {
+        let err: crate::error::CoreOrchestratorError =
+            IdentityError::InvalidToken("bad".to_string()).into();
+        assert!(matches!(
+            err,
+            crate::error::CoreOrchestratorError::Identity(_)
+        ));
+        assert_eq!(err.error_code(), "IDENTITY_ERROR");
+        assert_eq!(err.http_status(), 400);
+        assert!(!err.is_retriable());
     }
 }


### PR DESCRIPTION
## Issue Closeout

Closes #706

### Summary

Completes the **IdentityError** component (ISSUE-IDENTITY-6):

- **Recovery semantics** on `IdentityError`: `is_fatal_for_attestation()` + `is_retriable()` encoding the canonical recovery contract — `VerificationUnavailable` is **non-fatal for attestation** (claim degrades to `Unverified`, never fails the run/approval); `InvalidToken`/`MissingClaim`/`Expired` reject the presented identity; identity errors are never retriable (reject / re-auth / degrade, not retry)
- **CoreOrchestratorError wiring**: new `Identity(#[from] IdentityError)` variant — completes the error-handling contract ("every sub-error type has a corresponding variant with `#[from]`"); `IDENTITY_ERROR` code, HTTP 400, non-retriable

### Acceptance Criteria Verification

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 4 | attest with unreachable IdP → `IdentitySource::Unverified`, explicit marker, no error | ✅ | Integration tests from #702/#703 (attest degradation, JWKS unreachable) |
| 6 | RunInput.identity flows into envelope identity block (redacted) | ✅ | Integration tests from #701 (envelope factory + E2E run-flow) |

### Validator Results

| Validator | Status | Details |
|-----------|--------|---------|
| CI | ⚠️ 4/5 | Build ✅ Tests ✅ Clippy ✅ Canonical ✅; Format ❌ pre-existing debt on main (zero new violations) |
| Test | ✅ | Workspace 2733 passed / 0 failed (identity error 5, core error 52) |
| Architecture | ✅ | check_architecture_conformance.sh 8/8 |
| Canonical | ✅ | validate-canonical.sh 3/3 |
| Security | ✅ | Degradation explicitness preserved; error semantics deterministic |

### Files Changed

| File | Change Type | Reason |
|------|-------------|--------|
| `src/identity/domain/error.rs` | modified | is_fatal_for_attestation / is_retriable + conversion test |
| `src/error.rs` | modified | CoreOrchestratorError::Identity #[from] variant + code/status/retriable |

### Testing Evidence

```bash
$ cargo test --workspace        # 2733 passed, 0 failed
$ cargo test --lib identity::domain::error   # 5 passed
$ cargo clippy --workspace --lib -- -D warnings # 0 errors
```

### Manual Testing Performed

- `VerificationUnavailable` is non-fatal for attestation (degrade path)
- Identity errors are never retriable (reject / re-auth / degrade)
- `IdentityError → CoreOrchestratorError` conversion: code `IDENTITY_ERROR`, HTTP 400, non-retriable

---

🤖 Generated with Guardian compliance workflow
