### PR TITLE
fix: audit evidence — full-envelope HMAC, lifecycle events, degraded marker (#723 #755 #734 #752)

### DIFF
--- a/cli/src/tui/event_bridge.rs
+++ b/cli/src/tui/event_bridge.rs
@@ -381,6 +381,11 @@ pub(crate) fn event_to_vm_command(event: &ExecutionEvent) -> Option<VmCommand> {
             // No VmCommand equivalent for budget warnings currently
             None
         }
+        // Audit lifecycle events have no TUI rendering — informational.
+        ExecutionEvent::AuditEnvelopeDelivered { .. }
+        | ExecutionEvent::AuditEnvelopeQueued { .. }
+        | ExecutionEvent::AuditEnvelopeDropped { .. }
+        | ExecutionEvent::CircuitBreakerStateChanged { .. } => None,
     }
 }
 

--- a/engine/src/audit/application/audit_queue_impl.rs
+++ b/engine/src/audit/application/audit_queue_impl.rs
@@ -158,6 +158,7 @@ mod tests {
             file_paths: vec![],
             scoring_results: std::collections::HashMap::new(),
             signature: None,
+            evidence_degraded: false,
             repository: None,
             author: None,
             identity: None,

--- a/engine/src/audit/application/audit_sender_impl.rs
+++ b/engine/src/audit/application/audit_sender_impl.rs
@@ -17,6 +17,9 @@ use async_trait::async_trait;
 use std::sync::Arc;
 
 use crate::audit::domain::AuditError;
+use crate::event_system::application::dto::PublishEventInput;
+use crate::event_system::application::service::EventBusService;
+use crate::event_system::domain::event::ExecutionEvent;
 
 use super::dto::{
     DeliverEnvelopeInput, DeliverEnvelopeOutput, SendEnvelopeInput, SendEnvelopeOutput,
@@ -39,6 +42,9 @@ pub struct AuditSenderImpl {
     default_timeout_secs: u64,
     /// Optional API key for Bearer token authentication.
     api_key: Option<String>,
+    /// Optional event bus for emitting envelope lifecycle events
+    /// (GAP-A-17). `None` disables emission — zero behavior change.
+    event_bus: Option<Arc<dyn EventBusService>>,
 }
 
 impl AuditSenderImpl {
@@ -58,6 +64,7 @@ impl AuditSenderImpl {
             client,
             default_timeout_secs: 30,
             api_key: None,
+            event_bus: None,
         }
     }
 
@@ -78,6 +85,7 @@ impl AuditSenderImpl {
             client,
             default_timeout_secs,
             api_key: None,
+            event_bus: None,
         }
     }
 
@@ -85,6 +93,20 @@ impl AuditSenderImpl {
     pub fn with_api_key(mut self, api_key: Option<String>) -> Self {
         self.api_key = api_key;
         self
+    }
+
+    /// Attach an event bus to emit envelope lifecycle events (GAP-A-17).
+    pub fn with_event_bus(mut self, event_bus: Arc<dyn EventBusService>) -> Self {
+        self.event_bus = Some(event_bus);
+        self
+    }
+
+    /// Publish an envelope lifecycle event on the attached bus (best-effort:
+    /// publish failures are logged by the bus and never fail delivery).
+    async fn emit(&self, event: ExecutionEvent) {
+        if let Some(ref bus) = self.event_bus {
+            let _ = bus.publish(PublishEventInput { event }).await;
+        }
     }
 
     /// Compute the next backoff delay with jitter.
@@ -149,6 +171,14 @@ impl AuditSender for AuditSenderImpl {
                     if let Some(ref cb) = self.circuit_breaker {
                         cb.record_success().await.unwrap_or_default();
                     }
+                    // GAP-A-17: emit the delivered lifecycle event.
+                    self.emit(ExecutionEvent::AuditEnvelopeDelivered {
+                        execution_id: input.envelope.execution_id,
+                        attempt: 1,
+                        duration_ms,
+                        timestamp: chrono::Utc::now(),
+                    })
+                    .await;
                     Ok(SendEnvelopeOutput {
                         success: true,
                         http_status: Some(status),
@@ -216,6 +246,26 @@ impl AuditSender for AuditSenderImpl {
 
                     // Don't retry if circuit breaker is open
                     if matches!(err, AuditError::CircuitBreakerOpen { .. }) {
+                        // GAP-A-17: the breaker just transitioned — emit the
+                        // state change and the permanent drop.
+                        self.emit(ExecutionEvent::CircuitBreakerStateChanged {
+                            execution_id: input.envelope.execution_id,
+                            backend_url: self
+                                .default_backend_url
+                                .clone()
+                                .unwrap_or_else(|| "<default>".to_string()),
+                            from_state: "closed".to_string(),
+                            to_state: "open".to_string(),
+                            timestamp: chrono::Utc::now(),
+                        })
+                        .await;
+                        self.emit(ExecutionEvent::AuditEnvelopeDropped {
+                            execution_id: input.envelope.execution_id,
+                            attempts: attempt,
+                            reason: err.to_string(),
+                            timestamp: chrono::Utc::now(),
+                        })
+                        .await;
                         return Ok(DeliverEnvelopeOutput {
                             success: false,
                             attempts: attempt,
@@ -227,6 +277,15 @@ impl AuditSender for AuditSenderImpl {
 
                     // Wait for backoff before next retry
                     if attempt < input.max_retries {
+                        // GAP-A-17: delivery failed and will be retried.
+                        self.emit(ExecutionEvent::AuditEnvelopeQueued {
+                            execution_id: input.envelope.execution_id,
+                            reason: err.to_string(),
+                            retry_count: attempt,
+                            max_retries: input.max_retries,
+                            timestamp: chrono::Utc::now(),
+                        })
+                        .await;
                         let delay = Self::backoff_delay(
                             attempt,
                             input.backoff_base_secs,
@@ -237,6 +296,15 @@ impl AuditSender for AuditSenderImpl {
                 }
             }
         }
+
+        // GAP-A-17: retries exhausted — the envelope is permanently dropped.
+        self.emit(ExecutionEvent::AuditEnvelopeDropped {
+            execution_id: input.envelope.execution_id,
+            attempts: input.max_retries,
+            reason: last_error.clone().unwrap_or_else(|| "unknown".to_string()),
+            timestamp: chrono::Utc::now(),
+        })
+        .await;
 
         Ok(DeliverEnvelopeOutput {
             success: false,
@@ -279,6 +347,7 @@ mod tests {
             file_paths: vec![],
             scoring_results: std::collections::HashMap::new(),
             signature: None,
+            evidence_degraded: false,
             repository: None,
             author: None,
             identity: None,
@@ -364,5 +433,107 @@ mod tests {
         // Both should be capped at max_secs (5) plus jitter
         assert!(d1.as_secs_f64() <= 6.25); // 5 + 25%
         assert!(d2.as_secs_f64() <= 6.25);
+    }
+
+    /// GAP-A-17: delivery failures emit EnvelopeQueued then EnvelopeDropped.
+    #[tokio::test]
+    async fn test_sender_emits_queued_then_dropped_events() {
+        use crate::event_system::application::event_bus_service_impl::EventBusServiceImpl;
+        use crate::event_system::domain::event::ExecutionEvent;
+
+        let bus = Arc::new(EventBusServiceImpl::default());
+        let mut rx = bus.subscribe_receiver();
+        let sender = AuditSenderImpl::new(
+            None,
+            Some("http://127.0.0.1:1".to_string()), // port 1 -> instant ECONNREFUSED
+        )
+        .with_event_bus(bus);
+
+        let output = sender
+            .deliver_with_retry(DeliverEnvelopeInput {
+                envelope: sample_envelope(),
+                max_retries: 2,
+                backoff_base_secs: 0,
+                backoff_max_secs: 1,
+            })
+            .await
+            .unwrap();
+        assert!(!output.success, "delivery to port 1 must fail");
+
+        // First event: queued for retry.
+        let first = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("queued event must be emitted")
+            .expect("channel not closed");
+        match first {
+            ExecutionEvent::AuditEnvelopeQueued { retry_count, .. } => {
+                assert_eq!(retry_count, 1);
+            }
+            other => panic!("expected AuditEnvelopeQueued, got {other:?}"),
+        }
+
+        // Second event: permanently dropped after exhausting retries.
+        let second = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("dropped event must be emitted")
+            .expect("channel not closed");
+        assert!(
+            matches!(
+                second,
+                ExecutionEvent::AuditEnvelopeDropped { attempts: 2, .. }
+            ),
+            "expected AuditEnvelopeDropped after 2 attempts, got {second:?}"
+        );
+    }
+
+    /// GAP-A-17: an open circuit breaker emits the state change and a drop.
+    #[tokio::test]
+    async fn test_sender_emits_breaker_open_events() {
+        use crate::event_system::application::event_bus_service_impl::EventBusServiceImpl;
+        use crate::event_system::domain::event::ExecutionEvent;
+
+        let bus = Arc::new(EventBusServiceImpl::default());
+        let mut rx = bus.subscribe_receiver();
+        let cb = Arc::new(CircuitBreakerImpl::new(
+            "https://audit.example.com".to_string(),
+            1,
+            30,
+        ));
+        cb.record_failure().await.unwrap(); // open the breaker
+
+        let sender = AuditSenderImpl::new(Some(cb), Some("https://audit.example.com".to_string()))
+            .with_event_bus(bus);
+
+        let output = sender
+            .deliver_with_retry(DeliverEnvelopeInput {
+                envelope: sample_envelope(),
+                max_retries: 3,
+                backoff_base_secs: 0,
+                backoff_max_secs: 1,
+            })
+            .await
+            .unwrap();
+        assert!(!output.success, "open breaker must drop delivery");
+
+        let first = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("breaker event must be emitted")
+            .expect("channel not closed");
+        assert!(
+            matches!(
+                &first,
+                ExecutionEvent::CircuitBreakerStateChanged { to_state, .. } if to_state == "open"
+            ),
+            "expected CircuitBreakerStateChanged(open), got {first:?}"
+        );
+
+        let second = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("dropped event must be emitted")
+            .expect("channel not closed");
+        assert!(
+            matches!(&second, ExecutionEvent::AuditEnvelopeDropped { .. }),
+            "expected AuditEnvelopeDropped, got {second:?}"
+        );
     }
 }

--- a/engine/src/audit/application/envelope_factory_impl.rs
+++ b/engine/src/audit/application/envelope_factory_impl.rs
@@ -42,7 +42,11 @@ impl AuditEnvelopeFactoryImpl {
         hex
     }
 
-    /// Compute HMAC-SHA256 signature over the envelope content.
+    /// Compute HMAC-SHA256 signature over the full canonical envelope.
+    ///
+    /// GAP-A-06: previously only 7 scalar fields were signed — event contents,
+    /// `file_paths`, `scoring_results`, `identity` and git metadata were
+    /// unsigned, so tampering with any evidence field went undetected.
     fn compute_signature(envelope: &AuditEnvelope, key: &str) -> Result<String, AuditError> {
         use hmac::Mac;
         let mut mac =
@@ -50,14 +54,17 @@ impl AuditEnvelopeFactoryImpl {
                 detail: format!("HMAC key error: {e}"),
             })?;
 
-        // Sign the canonical fields
-        mac.update(envelope.execution_id.to_string().as_bytes());
-        mac.update(envelope.timestamp.to_rfc3339().as_bytes());
-        mac.update(envelope.template_id.as_bytes());
-        mac.update(envelope.planning_hash.as_bytes());
-        mac.update(&envelope.total_tokens.to_le_bytes());
-        mac.update(&envelope.duration_ms.to_le_bytes());
-        mac.update(&(envelope.events.len() as u64).to_le_bytes());
+        // Canonical form: the FULL envelope serialized as sorted-key JSON.
+        // serde_json::Map is BTreeMap-backed (no preserve_order feature), so
+        // HashMap fields serialize deterministically. The signature field is
+        // excluded so signing and verification hash identical bytes.
+        let mut canonical_envelope = envelope.clone();
+        canonical_envelope.signature = None;
+        let canonical =
+            serde_json::to_string(&canonical_envelope).map_err(|e| AuditError::Internal {
+                detail: format!("Canonical envelope serialization failed: {e}"),
+            })?;
+        mac.update(canonical.as_bytes());
 
         let result = mac.finalize().into_bytes();
         let hex: String = result.iter().map(|b| format!("{:02x}", b)).collect();
@@ -100,6 +107,10 @@ impl AuditEnvelopeFactory for AuditEnvelopeFactoryImpl {
             events: input.events,
             scoring_results: input.scoring_results,
             signature: None,
+            // GAP-M-12: an unsigned run is explicitly degraded evidence.
+            // Approval-bearing runs must request signing; this marker makes
+            // the absence of a signature observable downstream.
+            evidence_degraded: !input.sign,
         };
 
         // Optionally apply HMAC signing
@@ -249,5 +260,99 @@ mod tests {
 
         // Same planning prompt should produce the same hash
         assert_eq!(e1.planning_hash, e2.planning_hash);
+    }
+
+    /// GAP-A-06: the HMAC must cover the FULL envelope. Tampering with any
+    /// evidence field — event contents, file_paths, scoring_results — must
+    /// break verification. (Previously only 7 scalar fields were signed.)
+    #[tokio::test]
+    async fn test_verify_signature_detects_evidence_tampering() {
+        let factory = AuditEnvelopeFactoryImpl::new(Some("test-key-123".to_string()));
+
+        // Tamper with an event's payload content.
+        let mut input = sample_input();
+        input.sign = true;
+        let mut envelope = factory.build_envelope(input).await.unwrap();
+        envelope.events[0].summary = "Tampered summary".to_string();
+        assert!(
+            factory.verify_signature(&envelope).await.is_err(),
+            "tampered event content must fail verification"
+        );
+
+        // Tamper with file_paths.
+        let mut input = sample_input();
+        input.sign = true;
+        let mut envelope = factory.build_envelope(input).await.unwrap();
+        envelope.file_paths.push("src/injected.rs".to_string());
+        assert!(
+            factory.verify_signature(&envelope).await.is_err(),
+            "tampered file_paths must fail verification"
+        );
+
+        // Tamper with scoring_results.
+        let mut input = sample_input();
+        input.sign = true;
+        let mut envelope = factory.build_envelope(input).await.unwrap();
+        envelope.scoring_results.insert(
+            "node-1".to_string(),
+            crate::audit::domain::ScoringResultRef {
+                passed: true,
+                backend: "test".to_string(),
+                dimensions: std::collections::HashMap::new(),
+                duration_ms: 10,
+            },
+        );
+        assert!(
+            factory.verify_signature(&envelope).await.is_err(),
+            "tampered scoring_results must fail verification"
+        );
+
+        // Untampered envelope still verifies (control).
+        let mut input = sample_input();
+        input.sign = true;
+        let envelope = factory.build_envelope(input).await.unwrap();
+        assert!(factory.verify_signature(&envelope).await.is_ok());
+    }
+
+    /// GAP-M-12: unsigned envelopes are explicitly marked as degraded
+    /// evidence; signed envelopes are not.
+    #[tokio::test]
+    async fn test_evidence_degraded_marker() {
+        let factory = AuditEnvelopeFactoryImpl::new(Some("test-key-123".to_string()));
+
+        let mut unsigned_input = sample_input();
+        unsigned_input.sign = false;
+        let unsigned = factory.build_envelope(unsigned_input).await.unwrap();
+        assert!(
+            unsigned.evidence_degraded,
+            "unsigned envelope must be marked evidence_degraded"
+        );
+        assert!(unsigned.signature.is_none());
+
+        let mut signed_input = sample_input();
+        signed_input.sign = true;
+        let signed = factory.build_envelope(signed_input).await.unwrap();
+        assert!(
+            !signed.evidence_degraded,
+            "signed envelope must not be marked degraded"
+        );
+        assert!(signed.signature.is_some());
+    }
+
+    /// GAP-L-09: git provenance fields must carry from input into the
+    /// envelope (the orchestrator populates them from `detect_git_info`).
+    #[tokio::test]
+    async fn test_git_provenance_fields_carry_through() {
+        let factory = AuditEnvelopeFactoryImpl::default();
+        let mut input = sample_input();
+        input.git_commit = Some("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2".to_string());
+        input.git_branch = Some("main".to_string());
+
+        let envelope = factory.build_envelope(input).await.unwrap();
+        assert_eq!(
+            envelope.git_commit.as_deref(),
+            Some("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+        );
+        assert_eq!(envelope.git_branch.as_deref(), Some("main"));
     }
 }

--- a/engine/src/audit/domain/envelope.rs
+++ b/engine/src/audit/domain/envelope.rs
@@ -107,6 +107,14 @@ pub struct AuditEnvelope {
     ///
     /// `None` if HMAC signing is not configured.
     pub signature: Option<String>,
+
+    /// Evidence-integrity marker: true when this envelope was produced
+    /// WITHOUT an HMAC signature (signing not requested). Approval-bearing
+    /// runs must be signed; unsigned envelopes carry this explicit degraded
+    /// marker so consumers can distinguish "intentionally unsigned" from
+    /// "tampered" (GAP-M-12).
+    #[serde(default)]
+    pub evidence_degraded: bool,
 }
 
 /// A reference to a scoring result included in the audit envelope.

--- a/engine/src/audit/infrastructure/local_audit_repository.rs
+++ b/engine/src/audit/infrastructure/local_audit_repository.rs
@@ -240,6 +240,7 @@ mod tests {
             file_paths: vec![],
             scoring_results: std::collections::HashMap::new(),
             signature: None,
+            evidence_degraded: false,
             repository: None,
             author: None,
             identity: None,

--- a/engine/src/event_system/application/event_bus_service_impl.rs
+++ b/engine/src/event_system/application/event_bus_service_impl.rs
@@ -197,7 +197,11 @@ impl EventBusService for EventBusServiceImpl {
                         | ExecutionEvent::ExecutionCompleted { execution_id, .. }
                         | ExecutionEvent::ExecutionFailed { execution_id, .. }
                         | ExecutionEvent::ExecutionCancelled { execution_id, .. }
-                        | ExecutionEvent::BudgetWarning { execution_id, .. } => {
+                        | ExecutionEvent::BudgetWarning { execution_id, .. }
+                        | ExecutionEvent::AuditEnvelopeDelivered { execution_id, .. }
+                        | ExecutionEvent::AuditEnvelopeQueued { execution_id, .. }
+                        | ExecutionEvent::AuditEnvelopeDropped { execution_id, .. }
+                        | ExecutionEvent::CircuitBreakerStateChanged { execution_id, .. } => {
                             if execution_id != eid {
                                 return false;
                             }
@@ -231,6 +235,12 @@ impl EventBusService for EventBusServiceImpl {
                         ExecutionEvent::ExecutionFailed { .. } => "execution_failed",
                         ExecutionEvent::ExecutionCancelled { .. } => "execution_cancelled",
                         ExecutionEvent::BudgetWarning { .. } => "budget_warning",
+                        ExecutionEvent::AuditEnvelopeDelivered { .. } => "audit_envelope_delivered",
+                        ExecutionEvent::AuditEnvelopeQueued { .. } => "audit_envelope_queued",
+                        ExecutionEvent::AuditEnvelopeDropped { .. } => "audit_envelope_dropped",
+                        ExecutionEvent::CircuitBreakerStateChanged { .. } => {
+                            "circuit_breaker_state_changed"
+                        }
                     };
                     if variant_name != event_type {
                         return false;
@@ -253,6 +263,10 @@ impl EventBusService for EventBusServiceImpl {
                         ExecutionEvent::ExecutionFailed { timestamp, .. } => timestamp,
                         ExecutionEvent::ExecutionCancelled { timestamp, .. } => timestamp,
                         ExecutionEvent::BudgetWarning { timestamp, .. } => timestamp,
+                        ExecutionEvent::AuditEnvelopeDelivered { timestamp, .. } => timestamp,
+                        ExecutionEvent::AuditEnvelopeQueued { timestamp, .. } => timestamp,
+                        ExecutionEvent::AuditEnvelopeDropped { timestamp, .. } => timestamp,
+                        ExecutionEvent::CircuitBreakerStateChanged { timestamp, .. } => timestamp,
                     };
                     if ts < after {
                         return false;
@@ -274,6 +288,10 @@ impl EventBusService for EventBusServiceImpl {
                         ExecutionEvent::ExecutionFailed { timestamp, .. } => timestamp,
                         ExecutionEvent::ExecutionCancelled { timestamp, .. } => timestamp,
                         ExecutionEvent::BudgetWarning { timestamp, .. } => timestamp,
+                        ExecutionEvent::AuditEnvelopeDelivered { timestamp, .. } => timestamp,
+                        ExecutionEvent::AuditEnvelopeQueued { timestamp, .. } => timestamp,
+                        ExecutionEvent::AuditEnvelopeDropped { timestamp, .. } => timestamp,
+                        ExecutionEvent::CircuitBreakerStateChanged { timestamp, .. } => timestamp,
                     };
                     if ts > before {
                         return false;

--- a/engine/src/event_system/domain/event.rs
+++ b/engine/src/event_system/domain/event.rs
@@ -211,6 +211,62 @@ pub enum ExecutionEvent {
         /// ISO 8601 timestamp of the warning.
         timestamp: DateTime<Utc>,
     },
+
+    /// An audit envelope was successfully delivered to the backend.
+    AuditEnvelopeDelivered {
+        /// The execution ID this envelope belongs to.
+        execution_id: uuid::Uuid,
+        /// Delivery attempt number.
+        attempt: u32,
+        /// Duration of delivery in milliseconds.
+        duration_ms: u64,
+        /// ISO 8601 timestamp of the event.
+        timestamp: DateTime<Utc>,
+    },
+
+    /// An audit envelope failed delivery and was queued for retry.
+    AuditEnvelopeQueued {
+        /// The execution ID this envelope belongs to.
+        execution_id: uuid::Uuid,
+        /// Why delivery failed.
+        reason: String,
+        /// Number of pending retries so far.
+        retry_count: u32,
+        /// Maximum retries before dropping.
+        max_retries: u32,
+        /// ISO 8601 timestamp of the event.
+        timestamp: DateTime<Utc>,
+    },
+
+    /// An audit envelope was permanently dropped after exhausting retries.
+    AuditEnvelopeDropped {
+        /// The execution ID this envelope belongs to.
+        execution_id: uuid::Uuid,
+        /// Total delivery attempts made.
+        attempts: u32,
+        /// Final error detail.
+        reason: String,
+        /// ISO 8601 timestamp of the event.
+        timestamp: DateTime<Utc>,
+    },
+
+    /// The audit circuit breaker changed state.
+    ///
+    /// Carries the execution context of the delivery attempt that observed
+    /// the transition (the breaker is backend-scoped, but the transition is
+    /// surfaced during a specific envelope's delivery).
+    CircuitBreakerStateChanged {
+        /// The execution ID whose delivery observed the transition.
+        execution_id: uuid::Uuid,
+        /// The backend URL affected.
+        backend_url: String,
+        /// Previous state.
+        from_state: String,
+        /// New state.
+        to_state: String,
+        /// ISO 8601 timestamp of the event.
+        timestamp: DateTime<Utc>,
+    },
 }
 
 /// A persisted execution event with a monotonic sequence number.
@@ -251,6 +307,10 @@ impl ExecutionEvent {
             ExecutionEvent::ExecutionFailed { .. } => "execution_failed",
             ExecutionEvent::ExecutionCancelled { .. } => "execution_cancelled",
             ExecutionEvent::BudgetWarning { .. } => "budget_warning",
+            ExecutionEvent::AuditEnvelopeDelivered { .. } => "audit_envelope_delivered",
+            ExecutionEvent::AuditEnvelopeQueued { .. } => "audit_envelope_queued",
+            ExecutionEvent::AuditEnvelopeDropped { .. } => "audit_envelope_dropped",
+            ExecutionEvent::CircuitBreakerStateChanged { .. } => "circuit_breaker_state_changed",
         }
     }
 
@@ -267,7 +327,11 @@ impl ExecutionEvent {
             | ExecutionEvent::ExecutionCompleted { execution_id, .. }
             | ExecutionEvent::ExecutionFailed { execution_id, .. }
             | ExecutionEvent::ExecutionCancelled { execution_id, .. }
-            | ExecutionEvent::BudgetWarning { execution_id, .. } => execution_id,
+            | ExecutionEvent::BudgetWarning { execution_id, .. }
+            | ExecutionEvent::AuditEnvelopeDelivered { execution_id, .. }
+            | ExecutionEvent::AuditEnvelopeQueued { execution_id, .. }
+            | ExecutionEvent::AuditEnvelopeDropped { execution_id, .. }
+            | ExecutionEvent::CircuitBreakerStateChanged { execution_id, .. } => execution_id,
         }
     }
 
@@ -284,7 +348,11 @@ impl ExecutionEvent {
             | ExecutionEvent::ExecutionCompleted { timestamp, .. }
             | ExecutionEvent::ExecutionFailed { timestamp, .. }
             | ExecutionEvent::ExecutionCancelled { timestamp, .. }
-            | ExecutionEvent::BudgetWarning { timestamp, .. } => timestamp,
+            | ExecutionEvent::BudgetWarning { timestamp, .. }
+            | ExecutionEvent::AuditEnvelopeDelivered { timestamp, .. }
+            | ExecutionEvent::AuditEnvelopeQueued { timestamp, .. }
+            | ExecutionEvent::AuditEnvelopeDropped { timestamp, .. }
+            | ExecutionEvent::CircuitBreakerStateChanged { timestamp, .. } => timestamp,
         }
     }
 
@@ -368,6 +436,41 @@ impl ExecutionEvent {
                     "Budget warning: {} used {}/{} (resource: {})",
                     resource, used, limit, resource
                 )
+            }
+            ExecutionEvent::AuditEnvelopeDelivered {
+                attempt,
+                duration_ms,
+                ..
+            } => {
+                format!(
+                    "Audit envelope delivered (attempt {}, {}ms)",
+                    attempt, duration_ms
+                )
+            }
+            ExecutionEvent::AuditEnvelopeQueued {
+                reason,
+                retry_count,
+                ..
+            } => {
+                format!(
+                    "Audit envelope queued (retry {}, reason: {})",
+                    retry_count, reason
+                )
+            }
+            ExecutionEvent::AuditEnvelopeDropped {
+                attempts, reason, ..
+            } => {
+                format!(
+                    "Audit envelope dropped ({} attempts, reason: {})",
+                    attempts, reason
+                )
+            }
+            ExecutionEvent::CircuitBreakerStateChanged {
+                backend_url,
+                to_state,
+                ..
+            } => {
+                format!("Circuit breaker {} for {}", to_state, backend_url)
             }
         }
     }
@@ -455,7 +558,11 @@ impl ExecutionEvent {
             ExecutionEvent::PlanningStarted { .. }
             | ExecutionEvent::NodeStarted { .. }
             | ExecutionEvent::NodeRetrying { .. }
-            | ExecutionEvent::ExecutionCancelled { .. } => None,
+            | ExecutionEvent::ExecutionCancelled { .. }
+            | ExecutionEvent::AuditEnvelopeDelivered { .. }
+            | ExecutionEvent::AuditEnvelopeQueued { .. }
+            | ExecutionEvent::AuditEnvelopeDropped { .. }
+            | ExecutionEvent::CircuitBreakerStateChanged { .. } => None,
         }
     }
 

--- a/engine/src/event_system/infrastructure/in_memory_event_repository.rs
+++ b/engine/src/event_system/infrastructure/in_memory_event_repository.rs
@@ -110,7 +110,11 @@ impl PersistedEventRepository for InMemoryEventRepository {
                         | ExecutionEvent::ExecutionCompleted { execution_id, .. }
                         | ExecutionEvent::ExecutionFailed { execution_id, .. }
                         | ExecutionEvent::ExecutionCancelled { execution_id, .. }
-                        | ExecutionEvent::BudgetWarning { execution_id, .. } => {
+                        | ExecutionEvent::BudgetWarning { execution_id, .. }
+                        | ExecutionEvent::AuditEnvelopeDelivered { execution_id, .. }
+                        | ExecutionEvent::AuditEnvelopeQueued { execution_id, .. }
+                        | ExecutionEvent::AuditEnvelopeDropped { execution_id, .. }
+                        | ExecutionEvent::CircuitBreakerStateChanged { execution_id, .. } => {
                             if execution_id != eid {
                                 return false;
                             }
@@ -141,6 +145,12 @@ impl PersistedEventRepository for InMemoryEventRepository {
                         ExecutionEvent::ExecutionFailed { .. } => "execution_failed",
                         ExecutionEvent::ExecutionCancelled { .. } => "execution_cancelled",
                         ExecutionEvent::BudgetWarning { .. } => "budget_warning",
+                        ExecutionEvent::AuditEnvelopeDelivered { .. } => "audit_envelope_delivered",
+                        ExecutionEvent::AuditEnvelopeQueued { .. } => "audit_envelope_queued",
+                        ExecutionEvent::AuditEnvelopeDropped { .. } => "audit_envelope_dropped",
+                        ExecutionEvent::CircuitBreakerStateChanged { .. } => {
+                            "circuit_breaker_state_changed"
+                        }
                     };
                     if variant_name != event_type {
                         return false;
@@ -161,6 +171,10 @@ impl PersistedEventRepository for InMemoryEventRepository {
                     ExecutionEvent::ExecutionFailed { timestamp, .. } => timestamp,
                     ExecutionEvent::ExecutionCancelled { timestamp, .. } => timestamp,
                     ExecutionEvent::BudgetWarning { timestamp, .. } => timestamp,
+                    ExecutionEvent::AuditEnvelopeDelivered { timestamp, .. } => timestamp,
+                    ExecutionEvent::AuditEnvelopeQueued { timestamp, .. } => timestamp,
+                    ExecutionEvent::AuditEnvelopeDropped { timestamp, .. } => timestamp,
+                    ExecutionEvent::CircuitBreakerStateChanged { timestamp, .. } => timestamp,
                 };
                 if let Some(after) = &input.after_timestamp
                     && ts < after
@@ -227,6 +241,10 @@ impl PersistedEventRepository for InMemoryEventRepository {
                 ExecutionEvent::ExecutionFailed { timestamp, .. } => timestamp,
                 ExecutionEvent::ExecutionCancelled { timestamp, .. } => timestamp,
                 ExecutionEvent::BudgetWarning { timestamp, .. } => timestamp,
+                ExecutionEvent::AuditEnvelopeDelivered { timestamp, .. } => timestamp,
+                ExecutionEvent::AuditEnvelopeQueued { timestamp, .. } => timestamp,
+                ExecutionEvent::AuditEnvelopeDropped { timestamp, .. } => timestamp,
+                ExecutionEvent::CircuitBreakerStateChanged { timestamp, .. } => timestamp,
             };
             ts >= &older_than
         });

--- a/engine/src/orchestrator/application/orchestrator_impl.rs
+++ b/engine/src/orchestrator/application/orchestrator_impl.rs
@@ -796,6 +796,22 @@ impl OrchestratorService for OrchestratorServiceImpl {
                                 timestamp,
                                 ..
                             } => *timestamp,
+                            crate::event_system::domain::ExecutionEvent::AuditEnvelopeDelivered {
+                                timestamp,
+                                ..
+                            } => *timestamp,
+                            crate::event_system::domain::ExecutionEvent::AuditEnvelopeQueued {
+                                timestamp,
+                                ..
+                            } => *timestamp,
+                            crate::event_system::domain::ExecutionEvent::AuditEnvelopeDropped {
+                                timestamp,
+                                ..
+                            } => *timestamp,
+                            crate::event_system::domain::ExecutionEvent::CircuitBreakerStateChanged {
+                                timestamp,
+                                ..
+                            } => *timestamp,
                         };
                         ExecutionEventInfo {
                             event_type: pe.event.event_type_name().to_string(),
@@ -1313,6 +1329,22 @@ impl OrchestratorService for OrchestratorServiceImpl {
                                 timestamp,
                                 ..
                             } => *timestamp,
+                            crate::event_system::domain::ExecutionEvent::AuditEnvelopeDelivered {
+                                timestamp,
+                                ..
+                            } => *timestamp,
+                            crate::event_system::domain::ExecutionEvent::AuditEnvelopeQueued {
+                                timestamp,
+                                ..
+                            } => *timestamp,
+                            crate::event_system::domain::ExecutionEvent::AuditEnvelopeDropped {
+                                timestamp,
+                                ..
+                            } => *timestamp,
+                            crate::event_system::domain::ExecutionEvent::CircuitBreakerStateChanged {
+                                timestamp,
+                                ..
+                            } => *timestamp,
                         };
                         ExecutionEventInfo {
                             event_type: pe.event.event_type_name().to_string(),
@@ -1624,6 +1656,7 @@ mod tests {
                     events: vec![],
                     scoring_results: std::collections::HashMap::new(),
                     signature: None,
+                    evidence_degraded: false,
                 },
                 signed: false,
                 event_count: 0,

--- a/engine/src/orchestrator/application/orchestrator_mocks.rs
+++ b/engine/src/orchestrator/application/orchestrator_mocks.rs
@@ -501,6 +501,7 @@ impl crate::audit::application::AuditService for MockAuditService {
                 events: vec![],
                 scoring_results: std::collections::HashMap::new(),
                 signature: None,
+                evidence_degraded: false,
                 repository: None,
                 author: None,
                 identity: None,

--- a/mcp/src/audit_tools/infrastructure/in_memory_audit_service.rs
+++ b/mcp/src/audit_tools/infrastructure/in_memory_audit_service.rs
@@ -457,28 +457,24 @@ mod tests {
     }
 }
 
-/// Compute an HMAC-SHA256 signature over the envelope's canonical fields,
+/// Compute an HMAC-SHA256 signature over the envelope's canonical form,
 /// mirroring the engine's `envelope_factory_impl::compute_signature` so the
-/// MCP-facing envelope can be verified with the same key used by the engine.
+/// MCP-facing envelope is verified with the same key used by the engine.
+///
+/// GAP-A-06: the signature covers the FULL serialized envelope (the hmac
+/// field is empty at signing time), so tampering with any step/status/duration
+/// field breaks the signature — previously only a scalar subset was signed.
 fn compute_hmac(envelope: &AuditEnvelope, key: &str) -> String {
     use hmac::{Hmac, Mac};
     use sha2::Sha256;
 
     let mut mac =
         Hmac::<Sha256>::new_from_slice(key.as_bytes()).expect("HMAC key from config is valid");
-    mac.update(envelope.execution_id().to_string().as_bytes());
-    mac.update(envelope.started_at().to_rfc3339().as_bytes());
-    mac.update(envelope.completed_at().to_rfc3339().as_bytes());
-    mac.update(envelope.template_name().unwrap_or("").as_bytes());
-    mac.update(&envelope.duration_ms().to_le_bytes());
-    mac.update(&(envelope.steps().len() as u64).to_le_bytes());
-    for step in envelope.steps() {
-        mac.update(step.step_name().as_bytes());
-        mac.update(&[step.is_success() as u8]);
-        if let Some(err) = step.error() {
-            mac.update(err.as_bytes());
-        }
-    }
+    // Canonical: full sorted-key serialization (serde_json::Map is
+    // BTreeMap-backed without preserve_order). The hmac field is empty at
+    // signing time, matching the envelope the caller signs before rebuilding.
+    let canonical = serde_json::to_string(envelope).unwrap_or_default();
+    mac.update(canonical.as_bytes());
     let result = mac.finalize().into_bytes();
     result.iter().map(|b| format!("{:02x}", b)).collect()
 }


### PR DESCRIPTION
# fix(audit): full-envelope HMAC + lifecycle events + evidence marker

**Batch 3** of the gap-ledger implementation backlog (`feature/audit-evidence`).
Closes **#723** (GAP-A-06), **#755** (GAP-M-12), **#734** (GAP-A-17), **#752** (GAP-L-09).

## #723 — HMAC now covers the FULL canonical envelope

Engine `compute_signature` signed only 7 scalar fields — event contents, `file_paths`, `scoring_results`, `identity` and git metadata were unsigned, so tampering with any evidence field went undetected. MCP `compute_hmac` used a different, equally partial field set.

- Engine: sign the **full envelope as sorted-key canonical JSON** (serde_json `Map` is BTreeMap-backed without `preserve_order` → deterministic); the `signature` field is excluded so sign and verify hash identical bytes
- MCP: mirrored the same full-canonical-serialization approach
- **Tests:** tampering `events[0]`, `file_paths`, or `scoring_results` breaks verification; an untampered envelope still verifies

## #755 — explicit `evidence_degraded` marker

`AuditEnvelope.evidence_degraded` (serde-defaulted) is set true when signing is not requested, so an unsigned envelope is explicit degraded evidence. Sign-without-key still hard-fails (the M-12 "fail" branch). Test covers both states. This is the hook the approval epic needs: approval-bearing runs must request signing or carry the marker.

## #734 — envelope lifecycle events are emitted

`ExecutionEvent` gains `AuditEnvelopeDelivered` / `AuditEnvelopeQueued` / `AuditEnvelopeDropped` / `CircuitBreakerStateChanged` (execution_id + timestamp, consistent with the enum contract). `AuditSenderImpl` accepts an optional event bus (`with_event_bus`, default `None` = zero behavior change) and emits the lifecycle events from `send` / `deliver_with_retry`. All exhaustive matches updated (event_system, orchestrator, repository, CLI TUI bridge). **Tests:** queued-then-dropped and breaker-open emission via a real bus.

## #752 — git provenance verified + regression test

**Verified:** the orchestrator's `detect_git_info` (orchestrator_impl.rs:814-825) populates the record context → `BuildEnvelopeInput` → envelope. The `git_commit: None` sites in queue/sender/repository are **test fixtures**, not production paths. Added a factory regression test asserting git fields carry through.

## Verification
- 1894 engine lib tests (+5 new), 2500 workspace tests total
- `clippy -D warnings` clean, `fmt --check` clean, workspace builds
- mcp audit_tools tests pass (19)

**Note:** the full-envelope HMAC changes the signature bytes vs the old scalar-subset format. Signatures are computed and verified in-process at build/verify time; no persisted signature crosses this format boundary.