### PR TITLE
fix: exec-engine integrity — unknown-tool/missing-node failures, config_override, hydrate started_at (#718 #719 #720 #750)

### DIFF
--- a/engine/src/execution_engine/application/dto/mod.rs
+++ b/engine/src/execution_engine/application/dto/mod.rs
@@ -359,6 +359,9 @@ pub struct HydrateExecutionInput {
     pub node_states: std::collections::HashMap<Uuid, NodeExecutionState>,
     /// Node IDs already granted human approval.
     pub approved: std::collections::HashSet<Uuid>,
+    /// The original execution start time, preserved so resumed runs report
+    /// an undistorted `duration_ms` in the audit envelope.
+    pub started_at: DateTime<Utc>,
 }
 
 /// Output from hydrating an execution session.

--- a/engine/src/execution_engine/application/service_impl.rs
+++ b/engine/src/execution_engine/application/service_impl.rs
@@ -229,12 +229,13 @@ async fn spawn_concurrent_node(
                 .await
             }
             other => {
-                // Unknown tool — return minimal placeholder
+                // Unknown tool — fail the node instead of silently succeeding
                 let dur = start.elapsed().as_millis() as u64;
-                TaskResult::success(
+                TaskResult::failure(
                     node_id,
                     &node_name,
-                    Some(format!("Unknown tool '{}', intent: {}", other, node_intent)),
+                    format!("Unknown tool '{}', intent: {}", other, node_intent),
+                    "unknown_tool".to_string(),
                     dur,
                     0,
                 )
@@ -360,12 +361,13 @@ impl ParallelExecutionServiceImpl {
         started_at: chrono::DateTime<chrono::Utc>,
         total_nodes: u32,
         approved: &HashSet<Uuid>,
+        config: &crate::execution_engine::domain::ParallelExecutorConfig,
     ) -> Result<(u32, u32, HashMap<Uuid, TaskResult>, bool), ExecutionError> {
         let mut join_set: tokio::task::JoinSet<(Uuid, TaskResult)> = tokio::task::JoinSet::new();
         let mut completed_count: u32 = 0;
         let mut failed_count: u32 = 0;
         let mut node_results: HashMap<Uuid, TaskResult> = HashMap::new();
-        let max_concurrent = self.config.max_concurrent_executions.max(1) as usize;
+        let max_concurrent = config.max_concurrent_executions.max(1) as usize;
         let event_bus = &self.event_bus;
         let mut approval_blocked = false;
 
@@ -677,14 +679,13 @@ impl ParallelExecutionServiceImpl {
             "git_commit" => Self::exec_git_commit(tool_intent, node_id, &node.name, start).await,
             "edit_file" => Self::exec_edit_file(tool_intent, node_id, &node.name, start).await,
             _ => {
+                // Unknown tool — fail the node instead of silently succeeding
                 let duration_ms = start.elapsed().as_millis() as u64;
-                TaskResult::success(
+                TaskResult::failure(
                     node_id,
                     &node.name,
-                    Some(format!(
-                        "[PLACEHOLDER] Tool '{}' would execute: {}",
-                        tool_name, tool_intent
-                    )),
+                    format!("Unknown tool '{}', intent: {}", tool_name, tool_intent),
+                    "unknown_tool".to_string(),
                     duration_ms,
                     0,
                 )
@@ -1435,7 +1436,7 @@ impl ParallelExecutionService for ParallelExecutionServiceImpl {
         &self,
         input: ExecuteGraphInput,
     ) -> Result<ExecuteGraphOutput, ExecutionError> {
-        let _config = input
+        let config = input
             .config_override
             .clone()
             .unwrap_or_else(|| self.config.clone());
@@ -1568,7 +1569,14 @@ impl ParallelExecutionService for ParallelExecutionServiceImpl {
         };
 
         let (completed_count, failed_count, node_results, approval_blocked) = self
-            .run_dispatch_loop(&mut graph, input.dag_id, started_at, total_nodes, &approved)
+            .run_dispatch_loop(
+                &mut graph,
+                input.dag_id,
+                started_at,
+                total_nodes,
+                &approved,
+                &config,
+            )
             .await?;
 
         // Build final result using the LIVE node states from the session so
@@ -1757,12 +1765,15 @@ impl ParallelExecutionService for ParallelExecutionServiceImpl {
                         )
                     }
                 } else {
-                    // No graph or node not found: placeholder success
+                    // No graph or node not found: fail the node instead of placeholder success
                     (
-                        true,
-                        "execution output placeholder".to_string(),
+                        false,
                         String::new(),
-                        String::new(),
+                        "node_not_found".to_string(),
+                        format!(
+                            "Node {} not found in session graph for dag {}",
+                            node_id, input.dag_id
+                        ),
                         0,
                     )
                 };
@@ -2162,7 +2173,14 @@ impl ParallelExecutionService for ParallelExecutionServiceImpl {
             let total_nodes = graph.node_count() as u32;
             let started_at = Utc::now();
             let (completed, failed, node_results, approval_blocked) = self
-                .run_dispatch_loop(&mut graph, input.dag_id, started_at, total_nodes, &approved)
+                .run_dispatch_loop(
+                    &mut graph,
+                    input.dag_id,
+                    started_at,
+                    total_nodes,
+                    &approved,
+                    &self.config,
+                )
                 .await?;
 
             let live_states = {
@@ -2335,7 +2353,11 @@ impl ParallelExecutionService for ParallelExecutionServiceImpl {
 
         let node_count = input.node_states.len();
         let approved = input.approved;
-        let started_at = Utc::now();
+        // Preserve the original execution start: the persisted ExecutionState
+        // carries it (state_persistence `started_at`), so a resumed run reports
+        // an undistorted duration_ms in the audit envelope instead of
+        // re-baselining to "now".
+        let started_at = input.started_at;
 
         sessions.insert(
             input.dag_id,

--- a/engine/src/execution_engine/tests.rs
+++ b/engine/src/execution_engine/tests.rs
@@ -117,14 +117,20 @@ async fn test_execute_node_returns_result() {
         .execute_node(ExecuteNodeInput {
             dag_id,
             node_id,
-            retry_policy: None,
+            retry_policy: Some(fast_non_retriable_policy()),
         })
         .await
         .unwrap();
 
+    // A-02: a node that does not exist in any session graph must FAIL, not
+    // return the old placeholder success.
     assert_eq!(output.result.node_id, node_id);
-    assert!(output.result.success);
-    assert!(output.retry_decision.is_none());
+    assert!(!output.result.success);
+    let err = output.result.error.as_deref().unwrap_or("");
+    assert!(
+        err.contains("node_not_found") || err.contains("not found"),
+        "error should mention node_not_found, got: {err}"
+    );
 }
 
 #[tokio::test]
@@ -133,22 +139,183 @@ async fn test_execute_node_with_retry_policy() {
     let dag_id = Uuid::new_v4();
     let node_id = Uuid::new_v4();
 
-    let policy = RetryPolicy {
-        max_attempts: 2,
-        ..Default::default()
-    };
-
     let output = executor
         .execute_node(ExecuteNodeInput {
             dag_id,
             node_id,
-            retry_policy: Some(policy),
+            retry_policy: Some(fast_non_retriable_policy()),
         })
         .await
         .unwrap();
 
+    // A-02: missing node fails regardless of the configured retry policy.
     assert_eq!(output.result.node_id, node_id);
-    assert!(output.result.success);
+    assert!(!output.result.success);
+    assert!(
+        output
+            .result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("node_not_found"),
+        "missing node must fail, not succeed"
+    );
+}
+
+/// Fast retry policy that treats the failure as non-retriable: a single
+/// attempt, immediate backoff, no sleep, so tests stay deterministic.
+fn fast_non_retriable_policy() -> RetryPolicy {
+    RetryPolicy {
+        max_attempts: 1,
+        retryable_failures: vec!["__never_matches__".to_string()],
+        backoff_strategy: BackoffStrategy::Immediate,
+        ..Default::default()
+    }
+}
+
+/// A-01 (parallel path): an unknown tool name in a graph must produce a
+/// node failure, never a silent success.
+#[tokio::test]
+async fn test_unknown_tool_fails_graph_execution() {
+    use crate::dag_engine::domain::{TaskGraph, TaskNode};
+
+    let executor = create_executor();
+    let dag_id = Uuid::new_v4();
+    let node = TaskNode::new(
+        Uuid::new_v4(),
+        "step",
+        "no_such_tool",
+        vec![],
+        "no such tool",
+    );
+    let mut graph = TaskGraph::new();
+    graph.add_unchecked(node.clone()).unwrap();
+    graph.seal().unwrap();
+
+    let output = executor
+        .execute_graph(ExecuteGraphInput {
+            dag_id,
+            graph: Some(graph),
+            config_override: None,
+        })
+        .await
+        .unwrap();
+
+    let nr = output
+        .result
+        .node_results
+        .get(&node.id)
+        .expect("node result present");
+    assert!(
+        !nr.success,
+        "unknown tool must fail the node, not report success"
+    );
+    assert_eq!(
+        nr.failure_type.as_deref(),
+        Some("unknown_tool"),
+        "failure type must be unknown_tool"
+    );
+    assert!(
+        nr.error.as_deref().unwrap_or("").contains("no_such_tool"),
+        "error must name the tool"
+    );
+}
+
+/// A-01 (single-node path): the same unknown-tool failure must surface via
+/// `execute_node` (the `execute_tool` dispatch), not just the parallel loop.
+#[tokio::test]
+async fn test_unknown_tool_fails_single_node_path() {
+    use crate::dag_engine::domain::{TaskGraph, TaskNode};
+
+    let executor = create_executor();
+    let dag_id = Uuid::new_v4();
+    // Approval-gated so execute_graph leaves the node in the session graph
+    // without dispatching it; then execute_node drives the single-node path.
+    let node = TaskNode::new(
+        Uuid::new_v4(),
+        "step",
+        "no_such_tool",
+        vec![],
+        "no such tool",
+    )
+    .with_requires_approval(true);
+    let mut graph = TaskGraph::new();
+    graph.add_unchecked(node.clone()).unwrap();
+    graph.seal().unwrap();
+
+    let output = executor
+        .execute_graph(ExecuteGraphInput {
+            dag_id,
+            graph: Some(graph),
+            config_override: None,
+        })
+        .await
+        .unwrap();
+    assert!(output.approval_pending, "gate must pause before dispatch");
+
+    let node_out = executor
+        .execute_node(ExecuteNodeInput {
+            dag_id,
+            node_id: node.id,
+            retry_policy: Some(fast_non_retriable_policy()),
+        })
+        .await
+        .unwrap();
+    assert!(
+        !node_out.result.success,
+        "single-node path must fail on unknown tool"
+    );
+    let err = node_out.result.error.as_deref().unwrap_or("");
+    assert!(
+        err.contains("no_such_tool") || err.contains("unknown_tool"),
+        "error must reference the unknown tool, got: {err}"
+    );
+}
+
+/// H-08 regression: hydrating a session must preserve the persisted
+/// `started_at` so a resumed run reports an undistorted duration.
+#[tokio::test]
+async fn test_hydrate_preserves_persisted_started_at() {
+    use crate::dag_engine::domain::{TaskGraph, TaskNode};
+    use crate::execution_engine::application::dto::HydrateExecutionInput;
+    use chrono::{Duration, Utc};
+
+    let executor = create_executor();
+    let dag_id = Uuid::new_v4();
+    let node = TaskNode::new(Uuid::new_v4(), "step", "echo hi", vec![], "say hi");
+    let mut graph = TaskGraph::new();
+    graph.add_unchecked(node).unwrap();
+    graph.seal().unwrap();
+
+    let persisted_started_at = Utc::now() - Duration::minutes(10);
+    let hydrate = executor
+        .hydrate_execution(HydrateExecutionInput {
+            dag_id,
+            graph,
+            node_states: Default::default(),
+            approved: Default::default(),
+            started_at: persisted_started_at,
+        })
+        .await
+        .unwrap();
+    assert!(hydrate.created, "session must be created by hydration");
+
+    let state = executor
+        .get_execution_state(GetExecutionStateInput { dag_id })
+        .await
+        .unwrap();
+    assert_eq!(
+        state.started_at,
+        Some(persisted_started_at),
+        "hydrated session must keep the persisted start time"
+    );
+    // While paused, reported duration is wall-clock since the preserved start
+    // — a fresh Utc::now() baseline would under-report by the pause length.
+    assert!(
+        state.total_duration_ms >= 10 * 60 * 1000,
+        "duration must include the 10-minute pause, got {:?}",
+        state.total_duration_ms
+    );
 }
 
 #[tokio::test]
@@ -175,9 +342,21 @@ async fn test_approval_gate_pauses_until_human_signoff() {
     let dag_id = Uuid::new_v4();
 
     // Graph: [safe] and [risky] are independent; risky requires approval.
-    let safe = TaskNode::new(Uuid::new_v4(), "safe", "echo safe", vec![], "run safe");
-    let risky = TaskNode::new(Uuid::new_v4(), "risky", "echo risky", vec![], "run risky")
-        .with_requires_approval(true);
+    let safe = TaskNode::new(
+        Uuid::new_v4(),
+        "safe",
+        "run_command",
+        vec![],
+        r#"{"command": "echo safe"}"#,
+    );
+    let risky = TaskNode::new(
+        Uuid::new_v4(),
+        "risky",
+        "run_command",
+        vec![],
+        r#"{"command": "echo risky"}"#,
+    )
+    .with_requires_approval(true);
     let mut graph = TaskGraph::new();
     graph.add_unchecked(safe).unwrap();
     graph.add_unchecked(risky).unwrap();
@@ -249,24 +428,24 @@ async fn test_cross_process_resume_hydrates_session_and_continues() {
     let backup = TaskNode::new(
         Uuid::new_v4(),
         "backup",
-        "echo backup",
+        "run_command",
         vec![],
-        "run backup",
+        r#"{"command": "echo backup"}"#,
     );
     let migrate = TaskNode::new(
         Uuid::new_v4(),
         "migrate",
-        "echo migrate",
+        "run_command",
         vec![backup.id],
-        "run migrate",
+        r#"{"command": "echo migrate"}"#,
     )
     .with_requires_approval(true);
     let verify = TaskNode::new(
         Uuid::new_v4(),
         "verify",
-        "echo verify",
+        "run_command",
         vec![migrate.id],
-        "run verify",
+        r#"{"command": "echo verify"}"#,
     );
     let mut graph = TaskGraph::new();
     graph.add_unchecked(backup).unwrap();
@@ -282,7 +461,10 @@ async fn test_cross_process_resume_hydrates_session_and_continues() {
         })
         .await
         .unwrap();
-    assert!(output_a.approval_pending, "process A must pause at approval");
+    assert!(
+        output_a.approval_pending,
+        "process A must pause at approval"
+    );
     assert_eq!(output_a.pending_approval_steps, vec!["migrate".to_string()]);
 
     // The live node states from A's run (backup completed, migrate awaiting,
@@ -337,6 +519,9 @@ async fn test_cross_process_resume_hydrates_session_and_continues() {
             graph,
             node_states,
             approved: Default::default(),
+            // H-08: the persisted start must survive hydration (the resume
+            // duration is computed from this timestamp).
+            started_at: state_a.started_at.unwrap_or_else(chrono::Utc::now),
         })
         .await
         .unwrap();
@@ -409,13 +594,13 @@ async fn test_factory_threads_permission_enforcer_read_only_gates_bash_write() {
         vec![],
         "touch /tmp/rigorix-perm",
     );
-    // `grep_search` is allow-listed at ReadOnly → allowed, placeholder success.
+    // `grep_search` is allow-listed at ReadOnly → real file_read completes.
     let read_node = TaskNode::new(
         Uuid::new_v4(),
         "read",
-        "grep_search",
+        "file_read",
         vec![],
-        "pattern in src",
+        r#"{"path": "Cargo.toml"}"#,
     );
     let mut graph = TaskGraph::new();
     graph.add_unchecked(write_node).unwrap();
@@ -1259,11 +1444,41 @@ async fn test_factory_with_custom_config() {
 // Inline Retry Loop Tests
 // ---------------------------------------------------------------------------
 
-#[tokio::test]
-async fn test_inline_retry_loop_succeeds_on_first_attempt() {
+/// Create an approval-paused session holding a single `run_command` node, so
+/// `execute_node` can drive the single-node dispatch (inline retry loop)
+/// against a REAL tool — fake tool names now fail (GAP-A-01).
+async fn paused_session_with_node() -> (ParallelExecutionServiceImpl, Uuid, Uuid) {
+    use crate::dag_engine::domain::{TaskGraph, TaskNode};
+
     let executor = create_executor();
     let dag_id = Uuid::new_v4();
-    let node_id = Uuid::new_v4();
+    let node = TaskNode::new(
+        Uuid::new_v4(),
+        "step",
+        "run_command",
+        vec![],
+        r#"{"command": "echo hi"}"#,
+    )
+    .with_requires_approval(true);
+    let mut graph = TaskGraph::new();
+    graph.add_unchecked(node.clone()).unwrap();
+    graph.seal().unwrap();
+
+    let output = executor
+        .execute_graph(ExecuteGraphInput {
+            dag_id,
+            graph: Some(graph),
+            config_override: None,
+        })
+        .await
+        .unwrap();
+    assert!(output.approval_pending, "gate must pause before dispatch");
+    (executor, dag_id, node.id)
+}
+
+#[tokio::test]
+async fn test_inline_retry_loop_succeeds_on_first_attempt() {
+    let (executor, dag_id, node_id) = paused_session_with_node().await;
 
     let output = executor
         .execute_node(ExecuteNodeInput {
@@ -1274,7 +1489,10 @@ async fn test_inline_retry_loop_succeeds_on_first_attempt() {
         .await
         .unwrap();
 
-    assert!(output.result.success);
+    assert!(
+        output.result.success,
+        "real tool must succeed on first attempt"
+    );
     assert_eq!(output.result.node_id, node_id);
     assert_eq!(output.result.retry_attempts, 0);
     assert!(output.retry_decision.is_none());
@@ -1282,9 +1500,7 @@ async fn test_inline_retry_loop_succeeds_on_first_attempt() {
 
 #[tokio::test]
 async fn test_inline_retry_loop_with_retry_policy() {
-    let executor = create_executor();
-    let dag_id = Uuid::new_v4();
-    let node_id = Uuid::new_v4();
+    let (executor, dag_id, node_id) = paused_session_with_node().await;
 
     let policy = RetryPolicy {
         max_attempts: 2,
@@ -1300,15 +1516,14 @@ async fn test_inline_retry_loop_with_retry_policy() {
         .await
         .unwrap();
 
-    // Placeholder succeeds immediately, so returns success on first attempt
+    // A real tool succeeds on the first attempt — no retries consumed.
     assert!(output.result.success);
+    assert_eq!(output.result.retry_attempts, 0);
 }
 
 #[tokio::test]
 async fn test_inline_retry_loop_uses_default_policy_when_none_provided() {
-    let executor = create_executor();
-    let dag_id = Uuid::new_v4();
-    let node_id = Uuid::new_v4();
+    let (executor, dag_id, node_id) = paused_session_with_node().await;
 
     let output = executor
         .execute_node(ExecuteNodeInput {

--- a/engine/src/orchestrator/application/orchestrator_impl.rs
+++ b/engine/src/orchestrator/application/orchestrator_impl.rs
@@ -1490,6 +1490,7 @@ impl OrchestratorService for OrchestratorServiceImpl {
                     graph,
                     node_states,
                     approved,
+                    started_at: loaded.state.started_at,
                 })
                 .await
                 .map_err(|e| OrchestratorError::Internal {

--- a/engine/src/orchestrator/application/service.rs
+++ b/engine/src/orchestrator/application/service.rs
@@ -118,8 +118,5 @@ pub trait OrchestratorService: Send + Sync {
     async fn execution_state(
         &self,
         execution_id: uuid::Uuid,
-    ) -> Result<
-        crate::execution_engine::application::dto::GetExecutionStateOutput,
-        OrchestratorError,
-    >;
+    ) -> Result<crate::execution_engine::application::dto::GetExecutionStateOutput, OrchestratorError>;
 }

--- a/engine/src/permission/domain/config.rs
+++ b/engine/src/permission/domain/config.rs
@@ -55,6 +55,8 @@ impl Default for PermissionConfig {
             default_mode: PermissionMode::WorkspaceWrite,
             allow: vec![
                 "read_file".to_string(),
+                "file_read".to_string(),
+                "git_read".to_string(),
                 "grep_search".to_string(),
                 "glob".to_string(),
                 "lsp_query".to_string(),
@@ -67,10 +69,16 @@ impl Default for PermissionConfig {
             ],
             tool_permissions: HashMap::from([
                 ("read_file".to_string(), PermissionMode::ReadOnly),
+                ("file_read".to_string(), PermissionMode::ReadOnly),
+                ("git_read".to_string(), PermissionMode::ReadOnly),
                 ("grep_search".to_string(), PermissionMode::ReadOnly),
                 ("glob".to_string(), PermissionMode::ReadOnly),
                 ("lsp_query".to_string(), PermissionMode::ReadOnly),
                 ("write_file".to_string(), PermissionMode::WorkspaceWrite),
+                ("file_write".to_string(), PermissionMode::WorkspaceWrite),
+                ("file_append".to_string(), PermissionMode::WorkspaceWrite),
+                ("file_patch".to_string(), PermissionMode::WorkspaceWrite),
+                ("git_stage".to_string(), PermissionMode::WorkspaceWrite),
                 ("edit_file".to_string(), PermissionMode::WorkspaceWrite),
                 ("create_file".to_string(), PermissionMode::WorkspaceWrite),
                 (

--- a/engine/src/permission/domain/policy.rs
+++ b/engine/src/permission/domain/policy.rs
@@ -81,10 +81,16 @@ impl PermissionPolicy {
             active_mode,
             HashMap::from([
                 ("read_file".to_string(), PermissionMode::ReadOnly),
+                ("file_read".to_string(), PermissionMode::ReadOnly),
+                ("git_read".to_string(), PermissionMode::ReadOnly),
                 ("grep_search".to_string(), PermissionMode::ReadOnly),
                 ("glob".to_string(), PermissionMode::ReadOnly),
                 ("lsp_query".to_string(), PermissionMode::ReadOnly),
                 ("write_file".to_string(), PermissionMode::WorkspaceWrite),
+                ("file_write".to_string(), PermissionMode::WorkspaceWrite),
+                ("file_append".to_string(), PermissionMode::WorkspaceWrite),
+                ("file_patch".to_string(), PermissionMode::WorkspaceWrite),
+                ("git_stage".to_string(), PermissionMode::WorkspaceWrite),
                 ("edit_file".to_string(), PermissionMode::WorkspaceWrite),
                 ("create_file".to_string(), PermissionMode::WorkspaceWrite),
                 (
@@ -98,6 +104,8 @@ impl PermissionPolicy {
             ]),
             vec![
                 "read_file".to_string(),
+                "file_read".to_string(),
+                "git_read".to_string(),
                 "grep_search".to_string(),
                 "glob".to_string(),
                 "lsp_query".to_string(),

--- a/engine/src/state_persistence/domain/state.rs
+++ b/engine/src/state_persistence/domain/state.rs
@@ -184,10 +184,7 @@ pub struct ExecutionState {
     /// Additive field — absent in pre-GAP-3 state files, defaults to `None`.
     #[serde(default)]
     pub exec_node_states: Option<
-        std::collections::HashMap<
-            Uuid,
-            crate::execution_engine::domain::NodeExecutionState,
-        >,
+        std::collections::HashMap<Uuid, crate::execution_engine::domain::NodeExecutionState>,
     >,
 }
 

--- a/mcp/src/audit_tools/infrastructure/in_memory_audit_service.rs
+++ b/mcp/src/audit_tools/infrastructure/in_memory_audit_service.rs
@@ -410,7 +410,13 @@ mod tests {
         let id = Uuid::new_v4();
         let steps = vec![
             ExecutionStep::new("validate".into(), true, None, serde_json::json!({}), 5),
-            ExecutionStep::new("migrate".into(), false, Some("SQL error".into()), serde_json::json!({}), 12),
+            ExecutionStep::new(
+                "migrate".into(),
+                false,
+                Some("SQL error".into()),
+                serde_json::json!({}),
+                12,
+            ),
         ];
         let env = InMemoryAuditQueryService::build_from_run(
             id,
@@ -437,7 +443,13 @@ mod tests {
             17,
             vec![
                 ExecutionStep::new("validate".into(), true, None, serde_json::json!({}), 5),
-                ExecutionStep::new("migrate".into(), false, Some("SQL error".into()), serde_json::json!({}), 12),
+                ExecutionStep::new(
+                    "migrate".into(),
+                    false,
+                    Some("SQL error".into()),
+                    serde_json::json!({}),
+                    12,
+                ),
             ],
             Some("other-key"),
         );

--- a/mcp/src/execution_tools/tests.rs
+++ b/mcp/src/execution_tools/tests.rs
@@ -175,10 +175,8 @@ mod tests {
         async fn execution_state(
             &self,
             _: &ExecutionId,
-        ) -> Result<
-            crate::execution_tools::domain::value::ExecutionStateInfo,
-            EngineFacadeError,
-        > {
+        ) -> Result<crate::execution_tools::domain::value::ExecutionStateInfo, EngineFacadeError>
+        {
             unimplemented!("MockEngineFacade::execution_state not needed by current tests")
         }
     }

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -59,9 +59,9 @@ use rigorix_mcp::template_tools::application::service_impl::{
 use rigorix_mcp::template_tools::domain::entity::SharedTemplateRepository;
 use rigorix_mcp::template_tools::infrastructure::FilesystemTemplateRepository;
 
+use rigorix_engine::configuration::domain::config::Config;
 use rigorix_mcp::enterprise_proxy::domain::entity::SharedEnterpriseProxy;
 use rigorix_mcp::enterprise_proxy::domain::value::ProxyConfig;
-use rigorix_engine::configuration::domain::config::Config;
 use rigorix_mcp::enterprise_proxy::infrastructure::EnterpriseProxyImpl;
 
 use rigorix_mcp::enterprise_proxy::interfaces::mcp::ENTERPRISE_TOOL_PREFIX;
@@ -331,8 +331,13 @@ impl AppState {
                 if let Some(execution_id_str) = json_result["execution_id"].as_str()
                     && let Ok(exec_id) = uuid::Uuid::parse_str(execution_id_str)
                 {
-                    let envelope =
-                        build_envelope_from_run(&json_result, exec_id, template_name_for_audit, &self.audit_hmac_key, None);
+                    let envelope = build_envelope_from_run(
+                        &json_result,
+                        exec_id,
+                        template_name_for_audit,
+                        &self.audit_hmac_key,
+                        None,
+                    );
                     let _ = self.audit_storage.store(envelope);
                 }
 
@@ -398,8 +403,13 @@ impl AppState {
                         .as_str()
                         .unwrap_or_default()
                         .to_string();
-                    let envelope =
-                        build_envelope_from_run(&json_result, exec_id, template_name, &self.audit_hmac_key, None);
+                    let envelope = build_envelope_from_run(
+                        &json_result,
+                        exec_id,
+                        template_name,
+                        &self.audit_hmac_key,
+                        None,
+                    );
                     let _ = self.audit_storage.store(envelope);
                 }
 
@@ -460,50 +470,50 @@ impl AppState {
                         .execution_state(&ExecutionId::from_uuid(execution_id))
                         .await
                 {
-                        // Reuse the stored envelope's template name if present.
-                        let stored_template = self
-                            .audit_storage
-                            .read_audit(&ExecutionId::from_uuid(execution_id))
-                            .await
-                            .ok()
-                            .and_then(|e| e.template_name().map(|s| s.to_string()))
-                            .unwrap_or_else(|| "unknown".to_string());
-                        let steps: Vec<serde_json::Value> = state
-                            .node_states
-                            .values()
-                            .map(|s| {
-                                serde_json::json!({
-                                    "step_name": s.node_name,
-                                    "success": s.status == "completed",
-                                    "error": s.last_error,
-                                    "duration_ms": s.last_duration_ms.unwrap_or(0),
-                                })
+                    // Reuse the stored envelope's template name if present.
+                    let stored_template = self
+                        .audit_storage
+                        .read_audit(&ExecutionId::from_uuid(execution_id))
+                        .await
+                        .ok()
+                        .and_then(|e| e.template_name().map(|s| s.to_string()))
+                        .unwrap_or_else(|| "unknown".to_string());
+                    let steps: Vec<serde_json::Value> = state
+                        .node_states
+                        .values()
+                        .map(|s| {
+                            serde_json::json!({
+                                "step_name": s.node_name,
+                                "success": s.status == "completed",
+                                "error": s.last_error,
+                                "duration_ms": s.last_duration_ms.unwrap_or(0),
                             })
-                            .collect();
-                        let refreshed = serde_json::json!({
-                            "execution_id": execution_id.to_string(),
-                            "status": if state.is_complete && state.failed_count == 0 {
-                                "Completed"
-                            } else if state.failed_count > 0 {
-                                "Failed"
-                            } else {
-                                "PendingApproval"
-                            },
-                            "duration_ms": state.total_duration_ms,
-                            "steps": steps,
-                        });
-                        // Use the REAL run start time from the engine session so
-                        // the envelope's Started/Completed reflect the actual run.
-                        let run_started = state.started_at.unwrap_or_else(chrono::Utc::now);
-                        let envelope = build_envelope_from_run(
-                            &refreshed,
-                            execution_id,
-                            stored_template,
-                            &self.audit_hmac_key,
-                            Some(run_started),
-                        );
-                        let _ = self.audit_storage.store(envelope);
-                        final_state = Some(state);
+                        })
+                        .collect();
+                    let refreshed = serde_json::json!({
+                        "execution_id": execution_id.to_string(),
+                        "status": if state.is_complete && state.failed_count == 0 {
+                            "Completed"
+                        } else if state.failed_count > 0 {
+                            "Failed"
+                        } else {
+                            "PendingApproval"
+                        },
+                        "duration_ms": state.total_duration_ms,
+                        "steps": steps,
+                    });
+                    // Use the REAL run start time from the engine session so
+                    // the envelope's Started/Completed reflect the actual run.
+                    let run_started = state.started_at.unwrap_or_else(chrono::Utc::now);
+                    let envelope = build_envelope_from_run(
+                        &refreshed,
+                        execution_id,
+                        stored_template,
+                        &self.audit_hmac_key,
+                        Some(run_started),
+                    );
+                    let _ = self.audit_storage.store(envelope);
+                    final_state = Some(state);
                 }
 
                 Ok(serde_json::json!({
@@ -540,9 +550,8 @@ impl AppState {
                 // The handler may return markdown (text format) or JSON — pass
                 // the text through, only parsing when it is actually JSON.
                 let text = &result.content[0].text;
-                Ok(serde_json::from_str(text).unwrap_or_else(|_| {
-                    serde_json::Value::String(text.clone())
-                }))
+                Ok(serde_json::from_str(text)
+                    .unwrap_or_else(|_| serde_json::Value::String(text.clone())))
             }
             "rigorix_list_audits" => {
                 let input = serde_json::from_value(params.clone())
@@ -553,9 +562,8 @@ impl AppState {
                     .await
                     .map_err(|e| serde_json::json!({"error": e.to_string()}))?;
                 let text = &result.content[0].text;
-                Ok(serde_json::from_str(text).unwrap_or_else(|_| {
-                    serde_json::Value::String(text.clone())
-                }))
+                Ok(serde_json::from_str(text)
+                    .unwrap_or_else(|_| serde_json::Value::String(text.clone())))
             }
             "rigorix_audit_summary" => {
                 let input = serde_json::from_value(params.clone())

--- a/mcp/tests/execution_tools_tdd_test.rs
+++ b/mcp/tests/execution_tools_tdd_test.rs
@@ -137,10 +137,8 @@ impl EngineFacade for TddMockEngine {
     async fn execution_state(
         &self,
         _: &ExecutionId,
-    ) -> Result<
-        rigorix_mcp::execution_tools::domain::value::ExecutionStateInfo,
-        EngineFacadeError,
-    > {
+    ) -> Result<rigorix_mcp::execution_tools::domain::value::ExecutionStateInfo, EngineFacadeError>
+    {
         unimplemented!("mock execution_state not needed by current tests")
     }
 }

--- a/mcp/tests/unit/execution-tools/checkenforcementhandler-domain-service-/checkenforcementhandler-domain-service-_test.rs
+++ b/mcp/tests/unit/execution-tools/checkenforcementhandler-domain-service-/checkenforcementhandler-domain-service-_test.rs
@@ -92,10 +92,8 @@ impl EngineFacade for MockEngineForEnforcer {
     async fn execution_state(
         &self,
         _: &ExecutionId,
-    ) -> Result<
-        rigorix_mcp::execution_tools::domain::value::ExecutionStateInfo,
-        EngineFacadeError,
-    > {
+    ) -> Result<rigorix_mcp::execution_tools::domain::value::ExecutionStateInfo, EngineFacadeError>
+    {
         unimplemented!("mock execution_state not needed by current tests")
     }
 }

--- a/mcp/tests/unit/execution-tools/enginefacade-aggregate-root-/enginefacade-aggregate-root-_test.rs
+++ b/mcp/tests/unit/execution-tools/enginefacade-aggregate-root-/enginefacade-aggregate-root-_test.rs
@@ -111,10 +111,8 @@ impl EngineFacade for EngineFacadeTddContract {
     async fn execution_state(
         &self,
         _: &ExecutionId,
-    ) -> Result<
-        rigorix_mcp::execution_tools::domain::value::ExecutionStateInfo,
-        EngineFacadeError,
-    > {
+    ) -> Result<rigorix_mcp::execution_tools::domain::value::ExecutionStateInfo, EngineFacadeError>
+    {
         unimplemented!("mock execution_state not needed by current tests")
     }
 }

--- a/mcp/tests/unit/execution-tools/executehandler-domain-service-/executehandler-domain-service-_test.rs
+++ b/mcp/tests/unit/execution-tools/executehandler-domain-service-/executehandler-domain-service-_test.rs
@@ -100,10 +100,8 @@ impl EngineFacade for MockEngineForHandler {
     async fn execution_state(
         &self,
         _: &ExecutionId,
-    ) -> Result<
-        rigorix_mcp::execution_tools::domain::value::ExecutionStateInfo,
-        EngineFacadeError,
-    > {
+    ) -> Result<rigorix_mcp::execution_tools::domain::value::ExecutionStateInfo, EngineFacadeError>
+    {
         unimplemented!("mock execution_state not needed by current tests")
     }
 }

--- a/mcp/tests/unit/execution-tools/validateplanhandler-domain-service-/validateplanhandler-domain-service-_test.rs
+++ b/mcp/tests/unit/execution-tools/validateplanhandler-domain-service-/validateplanhandler-domain-service-_test.rs
@@ -86,10 +86,8 @@ impl EngineFacade for MockEngineForValidator {
     async fn execution_state(
         &self,
         _: &ExecutionId,
-    ) -> Result<
-        rigorix_mcp::execution_tools::domain::value::ExecutionStateInfo,
-        EngineFacadeError,
-    > {
+    ) -> Result<rigorix_mcp::execution_tools::domain::value::ExecutionStateInfo, EngineFacadeError>
+    {
         unimplemented!("mock execution_state not needed by current tests")
     }
 }


### PR DESCRIPTION
# fix(execution-engine): silent-success paths fail; hydrate preserves started_at

**Batch 1** of the gap-ledger implementation backlog (`feature/exec-engine-integrity`).
Closes **#718** (GAP-A-01), **#719** (GAP-A-02), **#720** (GAP-A-03), **#750** (GAP-H-08).

## What changed

### #718 — unknown tool must FAIL (not report success)
Two dispatch sites returned `TaskResult::success` for any unrecognized tool — a typo'd/unsupported node produced a green run that did nothing:
- `execute_tool` single-node arm → now `TaskResult::failure(..., "unknown_tool", ...)`
- `spawn_concurrent_node` parallel arm → same

### #719 — missing graph/node must FAIL (not placeholder)
`execute_node`'s node-not-found branch returned `("execution output placeholder", ...)` success → now a typed failure (`failure_type: "node_not_found"`).

### #720 — `config_override` applied
`execute_graph` cloned the override into `let _config` (discarded). It now threads the effective config into `run_dispatch_loop`, which reads `max_concurrent_executions` from it instead of `self.config`. Production callers pass `None`, so no behavior change — the existing override test's intent is now real.

### #750 — hydrate preserves persisted `started_at`
`hydrate_execution` reset `started_at` to `Utc::now()`, distorting `duration_ms` for resumed (approval-paused) runs. `HydrateExecutionInput` gains `started_at`; the orchestrator passes `loaded.state.started_at`; hydrate uses it. Regression test asserts the hydrated session keeps the original start and reports the pause in the duration.

### Companion (A-01 blast radius): permission catalog now recognizes exec-layer tool names
The permission catalog used policy-layer names (`read_file`, `write_file`) while the engine dispatches exec-layer names (`file_read`, `file_write`, ...). Unknown exec tools fell back to `WorkspaceWrite` — so `file_read` was denied in ReadOnly. With #718, every real read tool would fail in read-only mode. Added `file_read`/`git_read` (ReadOnly) and `file_write`/`file_append`/`file_patch`/`git_stage` (WorkspaceWrite) to `PermissionConfig::default` and `PermissionPolicy::default_with_mode`.

## Tests
- **New:** unknown-tool adversarial tests (parallel + single-node arms), hydrate-started_at regression
- **Updated:** 3 tests that asserted the old placeholder success now drive real tools (`run_command`, `file_read`) and assert the failure semantics; inline-retry-loop tests run against a real tool through an approval-paused session
- 1886 engine lib tests + integration tests green, workspace builds, `clippy -D warnings` clean, `fmt --check` clean

## Pre-existing (not introduced here)
`validate-architecture.sh` layer-structure check fails on main too: the validator expects a flat `src/domain/` layout, but this codebase uses per-module layer folders (`engine/src/<module>/domain|...`). Tracked as a CI-truth follow-up (A-27).