### PR TITLE
fix: hooks — pipe deadlock + PreToolUse/PostToolUse in parallel dispatch (#721 #722)

### DIFF
--- a/engine/src/execution_engine/application/service_impl.rs
+++ b/engine/src/execution_engine/application/service_impl.rs
@@ -72,7 +72,7 @@ async fn spawn_concurrent_node(
     dag_id: Uuid,
     node_id: Uuid,
     permission_enforcer: &Option<Arc<dyn PermissionEnforcer>>,
-    _hook_runner: &Option<Arc<dyn HookRunnerService>>,
+    hook_runner: &Option<Arc<dyn HookRunnerService>>,
 ) -> Result<(), ExecutionError> {
     let node = match graph.get_node(node_id).cloned() {
         Some(n) => n,
@@ -111,6 +111,7 @@ async fn spawn_concurrent_node(
     let eb = Arc::clone(event_bus);
     let exec_id = dag_id;
     let permission = permission_enforcer.clone();
+    let hook_runner = hook_runner.clone();
 
     join_set.spawn(async move {
         // Permission check (gate before execution)
@@ -133,6 +134,49 @@ async fn spawn_concurrent_node(
                             execution_id: exec_id,
                             node_id: node_id.to_string(),
                             node_name,
+                            duration_ms: dur,
+                            output: serde_json::json!(null),
+                            timestamp: chrono::Utc::now(),
+                        },
+                    })
+                    .await;
+                return (node_id, result);
+            }
+        }
+
+        // ── PreToolUse hooks (parallel path) — same gating as execute_tool ──
+        if let Some(ref hook_runner) = hook_runner {
+            let abort = crate::hooks::domain::HookAbortSignal::default();
+            let pre_input = crate::hooks::application::dto::RunPreToolUseInput {
+                tool_name: node_tool.clone(),
+                tool_input: serde_json::Value::String(node_intent.clone()),
+                session_id: node_id.to_string(),
+                workspace_root: ".".to_string(),
+            };
+            if let Ok(pre_output) = hook_runner.run_pre_tool_use(pre_input, Some(&abort))
+                && (pre_output.result.is_denied()
+                    || pre_output.result.is_failed()
+                    || pre_output.result.is_cancelled())
+            {
+                let dur = start.elapsed().as_millis() as u64;
+                let result = TaskResult::failure(
+                    node_id,
+                    &node_name,
+                    format!(
+                        "Tool '{}' blocked by PreToolUse hook: {:?}",
+                        node_tool,
+                        pre_output.result.feedback_messages()
+                    ),
+                    "hook_blocked".to_string(),
+                    dur,
+                    0,
+                );
+                let _ = eb
+                    .publish(crate::event_system::application::dto::PublishEventInput {
+                        event: ExecutionEvent::NodeCompleted {
+                            execution_id: exec_id,
+                            node_id: node_id.to_string(),
+                            node_name: node_name.clone(),
                             duration_ms: dur,
                             output: serde_json::json!(null),
                             timestamp: chrono::Utc::now(),
@@ -241,6 +285,22 @@ async fn spawn_concurrent_node(
                 )
             }
         };
+
+        // ── PostToolUse hooks (informational — no gating, mirrors execute_tool) ──
+        if let Some(ref hook_runner) = hook_runner {
+            let tool_output = result.output.clone().unwrap_or_default();
+            let abort = crate::hooks::domain::HookAbortSignal::default();
+            let post_input = crate::hooks::application::dto::RunPostToolUseInput {
+                tool_name: node_tool.clone(),
+                tool_input: serde_json::Value::String(node_intent.clone()),
+                tool_output,
+                session_id: node_id.to_string(),
+                workspace_root: ".".to_string(),
+            };
+            if let Ok(_post_output) = hook_runner.run_post_tool_use(post_input, Some(&abort)) {
+                // Post-tool feedback is informational — no gating
+            }
+        }
 
         // Emit NodeCompleted
         let _ = eb

--- a/engine/src/execution_engine/tests.rs
+++ b/engine/src/execution_engine/tests.rs
@@ -272,6 +272,72 @@ async fn test_unknown_tool_fails_single_node_path() {
     );
 }
 
+/// A-05: PreToolUse hooks must gate the PARALLEL dispatch loop, not just the
+/// single-node `execute_tool` path. A hook returning deny blocks the tool.
+#[tokio::test]
+async fn test_pre_tool_use_hook_blocks_parallel_dispatch() {
+    use crate::dag_engine::domain::{TaskGraph, TaskNode};
+    use crate::hooks::application::hook_runner_impl::HookRunnerImpl;
+    use crate::hooks::domain::config::HookConfig;
+
+    let retry =
+        crate::execution_engine::application::service_impl::RetryEvaluationServiceImpl::new();
+    let event_bus = Arc::new(EventBusServiceImpl::default());
+    let runner = Arc::new(HookRunnerImpl::new(HookConfig {
+        pre_tool_use: vec![r#"echo '{"decision":"Deny","reason":"blocked by test"}'"#.into()],
+        ..Default::default()
+    }));
+    let executor = ParallelExecutionServiceImpl::new(
+        ParallelExecutorConfig::default(),
+        Box::new(retry),
+        event_bus,
+    )
+    .with_hook_runner(runner);
+
+    let dag_id = Uuid::new_v4();
+    let node = TaskNode::new(
+        Uuid::new_v4(),
+        "step",
+        "run_command",
+        vec![],
+        r#"{"command": "echo hi"}"#,
+    );
+    let mut graph = TaskGraph::new();
+    graph.add_unchecked(node.clone()).unwrap();
+    graph.seal().unwrap();
+
+    let output = executor
+        .execute_graph(ExecuteGraphInput {
+            dag_id,
+            graph: Some(graph),
+            config_override: None,
+        })
+        .await
+        .unwrap();
+
+    let nr = output
+        .result
+        .node_results
+        .get(&node.id)
+        .expect("node result present");
+    assert!(
+        !nr.success,
+        "PreToolUse deny must block the tool in the parallel path"
+    );
+    assert_eq!(
+        nr.failure_type.as_deref(),
+        Some("hook_blocked"),
+        "failure type must be hook_blocked"
+    );
+    assert!(
+        nr.error
+            .as_deref()
+            .unwrap_or("")
+            .contains("blocked by test"),
+        "error must carry the hook reason"
+    );
+}
+
 /// H-08 regression: hydrating a session must preserve the persisted
 /// `started_at` so a resumed run reports an undistorted duration.
 #[tokio::test]

--- a/engine/src/hooks/application/hook_runner_impl.rs
+++ b/engine/src/hooks/application/hook_runner_impl.rs
@@ -30,6 +30,38 @@ use super::service::{HookCommandExecutor, HookRunnerService};
 /// Minimum timeout in seconds.
 const MIN_TIMEOUT_SECS: u64 = 1;
 
+/// Spawn a thread that drains a child pipe to EOF. Used by
+/// `execute_single_command` so a hook writing more than the pipe buffer
+/// (~64KB) cannot deadlock (GAP-A-04).
+fn spawn_reader_thread(pipe: std::process::ChildStdout) -> std::thread::JoinHandle<Vec<u8>> {
+    std::thread::spawn(move || {
+        use std::io::Read;
+        let mut buf = Vec::new();
+        let _ = std::io::BufReader::new(pipe).read_to_end(&mut buf);
+        buf
+    })
+}
+
+/// Spawn a thread that drains a child stderr pipe to EOF (see above).
+fn spawn_stderr_reader_thread(pipe: std::process::ChildStderr) -> std::thread::JoinHandle<Vec<u8>> {
+    std::thread::spawn(move || {
+        use std::io::Read;
+        let mut buf = Vec::new();
+        let _ = std::io::BufReader::new(pipe).read_to_end(&mut buf);
+        buf
+    })
+}
+
+/// Join both drain threads and return their collected output.
+fn join_reader_threads(
+    out_thread: Option<std::thread::JoinHandle<Vec<u8>>>,
+    err_thread: Option<std::thread::JoinHandle<Vec<u8>>>,
+) -> (Vec<u8>, Vec<u8>) {
+    let stdout = out_thread.and_then(|t| t.join().ok()).unwrap_or_default();
+    let stderr = err_thread.and_then(|t| t.join().ok()).unwrap_or_default();
+    (stdout, stderr)
+}
+
 /// Concrete implementation of `HookRunnerService`.
 ///
 /// Executes hook commands by spawning child processes, piping JSON to stdin,
@@ -107,13 +139,22 @@ impl HookRunnerImpl {
             });
         }
 
+        // Take stdout/stderr and drain them on reader threads while we wait.
+        // GAP-A-04: without concurrent draining, a hook writing more than the
+        // ~64KB pipe buffer blocks forever on write(2) — try_wait() then only
+        // ever sees None and the wall-clock timeout is the sole escape.
+        let out_thread = child.stdout.take().map(spawn_reader_thread);
+        let err_thread = child.stderr.take().map(spawn_stderr_reader_thread);
+
         // Wait for the process with timeout
         let start = Instant::now();
-        loop {
+        let status = loop {
             if let Some(signal) = abort_signal
                 && signal.is_aborted()
             {
                 let _ = child.kill();
+                let _ = child.wait();
+                let _ = join_reader_threads(out_thread, err_thread);
                 return Ok(HookRunResult::cancelled(
                     event,
                     vec![format!("Hook '{}' aborted during execution", command)],
@@ -121,50 +162,13 @@ impl HookRunnerImpl {
             }
 
             match child.try_wait() {
-                Ok(Some(status)) => {
-                    let elapsed = start.elapsed().as_millis() as u64;
-                    let output_result =
-                        child.wait_with_output().map_err(|e| HookError::Internal {
-                            detail: format!("Failed to read output from hook '{}': {}", command, e),
-                        })?;
-
-                    let stdout = String::from_utf8_lossy(&output_result.stdout).to_string();
-                    let stderr = String::from_utf8_lossy(&output_result.stderr).to_string();
-
-                    if !status.success() {
-                        // Try to parse JSON from stdout even on non-zero exit
-                        if let Ok(response) = serde_json::from_str::<HookStdoutResponse>(&stdout) {
-                            return Ok(Self::response_to_result(response, event, elapsed));
-                        }
-                        return Err(HookError::ProcessError {
-                            command: command.to_string(),
-                            exit_code: status.code().unwrap_or(-1),
-                            stderr,
-                        });
-                    }
-
-                    // Successful exit — parse stdout as JSON
-                    match serde_json::from_str::<HookStdoutResponse>(&stdout) {
-                        Ok(response) => {
-                            return Ok(Self::response_to_result(response, event, elapsed));
-                        }
-                        Err(e) => {
-                            if stdout.trim().is_empty() {
-                                // Empty stdout on success = allow (no-op hook)
-                                return Ok(HookRunResult::new(event));
-                            }
-                            return Err(HookError::InvalidJson {
-                                command: command.to_string(),
-                                detail: e.to_string(),
-                                raw_output: stdout.chars().take(500).collect(),
-                            });
-                        }
-                    }
-                }
+                Ok(Some(status)) => break status,
                 Ok(None) => {
                     // Process still running — check timeout
                     if start.elapsed().as_millis() as u64 > timeout_ms {
                         let _ = child.kill();
+                        let _ = child.wait();
+                        let _ = join_reader_threads(out_thread, err_thread);
                         return Err(HookError::Timeout {
                             command: command.to_string(),
                             timeout_ms,
@@ -173,10 +177,50 @@ impl HookRunnerImpl {
                     std::thread::sleep(std::time::Duration::from_millis(10));
                 }
                 Err(e) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    let _ = join_reader_threads(out_thread, err_thread);
                     return Err(HookError::Internal {
                         detail: format!("Error waiting for hook '{}': {}", command, e),
                     });
                 }
+            }
+        };
+
+        // Child has exited (reaped by try_wait above). The drain threads see
+        // EOF once the child's write ends close, so joining is prompt. This
+        // replaces the previous `wait_with_output()` call which ran AFTER the
+        // child was already reaped.
+        let (stdout_bytes, stderr_bytes) = join_reader_threads(out_thread, err_thread);
+        let elapsed = start.elapsed().as_millis() as u64;
+        let stdout = String::from_utf8_lossy(&stdout_bytes).to_string();
+        let stderr = String::from_utf8_lossy(&stderr_bytes).to_string();
+
+        if !status.success() {
+            // Try to parse JSON from stdout even on non-zero exit
+            if let Ok(response) = serde_json::from_str::<HookStdoutResponse>(&stdout) {
+                return Ok(Self::response_to_result(response, event, elapsed));
+            }
+            return Err(HookError::ProcessError {
+                command: command.to_string(),
+                exit_code: status.code().unwrap_or(-1),
+                stderr,
+            });
+        }
+
+        // Successful exit — parse stdout as JSON
+        match serde_json::from_str::<HookStdoutResponse>(&stdout) {
+            Ok(response) => Ok(Self::response_to_result(response, event, elapsed)),
+            Err(e) => {
+                if stdout.trim().is_empty() {
+                    // Empty stdout on success = allow (no-op hook)
+                    return Ok(HookRunResult::new(event));
+                }
+                Err(HookError::InvalidJson {
+                    command: command.to_string(),
+                    detail: e.to_string(),
+                    raw_output: stdout.chars().take(500).collect(),
+                })
             }
         }
     }
@@ -511,6 +555,65 @@ mod tests {
         // Empty config — no hooks to run, so abort doesn't matter
         let output = runner.run_pre_tool_use(input, Some(&signal)).unwrap();
         assert!(output.result.is_allowed());
+    }
+
+    /// GAP-A-04 regression: a hook emitting more than the ~64KB pipe buffer
+    /// must complete promptly (output drained on reader threads) instead of
+    /// blocking forever and only escaping via the wall-clock timeout.
+    ///
+    /// `execute_command` surfaces the raw error: before the fix this was
+    /// `Timeout` (after the 1s window); with the fix the child exits as soon
+    /// as the pipe drains and the non-JSON output yields `InvalidJson`.
+    #[test]
+    fn test_large_hook_output_does_not_deadlock() {
+        let runner = HookRunnerImpl::new(HookConfig::default());
+        let payload = serde_json::json!({});
+        let start = std::time::Instant::now();
+        let result = runner.execute_command("yes x | head -c 200000", &payload, None);
+        let elapsed_ms = start.elapsed().as_millis();
+        assert!(
+            matches!(result, Err(HookError::InvalidJson { .. })),
+            "expected InvalidJson (output drained), got {:?}",
+            result
+        );
+        assert!(
+            elapsed_ms < 900,
+            "must not wait out the 1s timeout, took {}ms",
+            elapsed_ms
+        );
+    }
+
+    #[test]
+    fn test_abort_kills_long_running_hook() {
+        // Abort must kill + reap the child and join the drain threads so no
+        // zombie/leaked pipe is left behind.
+        let config = HookConfig {
+            pre_tool_use: vec!["sleep 30".into()],
+            timeout_secs: 30,
+            ..Default::default()
+        };
+        let runner = HookRunnerImpl::new(config);
+        let signal = runner.create_abort_signal();
+        let input = RunPreToolUseInput {
+            tool_name: "test_tool".into(),
+            tool_input: serde_json::json!({}),
+            session_id: "s".into(),
+            workspace_root: "/tmp".into(),
+        };
+        let thread_signal = signal.clone();
+        let handle =
+            std::thread::spawn(move || runner.run_pre_tool_use(input, Some(&thread_signal)));
+        // Give the hook a moment to spawn, then abort.
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        signal.abort();
+        let output = handle
+            .join()
+            .expect("runner thread must not hang")
+            .expect("runner must return Ok");
+        assert!(
+            output.result.is_cancelled(),
+            "aborted hook must report cancelled"
+        );
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
# fix(hooks): pipe deadlock + hook gating in parallel dispatch

**Batch 2** of the gap-ledger implementation backlog (`feature/hooks-engine`).
Closes **#721** (GAP-A-04), **#722** (GAP-A-05).

## #721 — hook-runner subprocess pipe deadlock

`execute_single_command` polled `child.try_wait()` in a 10ms loop **without draining stdout/stderr**, then called `wait_with_output()` after the child was already reaped. A hook writing more than the ~64KB pipe buffer blocked forever on `write(2)` — only the wall-clock timeout escaped.

- stdout/stderr drained concurrently on reader threads while polling
- On exit: join threads (EOF once the child's write ends close)
- On timeout/abort/wait-error: `kill()` → `wait()` (reap) → join → return — no zombies, no leaked pipes
- **Regression test:** 200KB-output hook returns `InvalidJson` promptly instead of the 1s `Timeout`; abort test kills + reaps a long-running hook

## #722 — hooks bypassed in the parallel dispatch loop

`spawn_concurrent_node` received `_hook_runner` (underscore-unused) — the production `execute_graph` path skipped PreToolUse/PostToolUse hooks entirely, while the single-node `execute_tool` path ran them. Documented hook semantics did not apply to graph-parallel execution.

- Renamed `_hook_runner` → used; cloned into the spawned task
- **PreToolUse gating** after the permission check, mirroring `execute_tool` (deny/fail/cancel → `TaskResult::failure("hook_blocked")` + NodeCompleted)
- **PostToolUse** after dispatch (informational, no gating)
- Call sites already passed `&self.hook_runner` (`run_dispatch_loop`)
- **Test:** a deny PreToolUse hook blocks a parallel-path `run_command` tool

The parallel path now runs the full gate: **permission → pre-hook → exec → post-hook** (permission was already enforced in both paths — verified).

## Verification
- 1889 engine lib tests green (+3 new: large-output no-deadlock, abort-kill, parallel hook gate)
- `clippy -D warnings` clean, `fmt --check` clean, workspace builds