### PR TITLE
ci: make proofing gate + reconcile stale claims (#744)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,12 +74,12 @@ jobs:
       - run: cargo fmt --check -p rigorix-${{ matrix.crate }}
       - run: cargo clippy -p rigorix-${{ matrix.crate }} -- -D warnings
       - name: Per-crate scripts (all conventions)
-        continue-on-error: true
+        # GAP-A-27: proofing gates the stage — failures fail the job.
         run: |
           for script in .pi/scripts/ci/check_*.sh .pi/scripts/ci/run_*.sh \
                        .pi/scripts/ci/stage_*.sh .pi/scripts/ci/validate_*.sh \
                        .pi/scripts/validate-*.sh; do
-            [ -f "$script" ] && [[ "$script" != *_coverage.sh ]] && echo "--- $script ---" && bash "$script" || true
+            [ -f "$script" ] && [[ "$script" != *_coverage.sh ]] && echo "--- $script ---" && bash "$script"
           done
         working-directory: ${{ matrix.crate }}
 
@@ -100,12 +100,12 @@ jobs:
           cache-key: build-${{ matrix.crate }}
       - run: cargo check -p rigorix-${{ matrix.crate }}
       - name: Per-crate scripts (all conventions)
-        continue-on-error: true
+        # GAP-A-27: proofing gates the stage — failures fail the job.
         run: |
           for script in .pi/scripts/ci/check_*.sh .pi/scripts/ci/run_*.sh \
                        .pi/scripts/ci/stage_*.sh .pi/scripts/ci/validate_*.sh \
                        .pi/scripts/validate-*.sh; do
-            [ -f "$script" ] && [[ "$script" != *_coverage.sh ]] && echo "--- $script ---" && bash "$script" || true
+            [ -f "$script" ] && [[ "$script" != *_coverage.sh ]] && echo "--- $script ---" && bash "$script"
           done
         working-directory: ${{ matrix.crate }}
 
@@ -126,12 +126,12 @@ jobs:
           cache-key: test-${{ matrix.crate }}
       - run: cargo test -p rigorix-${{ matrix.crate }} --lib
       - name: Per-crate scripts (all conventions)
-        continue-on-error: true
+        # GAP-A-27: proofing gates the stage — failures fail the job.
         run: |
           for script in .pi/scripts/ci/check_*.sh .pi/scripts/ci/run_*.sh \
                        .pi/scripts/ci/stage_*.sh .pi/scripts/ci/validate_*.sh \
                        .pi/scripts/validate-*.sh; do
-            [ -f "$script" ] && [[ "$script" != *_coverage.sh ]] && echo "--- $script ---" && bash "$script" || true
+            [ -f "$script" ] && [[ "$script" != *_coverage.sh ]] && echo "--- $script ---" && bash "$script"
           done
         working-directory: ${{ matrix.crate }}
 
@@ -171,11 +171,11 @@ jobs:
     name: 📝 Documentation
     needs: [build]
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
       - name: Root + per-crate scripts (all conventions)
-        continue-on-error: true
+        # GAP-A-27: proofing gates the stage — failures fail the job.
         shell: bash
         run: |
           for script in .pi/scripts/ci/check_*.sh .pi/scripts/ci/run_*.sh \
@@ -184,7 +184,7 @@ jobs:
                        */.pi/scripts/ci/check_*.sh */.pi/scripts/ci/run_*.sh \
                        */.pi/scripts/ci/stage_*.sh */.pi/scripts/ci/validate_*.sh \
                        */.pi/scripts/validate-*.sh; do
-            [ -f "$script" ] && [[ "$script" != *_coverage.sh ]] && echo "--- $script ---" && bash "$script" || true
+            [ -f "$script" ] && [[ "$script" != *_coverage.sh ]] && echo "--- $script ---" && bash "$script"
           done
 
   # ── Stage 6: Integration ──────────────────────────────────────
@@ -198,7 +198,7 @@ jobs:
       - uses: ./.github/actions/setup
       - run: cargo test --workspace
       - name: Root + per-crate scripts (all conventions)
-        continue-on-error: true
+        # GAP-A-27: proofing gates the stage — failures fail the job.
         shell: bash
         run: |
           for script in .pi/scripts/ci/check_*.sh .pi/scripts/ci/run_*.sh \
@@ -207,7 +207,7 @@ jobs:
                        */.pi/scripts/ci/check_*.sh */.pi/scripts/ci/run_*.sh \
                        */.pi/scripts/ci/stage_*.sh */.pi/scripts/ci/validate_*.sh \
                        */.pi/scripts/validate-*.sh; do
-            [ -f "$script" ] && [[ "$script" != *_coverage.sh ]] && echo "--- $script ---" && bash "$script" || true
+            [ -f "$script" ] && [[ "$script" != *_coverage.sh ]] && echo "--- $script ---" && bash "$script"
           done
 
   # ── Stage 7: Final Gate ───────────────────────────────────────

--- a/.pi/.guardian-pipeline-state.json
+++ b/.pi/.guardian-pipeline-state.json
@@ -39,12 +39,44 @@
       }
     }
   ],
-  "currentItemIndex": 0,
+  "currentItemIndex": 1,
   "currentStepIndex": 0,
   "status": "running",
   "retryCount": 0,
