### PR TITLE
feat(actions): governance Mode A — diff analysis + policy evaluation (#725)

### DIFF
--- a/actions/src/action_entrypoint/application/context_builder_impl.rs
+++ b/actions/src/action_entrypoint/application/context_builder_impl.rs
@@ -355,6 +355,9 @@ impl ContextBuilder for ContextBuilderImpl {
                 ActionMode::Validate { .. } => ActionMode::Validate {
                     intent: intent_val.clone(),
                 },
+                ActionMode::Governance { .. } => ActionMode::Governance {
+                    intent: intent_val.clone(),
+                },
                 other => other,
             }
         } else {
@@ -411,6 +414,34 @@ impl ContextBuilder for ContextBuilderImpl {
                 .await?
         };
 
+        // 8b. Mode A governance flags (GAP-A-08)
+        let policy_file = if let Some(overrides) = &input.env_override {
+            overrides
+                .get("INPUT_POLICY_FILE")
+                .cloned()
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| ".rigorix/policy.toml".to_string())
+        } else {
+            self.repository
+                .read_env_var("INPUT_POLICY_FILE")
+                .await?
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| ".rigorix/policy.toml".to_string())
+        };
+
+        let fail_on_violation = if let Some(overrides) = &input.env_override {
+            overrides
+                .get("INPUT_FAIL_ON_VIOLATION")
+                .and_then(|v| v.parse::<bool>().ok())
+                .unwrap_or(false)
+        } else {
+            self.repository
+                .read_env_var("INPUT_FAIL_ON_VIOLATION")
+                .await?
+                .and_then(|v| v.parse::<bool>().ok())
+                .unwrap_or(false)
+        };
+
         // 9. Repository and author for audit trail (from GitHub CI env vars)
         let repository = if let Some(overrides) = &input.env_override {
             overrides.get("GITHUB_REPOSITORY").cloned()
@@ -435,6 +466,8 @@ impl ContextBuilder for ContextBuilderImpl {
             permission_mode,
             repository,
             author,
+            policy_file,
+            fail_on_violation,
         };
 
         Ok(BuildContextOutput {

--- a/actions/src/action_entrypoint/application/mode_resolver_impl.rs
+++ b/actions/src/action_entrypoint/application/mode_resolver_impl.rs
@@ -83,8 +83,10 @@ impl ModeResolver for ModeResolverImpl {
                 }
                 "governance" => {
                     let intent = input.input_intent.unwrap_or_default();
+                    // GAP-A-08: governance is Mode A (diff + policy evaluation),
+                    // NOT a silent alias for Validate.
                     return Ok(ResolveModeOutput {
-                        mode: ActionMode::Validate { intent },
+                        mode: ActionMode::Governance { intent },
                         source: "input".to_string(),
                         unambiguous: true,
                         warnings,
@@ -177,7 +179,10 @@ impl ModeResolver for ModeResolverImpl {
             "plan" => Some(ActionMode::Plan {
                 intent: String::new(),
             }),
-            "validate" | "governance" => Some(ActionMode::Validate {
+            "validate" => Some(ActionMode::Validate {
+                intent: String::new(),
+            }),
+            "governance" => Some(ActionMode::Governance {
                 intent: String::new(),
             }),
             "status" => Some(ActionMode::Status),
@@ -285,6 +290,17 @@ mod tests {
     async fn test_resolve_from_string_validate() {
         let mode = resolver().resolve_from_string("validate").await;
         assert!(matches!(mode, Some(ActionMode::Validate { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_from_string_governance_is_mode_a() {
+        // GAP-A-08: governance must resolve to Governance (Mode A), not a
+        // silent alias for Validate.
+        let mode = resolver().resolve_from_string("governance").await;
+        assert!(
+            matches!(mode, Some(ActionMode::Governance { .. })),
+            "governance must resolve to ActionMode::Governance, got {mode:?}"
+        );
     }
 
     #[tokio::test]

--- a/actions/src/action_entrypoint/application/router_impl.rs
+++ b/actions/src/action_entrypoint/application/router_impl.rs
@@ -192,6 +192,103 @@ impl ActionRouterImpl {
         }
     }
 
+    /// Mode A dispatch (GAP-A-08): diff analysis + policy evaluation.
+    ///
+    /// 1. Requires a `pull_request` event (base branch for the diff)
+    /// 2. Computes `git diff {base}...HEAD` in the workspace
+    /// 3. Requires the configured policy file to exist (explicit error, not
+    ///    a silent fallback)
+    /// 4. Runs DiffAnalysisPipeline -> PolicyEvaluationPipeline
+    /// 5. `fail_on_violation` gates the action exit code
+    async fn dispatch_governance(
+        &self,
+        ctx: &crate::action_entrypoint::domain::ActionContext,
+    ) -> Result<ActionOutput, ActionError> {
+        use crate::diff_analyzer::application::service::DiffAnalysisPipelineService;
+        use crate::policy_evaluator::application::service::PolicyEvaluationPipelineService;
+
+        // 1. Base branch from the PR event
+        let base_branch = match &ctx.event {
+            crate::action_entrypoint::domain::GitHubEvent::PullRequest { base_branch, .. } => {
+                base_branch.clone()
+            }
+            _ => return Err(ActionError::GovernanceError {
+                detail:
+                    "governance mode requires a pull_request event (base branch to diff against)"
+                        .to_string(),
+            }),
+        };
+
+        // 2. Raw diff: git diff {base}...HEAD
+        let diff_output = tokio::process::Command::new("git")
+            .args(["diff", &format!("{base_branch}...HEAD")])
+            .current_dir(&ctx.workspace_root)
+            .output()
+            .await
+            .map_err(|e| ActionError::GovernanceError {
+                detail: format!("failed to run git diff: {e}"),
+            })?;
+        let raw_diff = String::from_utf8_lossy(&diff_output.stdout).to_string();
+
+        // 3. Policy file must exist (AC: explicit error, not silent Validate)
+        let policy_path = std::path::Path::new(&ctx.workspace_root).join(&ctx.policy_file);
+        if !policy_path.exists() {
+            return Err(ActionError::GovernanceError {
+                detail: format!(
+                    "policy file '{}' not found in workspace (governance mode requires an existing policy file)",
+                    ctx.policy_file
+                ),
+            });
+        }
+
+        // 4. Diff analysis -> policy evaluation
+        let analyzer = crate::diff_analyzer::application::diff_analysis_pipeline_impl::DiffAnalysisPipelineImpl::default();
+        let analyzed =
+            analyzer
+                .analyze_default(raw_diff)
+                .await
+                .map_err(|e| ActionError::GovernanceError {
+                    detail: format!("diff analysis failed: {e}"),
+                })?;
+
+        let evaluator = crate::policy_evaluator::application::policy_evaluation_pipeline_impl::PolicyEvaluationPipelineServiceImpl;
+        let (eval_output, report) = evaluator
+            .run_with_report(
+                crate::policy_evaluator::application::dto::RunPolicyEvaluationInput {
+                    diff: analyzed.diff,
+                    policy_path: policy_path.to_string_lossy().to_string(),
+                    base_ref: base_branch,
+                    repo: ctx.repository.clone(),
+                    org_policy_config: None,
+                    fail_on_violation: ctx.fail_on_violation,
+                    include_details: Some(true),
+                },
+            )
+            .await
+            .map_err(|e| ActionError::GovernanceError {
+                detail: format!("policy evaluation failed: {e}"),
+            })?;
+
+        let violations = eval_output.result.violations.len();
+        let blocking = eval_output.result.has_blocking_violations;
+
+        // 5. Gate exit code on fail_on_violation
+        if ctx.fail_on_violation && blocking {
+            return Ok(ActionOutput::failure(format!(
+                "Governance: {} blocking policy violations found.\n{}",
+                violations, report.markdown_summary
+            )));
+        }
+
+        Ok(ActionOutput::success(
+            format!(
+                "Governance: {} violations ({} blocking) — {}",
+                violations, blocking, report.markdown_summary
+            ),
+            None,
+        ))
+    }
+
     /// Dispatch to the engine's status mode.
     async fn dispatch_status(
         &self,
@@ -242,6 +339,7 @@ impl ActionRouter for ActionRouterImpl {
             ActionMode::Run { .. } => self.dispatch_run(ctx).await,
             ActionMode::Plan { .. } => self.dispatch_plan(ctx).await,
             ActionMode::Validate { .. } => self.dispatch_validate(ctx).await,
+            ActionMode::Governance { .. } => self.dispatch_governance(ctx).await,
             ActionMode::Status => self.dispatch_status(ctx).await,
         };
 
@@ -304,6 +402,7 @@ impl ActionRouter for ActionRouterImpl {
             ActionMode::Run { .. }
                 | ActionMode::Plan { .. }
                 | ActionMode::Validate { .. }
+                | ActionMode::Governance { .. }
                 | ActionMode::Status
         )
     }
@@ -317,6 +416,9 @@ impl ActionRouter for ActionRouterImpl {
                 intent: String::new(),
             },
             ActionMode::Validate {
+                intent: String::new(),
+            },
+            ActionMode::Governance {
                 intent: String::new(),
             },
             ActionMode::Status,
@@ -825,7 +927,210 @@ mod tests {
     async fn test_supported_modes_returns_all() {
         let router = create_router();
         let modes = router.supported_modes().await;
-        assert_eq!(modes.len(), 4);
+        assert_eq!(modes.len(), 5);
+        assert!(modes.contains(&ActionMode::Governance {
+            intent: String::new()
+        }));
+    }
+
+    // ── Mode A governance tests (GAP-A-08) ──
+
+    /// Init a throwaway git repo with an optional policy file.
+    /// Returns (TempDir, workspace_root) with the base commit on `main`.
+    async fn setup_git_workspace(policy_toml: Option<&str>) -> (tempfile::TempDir, String) {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path().to_path_buf();
+        let git = |args: Vec<&'static str>| {
+            let root = root.clone();
+            async move {
+                let out = tokio::process::Command::new("git")
+                    .args(&args)
+                    .current_dir(&root)
+                    .output()
+                    .await
+                    .expect("git must run");
+                String::from_utf8_lossy(if out.status.success() {
+                    &out.stdout
+                } else {
+                    &out.stderr
+                })
+                .to_string()
+            }
+        };
+        git(vec!["init", "-q"]).await;
+        git(vec!["checkout", "-q", "-b", "main"]).await;
+        git(vec!["config", "user.email", "test@example.com"]).await;
+        git(vec!["config", "user.name", "Test"]).await;
+        if let Some(policy) = policy_toml {
+            std::fs::create_dir_all(root.join(".rigorix")).unwrap();
+            std::fs::write(root.join(".rigorix/policy.toml"), policy).unwrap();
+        }
+        std::fs::write(root.join("README.md"), "base").unwrap();
+        git(vec!["add", "-A"]).await;
+        git(vec!["commit", "-qm", "base"]).await;
+        (dir, root.to_string_lossy().to_string())
+    }
+
+    fn governance_context(
+        workspace: &str,
+        event: GitHubEvent,
+        fail_on_violation: bool,
+    ) -> ActionContext {
+        let mut ctx = ActionContext::new(
+            workspace.to_string(),
+            event,
+            ActionMode::Governance {
+                intent: String::new(),
+            },
+            Some("gh_token_123".to_string()),
+        );
+        ctx.policy_file = ".rigorix/policy.toml".to_string();
+        ctx.fail_on_violation = fail_on_violation;
+        ctx
+    }
+
+    fn pr_event() -> GitHubEvent {
+        GitHubEvent::PullRequest {
+            pr_number: 42,
+            action: "opened".to_string(),
+            title: "test".to_string(),
+            base_branch: "main".to_string(),
+            head_branch: "feature".to_string(),
+            head_sha: "abc123".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_governance_with_policy_runs_mode_a() {
+        let (_dir, workspace) = setup_git_workspace(Some(
+            "version = \"1.0.0\"\n\n[[rules.flag]]\nname = \"markdown\"\ndescription = \"md files\"\npattern = \"*.md\"\n",
+        ))
+        .await;
+        let router = create_router();
+        let ctx = governance_context(&workspace, pr_event(), false);
+
+        let result = router
+            .dispatch(DispatchInput {
+                context: ctx,
+                timeout_secs: Some(60),
+                force: false,
+            })
+            .await
+            .unwrap();
+
+        // Mode A ran (not Validate): output names governance, status success.
+        assert!(result.success, "Mode A dispatch must succeed");
+        assert!(
+            result.output.summary.contains("Governance"),
+            "expected Mode A output, got: {}",
+            result.output.summary
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_governance_missing_policy_is_explicit_error() {
+        let (_dir, workspace) = setup_git_workspace(None).await;
+        let router = create_router();
+        let ctx = governance_context(&workspace, pr_event(), false);
+
+        let result = router
+            .dispatch(DispatchInput {
+                context: ctx,
+                timeout_secs: Some(60),
+                force: false,
+            })
+            .await
+            .unwrap();
+
+        // dispatch() converts governance errors into a failed output
+        // (never a silent Validate fallback).
+        assert!(!result.success, "missing policy file must fail the action");
+        assert_eq!(result.output.status, DispatchStatus::Failure);
+        assert!(
+            result.output.summary.contains("policy file"),
+            "expected explicit policy-file error, got: {}",
+            result.output.summary
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_governance_requires_pr_event() {
+        let (_dir, workspace) = setup_git_workspace(Some("version = \"1.0.0\"\n")).await;
+        let router = create_router();
+        let ctx = governance_context(
+            &workspace,
+            GitHubEvent::WorkflowDispatch {
+                ref_name: "main".to_string(),
+            },
+            false,
+        );
+
+        let result = router
+            .dispatch(DispatchInput {
+                context: ctx,
+                timeout_secs: Some(60),
+                force: false,
+            })
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert_eq!(result.output.status, DispatchStatus::Failure);
+        assert!(
+            result.output.summary.contains("pull_request"),
+            "expected pull_request requirement, got: {}",
+            result.output.summary
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_governance_fail_on_violation_gates_exit_code() {
+        let (_dir, workspace) = setup_git_workspace(Some(
+            "version = \"1.0.0\"\n\n[[rules.deny]]\nname = \"no-sql\"\ndescription = \"No raw SQL\"\npattern = \"*.sql\"\nseverity = \"critical\"\n",
+        ))
+        .await;
+        // Add a violating file on a HEAD branch so `git diff main...HEAD`
+        // sees it (the policy file itself stays unchanged from base).
+        let root = std::path::PathBuf::from(&workspace);
+        let out = tokio::process::Command::new("git")
+            .args(["checkout", "-q", "-b", "feature"])
+            .current_dir(&root)
+            .output()
+            .await
+            .unwrap();
+        assert!(out.status.success());
+        std::fs::write(root.join("secret.sql"), "SELECT * FROM users;").unwrap();
+        let out = tokio::process::Command::new("git")
+            .args(["add", "secret.sql"])
+            .current_dir(&root)
+            .output()
+            .await
+            .unwrap();
+        assert!(out.status.success());
+        let out = tokio::process::Command::new("git")
+            .args(["commit", "-qm", "add sql"])
+            .current_dir(&root)
+            .output()
+            .await
+            .unwrap();
+        assert!(out.status.success());
+
+        let router = create_router();
+        let ctx = governance_context(&workspace, pr_event(), true);
+
+        let result = router
+            .dispatch(DispatchInput {
+                context: ctx,
+                timeout_secs: Some(60),
+                force: false,
+            })
+            .await
+            .unwrap();
+
+        // fail_on_violation + blocking violation -> Failure status (exit code
+        // gated by main.rs on DispatchStatus::Failure).
+        assert_eq!(result.output.status, DispatchStatus::Failure);
+        assert!(result.output.summary.contains("Governance"));
     }
 
     #[tokio::test]

--- a/actions/src/action_entrypoint/domain/error.rs
+++ b/actions/src/action_entrypoint/domain/error.rs
@@ -70,6 +70,13 @@ pub enum ActionError {
         iterations_completed: Option<u32>,
     },
 
+    /// Mode A governance dispatch failed (GAP-A-08).
+    #[error("Governance error: {detail}")]
+    GovernanceError {
+        /// Description of the governance error.
+        detail: String,
+    },
+
     /// The workspace root path is invalid or inaccessible.
     #[error("Invalid workspace root '{path}': {detail}")]
     InvalidWorkspaceRoot {
@@ -122,6 +129,7 @@ impl ActionError {
                 | ActionError::GitHubApi(_)
                 | ActionError::EngineError { .. }
                 | ActionError::ValidationLoopError { .. }
+                | ActionError::GovernanceError { .. }
         )
     }
 
@@ -138,6 +146,7 @@ impl ActionError {
             ActionError::UnsupportedEvent { .. } | ActionError::OutputError { .. } => "warning",
             ActionError::EngineError { .. }
             | ActionError::ValidationLoopError { .. }
+            | ActionError::GovernanceError { .. }
             | ActionError::ContextRepositoryError { .. }
             | ActionError::GitHubApi(_)
             | ActionError::Io(_)

--- a/actions/src/action_entrypoint/domain/types.rs
+++ b/actions/src/action_entrypoint/domain/types.rs
@@ -45,6 +45,16 @@ pub enum ActionMode {
         intent: String,
     },
 
+    /// Mode A — governance: diff analysis + policy evaluation (GAP-A-08).
+    ///
+    /// Routes through the diff_analyzer and policy_evaluator pipelines.
+    /// Requires a PR event, a base branch, and an existing policy file;
+    /// `fail-on-violation` gates the action exit code.
+    Governance {
+        /// Natural-language intent (informational for Mode A).
+        intent: String,
+    },
+
     /// Show current execution status.
     Status,
 }
@@ -54,7 +64,10 @@ impl ActionMode {
     pub fn requires_intent(&self) -> bool {
         matches!(
             self,
-            ActionMode::Run { .. } | ActionMode::Plan { .. } | ActionMode::Validate { .. }
+            ActionMode::Run { .. }
+                | ActionMode::Plan { .. }
+                | ActionMode::Validate { .. }
+                | ActionMode::Governance { .. }
         )
     }
 
@@ -63,7 +76,8 @@ impl ActionMode {
         match self {
             ActionMode::Run { intent }
             | ActionMode::Plan { intent }
-            | ActionMode::Validate { intent } => Some(intent.as_str()),
+            | ActionMode::Validate { intent }
+            | ActionMode::Governance { intent } => Some(intent.as_str()),
             ActionMode::Status => None,
         }
     }
@@ -74,6 +88,7 @@ impl ActionMode {
             ActionMode::Run { .. } => "run",
             ActionMode::Plan { .. } => "plan",
             ActionMode::Validate { .. } => "validate",
+            ActionMode::Governance { .. } => "governance",
             ActionMode::Status => "status",
         }
     }
@@ -210,6 +225,12 @@ pub struct ActionContext {
 
     /// Actor that triggered the workflow (from GITHUB_ACTOR).
     pub author: Option<String>,
+
+    /// Mode A governance: path to the policy file (GAP-A-08).
+    pub policy_file: String,
+
+    /// Mode A governance: fail the action when policy violations exist.
+    pub fail_on_violation: bool,
 }
 
 impl ActionContext {
@@ -232,6 +253,8 @@ impl ActionContext {
             permission_mode: None,
             repository: None,
             author: None,
+            policy_file: ".rigorix/policy.toml".to_string(),
+            fail_on_violation: false,
         }
     }
 
@@ -263,6 +286,8 @@ impl ActionContext {
             permission_mode: self.permission_mode.clone(),
             repository: self.repository.clone(),
             author: self.author.clone(),
+            policy_file: self.policy_file.clone(),
+            fail_on_violation: self.fail_on_violation,
         }
     }
 }

--- a/actions/src/action_input/application/config_loader_impl.rs
+++ b/actions/src/action_input/application/config_loader_impl.rs
@@ -608,8 +608,8 @@ inputs:
         assert_eq!(config.max_retries, 3);
         assert_eq!(config.retry_delay_ms, 1000);
         assert!(config.post_pr_comment);
-        assert_eq!(config.fail_on_violation, false);
-        assert_eq!(config.fail_on_action_error, false);
+        assert!(!config.fail_on_violation);
+        assert!(!config.fail_on_action_error);
         assert_eq!(config.intent, None);
         assert_eq!(config.profile, None);
     }

--- a/actions/src/action_output/infrastructure/repository/env_repository_impl.rs
+++ b/actions/src/action_output/infrastructure/repository/env_repository_impl.rs
@@ -89,13 +89,13 @@ impl crate::action_output::infrastructure::repository::EnvRepository for EnvRepo
 mod tests {
     use super::*;
     use crate::action_output::infrastructure::repository::EnvRepository;
-    use std::sync::Mutex;
+    use tokio::sync::Mutex;
 
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    static ENV_LOCK: Mutex<()> = Mutex::const_new(());
 
     #[tokio::test]
     async fn test_read_env_var_present() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK.lock().await;
         // SAFETY: test-only env manipulation
         unsafe { std::env::set_var("RIGORIX_TEST_VAR", "test-value") };
         let repo = EnvRepositoryImpl::new();
@@ -115,7 +115,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_read_step_summary_path() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK.lock().await;
         unsafe { std::env::set_var("GITHUB_STEP_SUMMARY", "/tmp/summary.md") };
         let repo = EnvRepositoryImpl::new();
         let result = repo.read_step_summary_path().await.unwrap();
@@ -125,7 +125,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_read_github_token_prefers_input() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK.lock().await;
         unsafe {
             std::env::set_var("INPUT_GITHUB_TOKEN", "input-token");
             std::env::set_var("GITHUB_TOKEN", "env-token");
@@ -141,7 +141,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_read_ci_context() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK.lock().await;
         unsafe { std::env::set_var("GITHUB_ACTIONS", "true") };
         let repo = EnvRepositoryImpl::new();
         let ctx = repo.read_ci_context().await.unwrap();

--- a/actions/src/action_output/infrastructure/repository/output_repository_impl.rs
+++ b/actions/src/action_output/infrastructure/repository/output_repository_impl.rs
@@ -174,10 +174,10 @@ impl OutputRepository for OutputRepositoryImpl {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
+    use tokio::sync::Mutex;
 
     /// Ensure tests don't run in parallel when modifying env vars
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    static ENV_LOCK: Mutex<()> = Mutex::const_new(());
 
     #[tokio::test]
     async fn test_resolve_path_rejects_traversal() {
@@ -193,7 +193,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_is_github_actions_false_locally() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK.lock().await;
         // SAFETY: test-only env manipulation
         unsafe { std::env::remove_var("GITHUB_ACTIONS") };
         let repo = OutputRepositoryImpl::new();
@@ -202,7 +202,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_write_output_variable_to_tempfile() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK.lock().await;
         let dir = tempfile::tempdir().unwrap();
         let output_path = dir.path().join("GITHUB_OUTPUT");
         // SAFETY: test-only env manipulation
@@ -220,7 +220,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_append_summary_to_tempfile() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK.lock().await;
         let dir = tempfile::tempdir().unwrap();
         let summary_path = dir.path().join("GITHUB_STEP_SUMMARY");
         // SAFETY: test-only env manipulation
@@ -238,7 +238,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_overwrite_summary() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK.lock().await;
         let dir = tempfile::tempdir().unwrap();
         let summary_path = dir.path().join("GITHUB_STEP_SUMMARY");
         // SAFETY: test-only env manipulation
@@ -258,7 +258,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_output_path() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK.lock().await;
         unsafe { std::env::remove_var("GITHUB_OUTPUT") };
         let repo = OutputRepositoryImpl::new();
         assert!(repo.get_output_path().await.unwrap().is_none());

--- a/actions/src/diff_analyzer/application/ai_signal_detector_impl.rs
+++ b/actions/src/diff_analyzer/application/ai_signal_detector_impl.rs
@@ -235,10 +235,10 @@ mod tests {
         let diff_lines: Vec<DiffLine> = lines
             .iter()
             .map(|&l| {
-                let (line_type, content) = if l.starts_with('+') {
-                    (DiffLineType::Added, l[1..].to_string())
-                } else if l.starts_with('-') {
-                    (DiffLineType::Deleted, l[1..].to_string())
+                let (line_type, content) = if let Some(rest) = l.strip_prefix('+') {
+                    (DiffLineType::Added, rest.to_string())
+                } else if let Some(rest) = l.strip_prefix('-') {
+                    (DiffLineType::Deleted, rest.to_string())
                 } else {
                     (DiffLineType::Context, l.to_string())
                 };

--- a/actions/src/diff_analyzer/application/limit_enforcer_impl.rs
+++ b/actions/src/diff_analyzer/application/limit_enforcer_impl.rs
@@ -265,7 +265,7 @@ mod tests {
         assert!(result.any_exceeded);
         assert!(result.degraded);
         // Small file should be kept, large should be excluded
-        assert!(result.diff.files.len() > 0 || result.diff.excluded_files.len() > 0);
+        assert!(!result.diff.files.is_empty() || !result.diff.excluded_files.is_empty());
     }
 
     #[tokio::test]

--- a/actions/src/policy_evaluator/application/policy_loader_impl.rs
+++ b/actions/src/policy_evaluator/application/policy_loader_impl.rs
@@ -85,15 +85,21 @@ impl PolicyLoadingService for PolicyLoadingServiceImpl {
 
     async fn read_policy_content(
         &self,
-        _policy_path: &str,
-        _base_ref: &str,
+        policy_path: &str,
+        base_ref: &str,
         _repo: Option<&str>,
     ) -> Result<String, PolicyError> {
-        // In production, this would use the GitHub API to fetch from base branch.
-        // For now, return an error — concrete implementations will override this.
+        // GAP-A-08: the action runs inside a checked-out workspace, so the
+        // policy file is available at `policy_path` (absolute, or relative to
+        // the workspace). Reading it locally is the Mode A runtime path.
+        // Fetching from the GitHub API by base ref remains future work for
+        // remote-only evaluation.
+        if let Ok(content) = tokio::fs::read_to_string(policy_path).await {
+            return Ok(content);
+        }
         Err(PolicyError::FileNotFound {
-            path: _policy_path.to_string(),
-            reference: _base_ref.to_string(),
+            path: policy_path.to_string(),
+            reference: base_ref.to_string(),
         })
     }
 }

--- a/actions/src/security_config/infrastructure/env_fork_repository_impl.rs
+++ b/actions/src/security_config/infrastructure/env_fork_repository_impl.rs
@@ -73,13 +73,11 @@ impl ForkRepository for EnvForkRepository {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{LazyLock, Mutex};
-
     /// Global lock for env var tests — prevents races between parallel test threads.
-    static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+    static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
-    fn lock_env() -> std::sync::MutexGuard<'static, ()> {
-        ENV_LOCK.lock().unwrap()
+    async fn lock_env() -> tokio::sync::MutexGuard<'static, ()> {
+        ENV_LOCK.lock().await
     }
 
     unsafe fn set_env(key: &str, value: &str) {
@@ -96,7 +94,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_base_repo() {
-        let _guard = lock_env();
+        let _guard = lock_env().await;
         unsafe {
             set_env("GITHUB_REPOSITORY", "org/test-repo");
         }
@@ -110,7 +108,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_base_repo_missing() {
-        let _guard = lock_env();
+        let _guard = lock_env().await;
         unsafe {
             remove_env("GITHUB_REPOSITORY");
         }
@@ -120,7 +118,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_head_repo_present() {
-        let _guard = lock_env();
+        let _guard = lock_env().await;
         unsafe {
             set_env(
                 "GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME",
@@ -137,7 +135,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_head_repo_absent() {
-        let _guard = lock_env();
+        let _guard = lock_env().await;
         unsafe {
             remove_env("GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME");
         }
@@ -147,7 +145,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_head_repo_owner() {
-        let _guard = lock_env();
+        let _guard = lock_env().await;
         unsafe {
             set_env("GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_OWNER", "fork-user");
         }
@@ -161,7 +159,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_event_name() {
-        let _guard = lock_env();
+        let _guard = lock_env().await;
         unsafe {
             set_env("GITHUB_EVENT_NAME", "pull_request");
         }
@@ -175,7 +173,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_pr_number() {
-        let _guard = lock_env();
+        let _guard = lock_env().await;
         unsafe {
             set_env("GITHUB_EVENT_PULL_REQUEST_NUMBER", "42");
         }
@@ -189,7 +187,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_pr_number_absent() {
-        let _guard = lock_env();
+        let _guard = lock_env().await;
         unsafe {
             remove_env("GITHUB_EVENT_PULL_REQUEST_NUMBER");
         }
@@ -199,7 +197,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_head_repo_empty() {
-        let _guard = lock_env();
+        let _guard = lock_env().await;
         unsafe {
             set_env("GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME", "");
         }


### PR DESCRIPTION
## Batch 11: feature/actions-governance (#725 GAP-A-08)

### AC1 — `governance` runs Mode A (diff + policy evaluation) when policy-file exists
`"governance"` now resolves to `ActionMode::Governance` (both resolver paths — was `Validate` in both). `dispatch_governance` runs `git diff {base}...HEAD` → `DiffAnalysisPipeline` → `PolicyEvaluationPipeline` (`run_with_report`). Verified by `test_dispatch_governance_with_policy_runs_mode_a` (real git repo fixture). ✅

### AC2 — `fail-on-violation` gates the action exit code
`fail_on_violation` + blocking violations → `DispatchStatus::Failure` (main.rs exits 1 on Failure). Verified by `test_dispatch_governance_fail_on_violation_gates_exit_code` (deny rule `*.sql` + committed violating file on a feature branch). ✅

### AC3 — Missing policy file produces an explicit error, not silent Validate
No policy file → `GovernanceError` ("policy file '...' not found...") → failure output. Non-PR event → explicit error requiring a `pull_request` event. ✅

### AC4 — CI + tests + architecture validators pass
Actions 456 tests, workspace 2761, local-ci 84/84, clippy `--all-targets -D warnings` clean.

### Also landed on this branch
- `policy_loader_impl.read_policy_content`: implemented the local-workspace read (the Mode A runtime path — was an always-`FileNotFound` stub, which would have made governance always error)
- 25 pre-existing cache-hidden clippy lints in the actions crate (bool asserts, strip_prefix, len>0, tokio Mutex for env-test locks)