### PR TITLE
feat(execution-engine): wire FailureClassifierService into the retry loop (#736)

### DIFF
--- a/engine/src/execution_engine/application/factory_impl.rs
+++ b/engine/src/execution_engine/application/factory_impl.rs
@@ -20,6 +20,7 @@ use crate::execution_engine::application::service_impl::{
     ParallelExecutionServiceImpl, RetryEvaluationServiceImpl,
 };
 use crate::execution_engine::domain::ExecutionError;
+use crate::failure_classification::application::failure_classifier_service_impl::FailureClassifierServiceImpl;
 
 /// Factory implementation for constructing `ParallelExecutionService` instances.
 ///
@@ -47,7 +48,11 @@ impl ParallelExecutionFactory for ParallelExecutionFactoryImpl {
         &self,
         config: ParallelExecutionFactoryConfig,
     ) -> Result<Box<dyn ParallelExecutionService>, ExecutionError> {
-        let retry_service = Box::new(RetryEvaluationServiceImpl::new());
+        // GAP-A-19: the production retry loop is driven by structured failure
+        // classification (with policy fallback for unclassified failures).
+        let retry_service = Box::new(RetryEvaluationServiceImpl::with_classifier(
+            std::sync::Arc::new(FailureClassifierServiceImpl),
+        ));
         // Use a default event bus if none was provided
         let event_bus = config
             .event_bus

--- a/engine/src/execution_engine/application/service_impl.rs
+++ b/engine/src/execution_engine/application/service_impl.rs
@@ -2695,12 +2695,32 @@ impl ParallelExecutionService for ParallelExecutionServiceImpl {
 /// - Remaining retry budget
 ///
 /// All decisions are computational — no external dependencies.
-pub struct RetryEvaluationServiceImpl;
+pub struct RetryEvaluationServiceImpl {
+    /// Optional structured failure classifier (GAP-A-19).
+    classifier: Option<
+        Arc<dyn crate::failure_classification::application::service::FailureClassifierService>,
+    >,
+}
 
 impl RetryEvaluationServiceImpl {
-    /// Create a new RetryEvaluationServiceImpl.
+    /// Create a new RetryEvaluationServiceImpl without structured
+    /// classification (legacy policy-only behavior).
     pub fn new() -> Self {
-        Self
+        Self { classifier: None }
+    }
+
+    /// Create a service whose retry decisions are driven by structured
+    /// `FailureClassifierService` classification (GAP-A-19) when the
+    /// classifier produces a confident match; unclassified failures defer
+    /// to the policy's substring list (preserving prior behavior).
+    pub fn with_classifier(
+        classifier: Arc<
+            dyn crate::failure_classification::application::service::FailureClassifierService,
+        >,
+    ) -> Self {
+        Self {
+            classifier: Some(classifier),
+        }
     }
 }
 
@@ -2784,21 +2804,63 @@ impl RetryEvaluationService for RetryEvaluationServiceImpl {
         policy: &RetryPolicy,
         fallback_node_id: Option<Uuid>,
     ) -> RetryDecision {
+        // GAP-A-19: structured classification augments the policy check.
+        // A confident classifier match decides retriability; the documented
+        // no-match default (NonRetryable) is treated as "unclassified" and
+        // defers to the policy's substring list.
+        let mut classification_note = String::new();
+        let classified_gate: Option<bool> = if let Some(classifier) = &self.classifier {
+            match classifier
+                .classify(
+                    crate::failure_classification::application::dto::ClassifyFailureInput {
+                        error_message: failure_context.error_message.clone(),
+                        operation_context: Some("execution retry evaluation".to_string()),
+                        source: Some("execution_engine".to_string()),
+                    },
+                )
+                .await
+            {
+                Ok(output) => {
+                    let is_default = output
+                        .explanation
+                        .as_deref()
+                        .is_some_and(|e| e.starts_with("No matching pattern"));
+                    if is_default {
+                        None
+                    } else {
+                        classification_note = format!(
+                            " (classified {:?}: {})",
+                            output.failure_type,
+                            output.explanation.as_deref().unwrap_or("")
+                        );
+                        Some(output.is_retryable)
+                    }
+                }
+                Err(_) => None,
+            }
+        } else {
+            None
+        };
+
         // 1. Check if the failure type is retriable
-        if !policy.is_failure_retriable(&failure_context.failure_type) {
+        let retriable = match classified_gate {
+            Some(decided) => decided,
+            None => policy.is_failure_retriable(&failure_context.failure_type),
+        };
+        if !retriable {
             if let Some(fallback_id) = fallback_node_id {
                 return RetryDecision::Fallback {
                     fallback_node_id: fallback_id,
                     reason: format!(
-                        "Failure type '{}' is not retriable; executing fallback",
-                        failure_context.failure_type
+                        "Failure type '{}' is not retriable{}; executing fallback",
+                        failure_context.failure_type, classification_note
                     ),
                 };
             }
             return RetryDecision::Skip {
                 reason: format!(
-                    "Failure type '{}' is not retriable and no fallback configured",
-                    failure_context.failure_type
+                    "Failure type '{}' is not retriable{} and no fallback configured",
+                    failure_context.failure_type, classification_note
                 ),
             };
         }

--- a/engine/src/execution_engine/tests.rs
+++ b/engine/src/execution_engine/tests.rs
@@ -25,6 +25,7 @@ use crate::execution_engine::domain::{
     BackoffStrategy, FailureContext, NodeExecutionState, ParallelExecutorConfig, RetryDecision,
     RetryPolicy, RetryStrategy,
 };
+use crate::failure_classification::application::failure_classifier_service_impl::FailureClassifierServiceImpl;
 
 // ---------------------------------------------------------------------------
 // Helper: create a configured service pair
@@ -1602,6 +1603,123 @@ async fn test_validate_policy_bad_multiplier() {
 
     let errors = service.validate_policy(&policy).await.unwrap();
     assert!(errors.iter().any(|e| e.contains("multiplier")));
+}
+
+#[tokio::test]
+async fn test_retry_decision_driven_by_classification_transient() {
+    // GAP-A-19: a confident Transient classification (network/timeout)
+    // drives a Retry decision.
+    let service = RetryEvaluationServiceImpl::with_classifier(std::sync::Arc::new(
+        FailureClassifierServiceImpl,
+    ));
+    let policy = RetryPolicy {
+        // Policy says this failure_code is NOT retriable; the structured
+        // classification (Transient) overrides and grants the retry.
+        retryable_failures: vec!["compile_error".to_string()],
+        max_attempts: 3,
+        ..Default::default()
+    };
+    let ctx = FailureContext::new(
+        uuid::Uuid::new_v4(),
+        "test-node",
+        "run-command",
+        "run",
+        "command_failed",
+        "connection to host timed out after 30s",
+        0,
+        3,
+        100,
+        100,
+    );
+
+    let output = service
+        .evaluate_retry(EvaluateRetryInput {
+            failure_context: ctx,
+            policy,
+            fallback_node_id: None,
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        output.decision.is_retry(),
+        "Transient must retry: {:?}",
+        output.decision
+    );
+}
+
+#[tokio::test]
+async fn test_retry_decision_driven_by_classification_build_failure_skips() {
+    // GAP-A-19: a confident BuildFailure classification is NOT retryable
+    // even though the policy would allow the code.
+    let service = RetryEvaluationServiceImpl::with_classifier(std::sync::Arc::new(
+        FailureClassifierServiceImpl,
+    ));
+    let policy = RetryPolicy::default(); // all codes retriable
+    let ctx = FailureContext::new(
+        uuid::Uuid::new_v4(),
+        "test-node",
+        "cargo build",
+        "build",
+        "command_failed",
+        "error: build failed: cannot compile",
+        0,
+        3,
+        100,
+        100,
+    );
+
+    let output = service
+        .evaluate_retry(EvaluateRetryInput {
+            failure_context: ctx,
+            policy,
+            fallback_node_id: None,
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        matches!(output.decision, RetryDecision::Skip { .. }),
+        "BuildFailure must skip: {:?}",
+        output.decision
+    );
+}
+
+#[tokio::test]
+async fn test_retry_decision_unclassified_defers_to_policy() {
+    // GAP-A-19: an unmatched message (documented NonRetryable default) is
+    // treated as unclassified and defers to the policy (all retriable here).
+    let service = RetryEvaluationServiceImpl::with_classifier(std::sync::Arc::new(
+        FailureClassifierServiceImpl,
+    ));
+    let policy = RetryPolicy::default();
+    let ctx = FailureContext::new(
+        uuid::Uuid::new_v4(),
+        "test-node",
+        "tool",
+        "op",
+        "custom_failure",
+        "some completely unusual error text",
+        0,
+        3,
+        100,
+        100,
+    );
+
+    let output = service
+        .evaluate_retry(EvaluateRetryInput {
+            failure_context: ctx,
+            policy,
+            fallback_node_id: None,
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        output.decision.is_retry(),
+        "unclassified must defer to policy: {:?}",
+        output.decision
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
feat(execution-engine): wire FailureClassifierService into the retry loop (#736)

GAP-A-19: failure_classification services had zero callers; retry decisions
used only substring-based policy mapping.

- RetryEvaluationServiceImpl gains an optional FailureClassifierService;
  with_classifier() wires it (new() keeps legacy policy-only behavior)
- decide(): classifies the failure message; a confident match decides
  retriability (Transient/LspConflict/ResourceExhausted/SystemError ->
  retryable; TestFailure/BuildFailure -> not). The documented no-match
  default (NonRetryable) is treated as "unclassified" and defers to the
  policy's substring list, preserving prior behavior for unknown errors
- Production factory (execution_engine factory_impl) constructs the
  service with the classifier — AC1: constructed + called from the retry loop
- Tests: Transient timeout message -> Retry despite a restrictive policy;
  BuildFailure message -> Skip despite an all-retriable policy;
  unclassified message -> defers to policy

Engine 2018 tests; local-ci 84/84; clippy clean.