-  "results": [],
+  "results": [
+    {
+      "item": "feature/docs-truth",
+      "status": "done",
+      "stepResults": [
+        {
+          "step": "Impact Analysis",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "Implementation",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "Validate",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "PR",
+          "status": "passed",
+          "reason": ""
+        },
+        {
+          "step": "Merge",
+          "status": "passed",
+          "reason": ""
+        }
+      ]
+    }
+  ],
   "mergeOnValid": false,
   "createdAt": "2026-09-01T16:51:56.575Z",
-  "updatedAt": "2026-09-01T16:51:56.575Z"
+  "updatedAt": "2026-09-01T17:25:33.135Z"
 }

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ When a user runs `rigorix plan "Extract docs from src/api.ts"`, Rigorix classifi
 
 When no existing template matches the intent — or confidence is low — Rigorix prompts the LLM to generate a new template dynamically. Generated templates can be cached and reused, reducing the need to regenerate common workflows.
 
-Rigorix currently supports Rust, TypeScript, Python, and Go as target codebases. TypeScript is the most mature integration today; the others are functional but earlier-stage.
+Rigorix currently supports Rust, TypeScript, and Python as target codebases. TypeScript is the most mature integration today; the others are functional but earlier-stage.
 
 ---
 
@@ -290,7 +290,7 @@ rigorix-oss/
 Rigorix treats CI as continuous verification rather than compilation and testing. Beyond formatting, linting, unit tests, and security scanning, every architectural capability is validated through proofing scripts that verify contracts, architecture readiness, documentation consistency, policy enforcement, and execution guarantees.
 
 ```
-📦 86 automated verification steps
+📦 84 automated verification steps
 
   Lint (12)     — formatting, clippy, CI validation × 3 crates
   Build (9)     — release build, static analysis, package × 3 crates
@@ -301,7 +301,7 @@ Rigorix treats CI as continuous verification rather than compilation and testing
 ```
 
 ```bash
-# Run the full CI suite (86 steps, ~2 min)
+# Run the full CI suite (84 steps, ~6 min)
 bash .pi/scripts/local-ci.sh
 
 # Run a specific stage

--- a/mcp/.pi/architecture/modules/mcp-server.md
+++ b/mcp/.pi/architecture/modules/mcp-server.md
@@ -10,7 +10,9 @@
 
 Core protocol implementation: transport management, session lifecycle, tool registration, request routing, resource exposure, prompt templates. This is the **entry point** for all MCP client connections — every tool call, resource read, and prompt request arrives here first.
 
-**Auth integration (ADR-008):** the SSE transport gains an optional gate — when `mcp.sse.bind_address` is non-localhost AND `mcp.sse.auth` is set (`"idp" | "api_key"`), the transport requires a valid bearer token before routing any tool call. Default remains localhost-only with no auth (ADR-005). Stdio remains trusted-parent (no auth).
+> **GAP-A-10:** the SSE transport was **removed** — the server is stdio-only.
+> The `--sse` flag is accepted for compatibility and starts stdio mode with a warning.
+> The following ADR-005/ADR-008 auth-gate design applied to the removed SSE transport and is retained here as historical record.
 
 ## Architecture
 
@@ -20,7 +22,7 @@ This module follows **Domain-Driven Design** with Clean Architecture layers:
 |-------|---------------|------|
 | **Domain** | Aggregates, entities, value objects, domain services, repository interfaces | `src/mcp-server/domain/` |
 | **Application** | Use cases, DTOs, input validation, session management | `src/mcp-server/application/` |
-| **Infrastructure** | Transport implementations (stdio, SSE-Axum), JSON-RPC serialization | `src/mcp-server/infrastructure/` |
+| **Infrastructure** | Transport implementation (stdio only since GAP-A-10; SSE-Axum removed), JSON-RPC serialization | `src/mcp-server/infrastructure/` |
 | **Interfaces** | MCP protocol handlers, tool routing, resource/prompt providers | `src/mcp-server/interfaces/` |
 
 ## Related ADRs

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -20,11 +20,11 @@ cargo install rigorix-mcp
 # Run in stdio mode (default, for Claude Code / Aider)
 rigorix-mcp
 
-# Run in SSE mode (for Claude Desktop / Cursor)
-rigorix-mcp --sse --bind 127.0.0.1:3001
+# (Removed) SSE mode — GAP-A-10
+rigorix-mcp --sse --bind 127.0.0.1:3001  # accepted for compatibility; starts stdio mode with a warning
 ```
 
-The server reads newline-delimited JSON-RPC messages from stdin (stdio mode) or accepts HTTP SSE connections (SSE mode). No configuration file required for basic use.
+The server reads newline-delimited JSON-RPC messages from stdin (stdio mode — the only transport since GAP-A-10 removed SSE). No configuration file required for basic use.
 
 ---
 


### PR DESCRIPTION
ci: make proofing gate + reconcile stale claims (#744)

GAP-A-27:
- Remove continue-on-error:true + the `|| true` escapes from all 5
  "Per-crate / Root + per-crate scripts (all conventions)" proofing steps
  (lint/build/test/docs/integration) so docs + integration stages actually
  gate; docs job timeout 25 -> 45 (the gated proofing loop takes ~20 min)
- README: remove the Go claim (only detect_project_type mentions go.mod —
  no Go parser/indexer exists); reconcile 86 -> 84 verification steps
- mcp docs: qualify SSE claims — GAP-A-10 removed the SSE transport
  (stdio-only; --sse flag accepted for compatibility); mcp-server.md auth
  paragraph + infrastructure table + mcp/README SSE sections marked removed

Verified: ci.yml YAML parses; local-ci 84/84.
