### PR TITLE
feat: gap-ledger remainder — A-02/A-20/A-22 + M-09 ADRs + tooling

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# M-04: pre-commit hook — formatting + clippy gate (restored from ledger claim).
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+echo "== fmt =="
+cargo fmt --check
+
+echo "== clippy (workspace) =="
+cargo clippy --workspace --all-targets -- -D warnings

--- a/.pi/scripts/install_coverage_tools.sh
+++ b/.pi/scripts/install_coverage_tools.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# L-06: coverage tooling installer (restored from ledger claim).
+# Installs cargo-llvm-cov used by the coverage proofing stage.
+set -euo pipefail
+
+if command -v cargo-llvm-cov >/dev/null 2>&1; then
+    echo "cargo-llvm-cov already installed: $(cargo-llvm-cov --version)"
+    exit 0
+fi
+
+echo "Installing cargo-llvm-cov..."
+cargo install cargo-llvm-cov --locked
+
+echo "cargo-llvm-cov installed: $(cargo-llvm-cov --version)"

--- a/cli/src/cli_boundary/orchestrator.rs
+++ b/cli/src/cli_boundary/orchestrator.rs
@@ -131,27 +131,27 @@ pub async fn build_cli_services(config: CliConfig) -> Result<CliServices, CliErr
     // ── Template service ───────────────────────────────────────────────
     let cli_template_service: Arc<dyn TemplateEngineService> = Arc::new(TemplateEngineImpl::new());
 
+    // GAP-A-20: the engine's config-gated filesystem TemplateRepository is
+    // the single template-loading path here (no hand-rolled fs loop). A
+    // missing dir yields no templates, not an error — same as before.
     let tpl_dir = PathBuf::from(&repo_root).join(".rigorix/templates");
-    if tpl_dir.exists()
-        && let Ok(mut entries) = tokio::fs::read_dir(&tpl_dir).await
     {
-        let mut files = Vec::new();
-        while let Ok(Some(entry)) = entries.next_entry().await {
-            let path = entry.path();
-            if path.extension().and_then(|e| e.to_str()) == Some("toml") {
-                files.push(path);
-            }
-        }
-        for path in files {
-            if let Ok(content) = tokio::fs::read_to_string(&path).await
-                && let Ok(template) =
-                    toml::from_str::<rigorix_engine::templates::domain::Template>(&content)
-            {
-                let input = rigorix_engine::templates::application::dto::RegisterInput {
-                    template,
-                    overwrite: true,
-                };
-                let _ = cli_template_service.register(input).await;
+        let template_repo =
+            rigorix_engine::templates::infrastructure::template_repository_from_config(&[tpl_dir
+                .to_string_lossy()
+                .to_string()]);
+        if let Ok(files) = template_repo.list_template_files(".", "toml").await {
+            for path in files {
+                if let Ok(content) = template_repo.read_template_file(&path).await
+                    && let Ok(template) =
+                        toml::from_str::<rigorix_engine::templates::domain::Template>(&content)
+                {
+                    let input = rigorix_engine::templates::application::dto::RegisterInput {
+                        template,
+                        overwrite: true,
+                    };
+                    let _ = cli_template_service.register(input).await;
+                }
             }
         }
     }

--- a/engine/.pi/architecture/decisions/ADR-010-scored-evaluation.md
+++ b/engine/.pi/architecture/decisions/ADR-010-scored-evaluation.md
@@ -1,6 +1,6 @@
 # ADR-010: Scored Evaluation Architecture — Pluggable Quality Scoring Backends
 
-**Status:** Accepted
+**Status:** Implemented (EvaluateInput.backend selection + typed BackendNotFound; engine/src/scored_evaluation/application/service_impl.rs:134-145)
 **Date:** 2026-07-15
 
 **Tech Stack:** Rust

--- a/engine/.pi/architecture/gap-ledger.md
+++ b/engine/.pi/architecture/gap-ledger.md
@@ -2,6 +2,7 @@
 
 > **Source:** Comprehensive codebase assessment — 2026-06-15
 > **Last Updated:** 2026-08-30 (Addendum 2: codebase audit implementation backlog — 30 new, see bottom)
+> **⚠️ Status verification 2026-08-30:** every Open item re-verified against source. **Most Addendum-2 items are already FIXED in code** (marked `GAP-A-xx` in source) — see "Verification 2026-08-30" section at the bottom for the authoritative per-item verdict. Table statuses above are stale relative to that section.
 > **Scope:** All 17 modules across engine/src/, architecture docs, tests, CI, tooling
 > **Total findings:** 65 | **Resolved:** 27 | **Open:** 38
 
@@ -205,3 +206,149 @@
 ---
 
 *Addendum generated: 2026-08-30 | Disposition: implement/connect everything — no deletions. Cross-references: gap-ledger-validation.md (verification record); 07/08 in codebase-analysis/ (audit record).*
+
+---
+
+# Verification 2026-08-30 — Ledger vs. Implemented Code (authoritative)
+
+> **Method:** Every Open item re-checked against current source (grep + direct reads, code is truth). Verdicts below supersede table statuses above.
+
+## Addendum 2 (A-01…A-30) — verified verdicts
+
+| ID | Ledger | Verified verdict | Evidence |
+|----|--------|------------------|----------|
+| A-01 | Open | ✅ **FIXED** | Unknown tool → `TaskResult::failure(..., "unknown_tool")` (`service_impl.rs:287-294` parallel, `:799-805` single-node) |
+| A-02 | Open | ✅ **FIXED** (partial) | Missing node fails `node_not_found` (`:1941-1950`). NOTE: missing-graph path still returns placeholder "backwards compatibility" shim (`:1612`) — decide its fate |
+| A-03 | Open | ✅ **FIXED** | `config_override` applied (`:1607-1610`), `config` consumed downstream |
+| A-04 | Open | ✅ **FIXED** | `tokio::process::Command` (`hook_runner_impl.rs:83`), concurrent drain task (`:61`); 10ms poll loop gone |
+| A-05 | Open | ✅ **FIXED** | Parallel path runs PreToolUse gating with `HookAbortSignal` + PostToolUse mirrored (`service_impl.rs:156-175` region); permission enforced |
+| A-06 | Open | ✅ **FIXED** | `GAP-A-06`: HMAC over FULL canonical envelope, sorted-key JSON (`envelope_factory_impl.rs:45-65`) |
+| A-07 | Open | ✅ **FIXED** | Real `ClaudeClassifier`/`OpenaiClassifier` wired on API keys; mock only behind `RIGORIX_MOCK_PLANNING=1` (`mcp/main.rs:820-880`) |
+| A-08 | Open | ✅ **FIXED** | `"governance"` → `ActionMode::Governance` (`mode_resolver_impl.rs:84-89`) + real `dispatch_governance` (`router_impl.rs:342`) |
+| A-09 | Open | ✅ **FIXED** | `GAP-A-09`: `fetch_update` CAS reserve (`llm_budget_impl.rs:206-219`); reservation guard in production path |
+| A-10 | Open | ✅ **FIXED (removed)** | `GAP-A-10`: SSE removed; `--sse` deprecation-warns, always stdio (`mcp/main.rs:1774-1785`) |
+| A-11 | Open | ✅ **FIXED** | All 4 flags read (`service_impl.rs:481,502-513,580,2126-2137`); actions `max_llm_calls` applied (`context_builder_impl.rs:381-463`) |
+| A-12 | Open | ✅ **FIXED** | Hooks on `tokio::process`; **0** `std::fs`/`std::process` in `service_impl.rs`; old `template_generation/generator.rs` gone |
+| A-13 | Open | ✅ **FIXED** | `GAP-A-13`: `EvaluateInput.backend` + `BackendNotFound` (`service_impl.rs:134-145`, `dto.rs:33-38`) |
+| A-14 | Open | ✅ **FIXED** | `GAP-A-14`: gate blocks on time + token limits (`enforcement/application/enforcer_impl.rs:221-224`) |
+| A-15 | Open | ✅ **FIXED** | `IndexerServiceImpl` + FileSystem symbol/source + InMemory grammar repos all exist |
+| A-16 | Open | ✅ **FIXED** | All 9 checked traits now have 1 impl each |
+| A-17 | Open | ✅ **FIXED** | `AuditEvent::` emitted at 5 sites (`audit_sender_impl.rs:244,320,330,348,367`) |
+| A-18 | Open | ✅ **FIXED** | `GAP-A-18`: RiskClassifier constructed + drives gating (`tools/application/registry_impl.rs:35,56,521`) |
+| A-19 | Open | ⚠️ **PARTIAL** | `GAP-A-19` builder param exists (`service_impl.rs:2701-2718`) but no production construction of `FailureClassifierServiceImpl` found (only tests) — verify composition wiring |
+| A-20 | Open | ⚠️ **PARTIAL** | `FileSystemTemplateRepository` implemented + exported but no construction in engine/mcp composition — implemented, not wired |
+| A-21 | Open | ✅ **FIXED** | Both domain→application imports replaced with domain-local types |
+| A-22 | Open | ❌ **STILL OPEN** | `create_session` zero runtime callers; `handle_initialize` takes unused `_params` (`mcp/main.rs:1303,1326`) |
+| A-23 | Open | ✅ **MOSTLY FIXED** | 12+ integration files incl. backend/budget/identity; `unit/mod.rs` now compiles |
+| A-24 | Open | ✅ **FIXED** | 24 stub files replaced; single `unit/mod.rs` documents history (match is a doc comment) |
+| A-25 | Open | ✅ **FIXED** | Shared `mcp/tests/common/mod.rs`, deadline-based; 1 residual sleep |
+| A-26 | Open | ✅ **FIXED** | README uses `rigorix-cli` (`:179,183-184`); `[[bin]] name="rigorix"` also added |
+| A-27 | Open | ✅ **MOSTLY FIXED** | Go claim gone; 1 `continue-on-error` (documented teardown); "86 steps" moot — HOW docs removed |
+| A-28 | Open | ✅ **FIXED (moot)** | `HOW-*.md` no longer exists (docs/ = dr-plan.md, runbook.md) |
+| A-29 | Open | ✅ **FIXED** | `.gitignore` repaired; `.mov` untracked; no `.rigorix/state` tracked |
+## Addendum 1 (H-07…L-09) — verified verdicts
+
+| ID | Ledger | Verified verdict | Evidence |
+|----|--------|------------------|----------|
+| H-07 | Open | ✅ **FIXED** | `approve_node` checks `requires_approval` + `AwaitingApproval` (`service_impl.rs:2506-2518`) |
+| H-08 | Open | ✅ **FIXED** | `hydrate_execution` uses persisted `input.started_at` (`service_impl.rs:~2597-2614`) |
+| M-12 | Open | ❌ **STILL OPEN** | Signing still `Option<String> signing_key` (`envelope_factory_impl.rs:24-31`); no `evidence: degraded` marker |
+| M-13 | Open | ✅ **FIXED** | `planning_prompt_content` wired (`orchestrator_impl.rs:414` → `envelope_factory_impl.rs:105`) |
+| M-14 | Open | ✅ **FIXED** | Zero `let _ = ...publish(...)` remaining in engine/src |
+| M-15 | Open | ⚠️ **PARTIAL** | Both vocabularies still persisted; `state.rs:211-215` documents GAP-3 migration compat — consolidate or mark intentional |
+| L-08 | Open | ❌ **STILL OPEN** | unwrap/expect count now **~1729** (grew from 1617) |
+| L-09 | Open | ✅ **FIXED** | `detect_git_info` populates git_commit/branch (`orchestrator_impl.rs:876`) |
+
+## Base ledger "Resolved" claims — spot-check results
+
+| Item | Claim | Verified |
+|------|-------|----------|
+| C-01 | 179 `#[tracing::instrument]` | ✅ now 183 (claim holds) |
+| M-03 | `deny.toml` added | ❌ **MISSING** at repo root — stale Resolved claim |
+| M-04 | `.githooks/pre-commit` | ❌ **MISSING** — stale Resolved claim |
+| L-06 | `install_coverage_tools.sh` | ❌ **MISSING** from `.pi/scripts/` — stale Resolved claim |
+| M-07 | `common/validation.rs` | ✅ exists |
+| M-10 | `benches/dag_engine.rs` | ✅ exists |
+| M-09 | 8 ADRs "Accepted" | ⚠️ down to 2 — nearly resolved |
+
+## Corrected totals (post-verification)
+
+| Group | Ledger open | Actually open | Fixed | Partial |
+|-------|------------|---------------|-------|---------|
+| Addendum 2 (A-01…A-30) | 30 | **2** (A-22; A-02 graph-shim edge) | 26 | 2 (A-19, A-20 wiring) |
+| Addendum 1 (H-07…L-09) | 8 | **2** (M-12, L-08) | 5 | 1 (M-15) |
+| Base | M-09 open; M-03/M-04/L-06 marked Resolved | 3 stale Resolved claims + 2 ADRs | — | — |
+
+**Remaining actions:** (1) wire A-19 classifier + A-20 filesystem template repo into composition roots; (2) A-22 session handshake; (3) M-12 signing policy for approval runs; (4) L-08 unwrap pass on dispatch/evidence path; (5) restore or re-scope M-03/M-04/L-06 tooling files or mark Removed; (6) decide A-02 missing-graph placeholder shim fate; (7) finish M-09's last 2 ADRs.
+
+---
+
+*Verification performed 2026-08-30 against working tree @ commit 3dcd26ab. This section supersedes table statuses above.*
+
+## Re-verification 2026-08-30 (post issue-series batches 8–20, @ dba15950)
+
+> The batch series (#763–#775) landed 28 commits after the verification base (3dcd26ab), which
+> invalidated several verdicts. Re-checked every Open/Partial/Disputed row against HEAD:
+
+| ID | Prior verdict | **Re-verified** | Delta |
+|----|--------------|-----------------|-------|
+| A-19 | ⚠️ PARTIAL (no prod construction) | ✅ **FIXED** | `ParallelExecutionFactoryImpl::create` constructs `RetryEvaluationServiceImpl::with_classifier(Arc::new(FailureClassifierServiceImpl))` (`factory_impl.rs:53`) — wired by #769 after the verification base |
+| A-25 | ✅ FIXED (1 residual sleep) | ✅ **FIXED** | 0 `sleep` calls in `mcp/tests/` — residual removed post-verification |
+| A-27 | ✅ MOSTLY (1 documented continue-on-error) | ✅ **FIXED** | 0 `continue-on-error: true` remain in `ci.yml` (#773) — the 1 remaining text mention is a comment, not a step |
+| A-26 | ✅ FIXED ("`[[bin]] name="rigorix"` also added") | ⚠️ **FIXED, evidence wrong** | No `[[bin]]` exists in `cli/Cargo.toml` (only `[package] rigorix-cli` + `[lib] rigorix`) — README→`rigorix-cli` fix is correct, but the cited `[[bin]]` is fictional |
+| M-09 | "down to 2 ADRs" | ⚠️ **STILL OPEN: 8** | Batch 17 flipped engine ADR-002..009 only. Remaining `Accepted`: **7 mcp ADRs** (ADR-001..007 in `mcp/.pi/architecture/decisions/`) + **engine ADR-010** (scored-evaluation, implemented by #765 but never flipped). ADR-011/012 correctly `Proposed` (approval epic pending) |
+| L-08 | ❌ STILL OPEN (~1729 global) | ⚠️ **Path-scope FIXED; global open** | #775 removed the audit evidence-path panics (client-build expects → `Option<reqwest::Client>` + `AuditError::Internal`). `service_impl.rs` = 0 non-test unwraps; hooks/state_persistence production paths clean. Global count (~1700) remains a separate backlog item per issue scope |
+| A-02 | ⚠️ PARTIAL (graph shim) | ⚠️ **UNCHANGED** | `service_impl.rs:1612` missing-graph placeholder shim still present — fate decision still pending |
+| A-20 | ⚠️ PARTIAL (not wired) | ⚠️ **UNCHANGED** | `template_repository_from_config` still has no production caller outside `templates/infrastructure/` |
+| A-22 | ❌ STILL OPEN | ❌ **UNCHANGED** | `create_session` still zero runtime callers; `handle_initialize` still fabricates the response |
+| M-12 | ❌ STILL OPEN | ❌ **UNCHANGED** | `signing_key: Option<String>` + no `evidence: degraded` marker |
+| M-15 | ⚠️ PARTIAL | ⚠️ **UNCHANGED** | dual `node_states`/`exec_node_states` both persisted (GAP-3 compat documented) |
+| M-03/M-04/L-06 | stale Resolved claims | ❌ **CONFIRMED MISSING** | `deny.toml`, `.githooks/pre-commit`, `.pi/scripts/install_coverage_tools.sh` do not exist — re-scope or mark Removed |
+| C-01 | 183 instruments | ✅ exact | 183 `#[tracing::instrument]` |
+
+**Net correction to "Corrected totals":** Actually-open = 2 (A-22, M-12) + M-09(8 ADRs); Partial = 2 (A-02 graph-shim, A-20 wiring) + M-15; stale-Resolved = 3 tooling files (M-03/M-04/L-06); evidence-wrong = A-26 (`[[bin]]` claim). All other FIXED verdicts hold.
+
+
+## Validation 2026-08-30 (independent audit of the Re-verification above)
+
+> Every row of the Re-verification section re-checked against HEAD (dba15950). Two corrections:
+
+| Row | Re-verification verdict | Validation verdict | Evidence |
+|-----|------------------------|--------------------|----------|
+| M-12 | ❌ UNCHANGED / STILL OPEN | ✅ **FIXED** — re-verification missed it | `GAP-M-12` implemented: `evidence_degraded: !input.sign` + comment "an unsigned run is explicitly degraded evidence" (`envelope_factory_impl.rs:109-113`), test `test_evidence_degraded_marker` (`:317-320`). Fix landed in 5eb95f43 (#761), **verified ancestor of dba15950** — so it was already in HEAD when the re-verification ran; its `signing_key: Option` grep caught the key but missed the degraded marker |
+| A-25 | ✅ FIXED (0 sleeps) | ⚠️ **FIXED, count wrong** | 5 `sleep` matches in `mcp/tests/` — 4 are doc comments, 1 is a real `std::thread::sleep(POLL_INTERVAL)` (`common/mod.rs:109`) inside the deadline-based poll loop. That poll-sleep is the *replacement* for fixed sleeps (bounded, interval-based), so the verdict "fixed" stands but "0 sleeps" is literally false |
+
+All other rows **validated correct**:
+- **A-19 FIXED** ✅ — confirmed `RetryEvaluationServiceImpl::with_classifier(Arc::new(FailureClassifierServiceImpl))` at `execution_engine/infrastructure/factory_impl.rs:53` (unit struct, no `::new` — which is why a `::new` grep misses it).
+- **A-26 evidence-wrong** ✅ — confirmed: `cli/Cargo.toml` has only `[package] rigorix-cli` + `[lib] name = "rigorix"`, **no `[[bin]]` section**. The earlier verification's `[[bin]]` citation was wrong (a `^name` grep matched the lib name).
+- **M-09 = 8 ADRs** ✅ — exactly 7 mcp ADRs (001–007) + engine ADR-010 remain "Accepted" (templates excluded).
+- **A-27** ✅ — single `continue-on-error` match is inside a comment (ci.yml:165), no active step.
+- **L-08 path-scoped** ✅ — 0 non-test unwraps/expects in `service_impl.rs`; global engine count ~1729 stands.
+- **A-02 shim, A-20 unwired, A-22 open, M-15 dual-vocabulary, M-03/M-04/L-06 files missing** ✅ — all re-confirmed unchanged.
+
+**Net final state:** Actually-open = **A-22** + A-02 graph-shim decision + A-20 wiring + M-15 consolidation + M-09 (8 ADRs) + L-08 (global) + 3 stale tooling claims (M-03/M-04/L-06). **M-12 is closed.**
+
+*Validated 2026-08-30 against HEAD dba15950. Supersedes the Re-verification for the M-12 and A-25 rows.*
+
+
+
+## Batch 21 (gap-ledger remainder) — implemented
+
+> One run, branch `feature/gap-ledger-remainder` (PR #776-sibling). Code-verified against HEAD.
+
+| ID | Outcome | Evidence |
+|----|---------|----------|
+| A-02 | ✅ **FIXED** | Missing graph → `ExecutionError::InvalidState` (service_impl.rs execute_graph); placeholder shim removed; 3 tests converted to the fail-contract. **Bonus:** exposed + fixed a latent deadlock — `notify_progress` re-locked the `sessions` Mutex while callers held it (non-reentrant std Mutex); both call sites now release the lock before notifying; `test_progress_callback_fires` is the regression guard |
+| A-20 | ✅ **FIXED (wired)** | CLI orchestrator loads `.rigorix/templates` via `template_repository_from_config` (engine's config-gated filesystem repo) — the hand-rolled tokio::fs loop is gone |
+| A-22 | ✅ **FIXED** | `handle_initialize` routes through `McpServerService::initialize` (creates the session); protocol negotiation echoes the client's version when supported (`2025-03-26`/`2025-06-18`/`2024-11-05`), else the default — no fabricated response |
+| M-09 | ✅ **RESOLVED** | 7 mcp ADRs + engine ADR-010 statused with code evidence. **Honest verdicts:** ADR-002 = **Superseded** (SQLx never adopted — 0 deps); ADR-006 = **Partial** (engine-delegated usage yes; proxy telemetry not implemented); ADR-004/005 qualified (SSE removed, GAP-A-10) |
+| M-03 | ✅ **RESOLVED** | `engine/deny.toml` exists (claim said repo root — corrected to actual location) |
+| M-04 | ✅ **RESOLVED** | `.githooks/pre-commit` restored: `cargo fmt --check` + `cargo clippy --workspace --all-targets -D warnings` |
+| L-06 | ✅ **RESOLVED** | `.pi/scripts/install_coverage_tools.sh` restored (cargo-llvm-cov installer) |
+| A-26 | ✅ **Evidence corrected** | No `[[bin]]` exists in cli/Cargo.toml (prior evidence was fictional); README→`rigorix-cli` fix stands |
+| M-12 | ✅ **ALREADY FIXED (missed by re-verification)** | `evidence_degraded: !input.sign` + `test_evidence_degraded_marker` landed in 5eb95f43 (#761), ancestor of HEAD. The re-verification's grep (`evidence: degraded` with colon) missed the underscore field name; the independent Validation section caught it. Unnecessary tracking issue #776 closed |
+| A-25 | ✅ verdict stands | 1 bounded poll-sleep remains in `mcp/tests/common/mod.rs:109` (deadline-loop interval) — the intended replacement for fixed sleeps |
+| L-08-global | ⬜ **Deferred** → issue #777 (backlog) | global unwrap elimination, beyond the #751 path scope |
+| M-15 | ⬜ **Deferred** → issue #758 (approval epic) | consolidate node-state vocabularies when `approval_records` lands in the state format |
+
+**Remaining open after batch 21:** deferred to approval epic: M-15 (#758) · backlog: L-08-global (#777). All A-rows + M-09/M-03/M-04/L-06/M-12 resolved.

--- a/engine/src/execution_engine/application/service_impl.rs
+++ b/engine/src/execution_engine/application/service_impl.rs
@@ -526,8 +526,9 @@ impl ParallelExecutionServiceImpl {
                 }
             }
 
-            // Update session node state
-            {
+            // Update session node state (lock scope ends before notify_progress:
+            // it re-locks `sessions` internally — a self-deadlock otherwise).
+            let updated_state = {
                 let mut sessions =
                     self.sessions
                         .lock()
@@ -548,9 +549,13 @@ impl ParallelExecutionServiceImpl {
                             task_result.error.clone().unwrap_or_default(),
                         );
                     }
-                    // Notify progress callbacks
-                    self.notify_progress(dag_id, node_id, state, total_nodes);
+                    Some(state.clone())
+                } else {
+                    None
                 }
+            };
+            if let Some(state) = updated_state {
+                self.notify_progress(dag_id, node_id, state, total_nodes);
             }
 
             // Mark completed in graph to release dependents
@@ -634,16 +639,24 @@ impl ParallelExecutionServiceImpl {
         let Some(blocked_id) = graph.ready_nodes().first().copied() else {
             return Ok(());
         };
-        let mut sessions = self
-            .sessions
-            .lock()
-            .map_err(|e| ExecutionError::InternalError {
-                detail: format!("Lock error: {}", e),
-            })?;
-        if let Some(session) = sessions.get_mut(&dag_id)
-            && let Some(state) = session.node_states.get_mut(&blocked_id)
-        {
-            state.mark_awaiting_approval();
+        let updated_state = {
+            let mut sessions = self
+                .sessions
+                .lock()
+                .map_err(|e| ExecutionError::InternalError {
+                    detail: format!("Lock error: {}", e),
+                })?;
+            if let Some(session) = sessions.get_mut(&dag_id)
+                && let Some(state) = session.node_states.get_mut(&blocked_id)
+            {
+                state.mark_awaiting_approval();
+                Some(state.clone())
+            } else {
+                None
+            }
+        };
+        // Drop the sessions lock before notify (it re-locks internally).
+        if let Some(state) = updated_state {
             self.notify_progress(dag_id, blocked_id, state, total_nodes);
         }
         Ok(())
@@ -1545,7 +1558,7 @@ impl ParallelExecutionServiceImpl {
         &self,
         dag_id: Uuid,
         node_id: Uuid,
-        state: &NodeExecutionState,
+        state: NodeExecutionState,
         total_nodes: u32,
     ) {
         let Ok(callbacks) = self.progress_callbacks.lock() else {
@@ -1585,7 +1598,7 @@ impl ParallelExecutionServiceImpl {
         let progress = ExecutionProgress {
             dag_id,
             node_id,
-            state: state.clone(),
+            state,
             total_nodes,
             completed_count: completed,
             failed_count: failed,
@@ -1609,59 +1622,14 @@ impl ParallelExecutionService for ParallelExecutionServiceImpl {
             .clone()
             .unwrap_or_else(|| self.config.clone());
 
-        // If no graph is provided, return placeholder (backwards compatibility)
+        // GAP-A-02: a missing graph is a caller contract violation — fail with
+        // a typed error instead of returning a fake-success empty result.
         let Some(mut graph) = input.graph else {
-            let mut sessions = self
-                .sessions
-                .lock()
-                .map_err(|e| ExecutionError::InternalError {
-                    detail: format!("Lock error: {}", e),
-                })?;
-
-            if sessions.contains_key(&input.dag_id) {
-                return Err(ExecutionError::InvalidState {
-                    reason: format!("Execution already in progress for dag_id={}", input.dag_id),
-                });
-            }
-
-            sessions.insert(
-                input.dag_id,
-                ExecutionSession {
-                    node_states: HashMap::new(),
-                    in_flight: Vec::new(),
-                    result: ExecutionResult::new(input.dag_id),
-                    paused: false,
-                    aborted: false,
-                    total_retries: 0,
-                    approved: HashSet::new(),
-                    started_at: Utc::now(),
-                    graph: None,
-                },
-            );
-            drop(sessions);
-
-            let now = Utc::now();
-            let result = ExecutionResult {
-                dag_id: input.dag_id,
-                node_results: HashMap::new(),
-                execution_states: HashMap::new(),
-                completed_count: 0,
-                failed_count: 0,
-                skipped_count: 0,
-                total_nodes: 0,
-                total_duration_ms: 0,
-                total_retries: 0,
-                started_at: now,
-                completed_at: now,
-                cancelled: false,
-                cancellation_reason: None,
-            };
-
-            return Ok(ExecuteGraphOutput {
-                result,
-                completed_at: now,
-                approval_pending: false,
-                pending_approval_steps: Vec::new(),
+            return Err(ExecutionError::InvalidState {
+                reason: format!(
+                    "execute_graph called without a graph (dag_id={})",
+                    input.dag_id
+                ),
             });
         };
 

--- a/engine/src/execution_engine/tests.rs
+++ b/engine/src/execution_engine/tests.rs
@@ -38,37 +38,53 @@ fn create_executor() -> ParallelExecutionServiceImpl {
     ParallelExecutionServiceImpl::new(config, Box::new(retry), event_bus)
 }
 
+/// A-02: minimal sealed graph for session-setup tests (abort/pause/state).
+fn sample_graph() -> crate::dag_engine::domain::TaskGraph {
+    use crate::dag_engine::domain::{TaskGraph, TaskNode};
+    let mut graph = TaskGraph::new();
+    let root = TaskNode::new(Uuid::new_v4(), "root", "shell", vec![], "echo hi");
+    graph.add_unchecked(root).unwrap();
+    graph.seal().unwrap();
+    graph
+}
+
 // ---------------------------------------------------------------------------
 // ParallelExecutionServiceImpl Tests
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn test_execute_graph_creates_session() {
+async fn test_execute_graph_without_graph_fails() {
+    // GAP-A-02: a missing graph is a caller contract violation — typed error,
+    // never a fake-success empty result.
     let executor = create_executor();
     let dag_id = Uuid::new_v4();
 
-    let output = executor
+    let err = executor
         .execute_graph(ExecuteGraphInput {
             dag_id,
             graph: None,
             config_override: None,
         })
         .await
-        .unwrap();
+        .unwrap_err();
 
-    assert_eq!(output.result.dag_id, dag_id);
-    assert!(output.result.execution_states.is_empty());
+    assert!(err.to_string().contains("without a graph"), "got: {err}");
 }
 
 #[tokio::test]
 async fn test_execute_graph_rejects_duplicate() {
     let executor = create_executor();
     let dag_id = Uuid::new_v4();
+    use crate::dag_engine::domain::{TaskGraph, TaskNode};
+    let mut graph = TaskGraph::new();
+    let root = TaskNode::new(Uuid::new_v4(), "root", "shell", vec![], "echo hi");
+    graph.add_unchecked(root.clone()).unwrap();
+    graph.seal().unwrap();
 
     executor
         .execute_graph(ExecuteGraphInput {
             dag_id,
-            graph: None,
+            graph: Some(graph),
             config_override: None,
         })
         .await
@@ -77,7 +93,7 @@ async fn test_execute_graph_rejects_duplicate() {
     let err = executor
         .execute_graph(ExecuteGraphInput {
             dag_id,
-            graph: None,
+            graph: Some(sample_graph()),
             config_override: None,
         })
         .await
@@ -96,10 +112,16 @@ async fn test_execute_graph_with_config_override() {
         ..Default::default()
     };
 
+    use crate::dag_engine::domain::{TaskGraph, TaskNode};
+    let mut graph = TaskGraph::new();
+    let root = TaskNode::new(Uuid::new_v4(), "root", "shell", vec![], "echo hi");
+    graph.add_unchecked(root.clone()).unwrap();
+    graph.seal().unwrap();
+
     let output = executor
         .execute_graph(ExecuteGraphInput {
             dag_id,
-            graph: None,
+            graph: Some(graph),
             config_override: Some(custom_config),
         })
         .await
@@ -946,7 +968,7 @@ async fn test_pause_and_resume_execution() {
     executor
         .execute_graph(ExecuteGraphInput {
             dag_id,
-            graph: None,
+            graph: Some(sample_graph()),
             config_override: None,
         })
         .await
@@ -989,7 +1011,7 @@ async fn test_pause_already_paused_returns_error() {
     executor
         .execute_graph(ExecuteGraphInput {
             dag_id,
-            graph: None,
+            graph: Some(sample_graph()),
             config_override: None,
         })
         .await
@@ -1016,7 +1038,7 @@ async fn test_resume_not_paused_returns_error() {
     executor
         .execute_graph(ExecuteGraphInput {
             dag_id,
-            graph: None,
+            graph: Some(sample_graph()),
             config_override: None,
         })
         .await
@@ -1038,7 +1060,7 @@ async fn test_abort_execution() {
     executor
         .execute_graph(ExecuteGraphInput {
             dag_id,
-            graph: None,
+            graph: Some(sample_graph()),
             config_override: None,
         })
         .await
@@ -1064,7 +1086,7 @@ async fn test_abort_twice_returns_error() {
     executor
         .execute_graph(ExecuteGraphInput {
             dag_id,
-            graph: None,
+            graph: Some(sample_graph()),
             config_override: None,
         })
         .await
@@ -1160,7 +1182,7 @@ async fn test_execute_graph_with_custom_config_override_respected() {
     let output = executor
         .execute_graph(ExecuteGraphInput {
             dag_id,
-            graph: None,
+            graph: Some(sample_graph()),
             config_override: Some(config),
         })
         .await
@@ -1751,7 +1773,7 @@ async fn test_parallel_execution_factory_creates_service() {
     let output = service
         .execute_graph(ExecuteGraphInput {
             dag_id,
-            graph: None,
+            graph: Some(sample_graph()),
             config_override: None,
         })
         .await
@@ -1812,7 +1834,7 @@ async fn test_factory_with_custom_config() {
     let output = service
         .execute_graph(ExecuteGraphInput {
             dag_id,
-            graph: None,
+            graph: Some(sample_graph()),
             config_override: None,
         })
         .await
@@ -1926,7 +1948,7 @@ async fn test_execute_graph_creates_session_and_tracks_state() {
     executor
         .execute_graph(ExecuteGraphInput {
             dag_id,
-            graph: None,
+            graph: Some(sample_graph()),
             config_override: None,
         })
         .await
@@ -1950,7 +1972,7 @@ async fn test_execute_graph_completes_without_cancellation() {
     let output = executor
         .execute_graph(ExecuteGraphInput {
             dag_id,
-            graph: None,
+            graph: Some(sample_graph()),
             config_override: None,
         })
         .await
@@ -1968,7 +1990,7 @@ async fn test_abort_marks_execution_as_cancelled() {
     executor
         .execute_graph(ExecuteGraphInput {
             dag_id,
-            graph: None,
+            graph: Some(sample_graph()),
             config_override: None,
         })
         .await
@@ -2113,15 +2135,21 @@ async fn test_progress_callback_fires() {
     executor
         .execute_graph(ExecuteGraphInput {
             dag_id,
-            graph: None,
+            graph: Some(sample_graph()),
             config_override: None,
         })
         .await
         .unwrap();
 
-    // Callback registered but not triggered since no nodes complete
-    // The callback infrastructure is ready for real execution
-    assert_eq!(called.load(std::sync::atomic::Ordering::SeqCst), 0);
+    // GAP-A-02 change: the graph now really executes (sample_graph has one
+    // shell node), so the progress callback fires for the completed node.
+    // This also guards the notify_progress re-lock deadlock (regression):
+    // a registered callback used to self-deadlock on the sessions Mutex.
+    let fired = called.load(std::sync::atomic::Ordering::SeqCst);
+    assert!(
+        fired >= 1,
+        "progress callback should fire for completed node, got {fired}"
+    );
 }
 
 #[tokio::test]

--- a/mcp/.pi/architecture/decisions/ADR-001-architecture-pattern.md
+++ b/mcp/.pi/architecture/decisions/ADR-001-architecture-pattern.md
@@ -1,6 +1,6 @@
 # ADR-001: Domain-Driven Design with Bounded Contexts
 
-**Status:** Accepted
+**Status:** Implemented (mcp/src/ bounded-context modules: mcp_server, execution_tools, audit_tools, template_tools, enterprise_proxy)
 **Date:** 2026-07-12
 **Session:** d19b7a21-8f4c-4b3e-9a1d-5e6f7c8b9a0d
 

--- a/mcp/.pi/architecture/decisions/ADR-002-data-storage-strategy.md
+++ b/mcp/.pi/architecture/decisions/ADR-002-data-storage-strategy.md
@@ -1,6 +1,6 @@
 # ADR-002: Data Storage Strategy — SQLx + Per-Context Schema
 
-**Status:** Accepted
+**Status:** Superseded — SQLx was never adopted (0 `sqlx` deps/uses); storage is in-memory + filesystem repositories (mcp/src/*/infrastructure/, LocalAuditEnvelopeRepository)
 **Date:** 2026-07-12
 **Session:** d19b7a21-8f4c-4b3e-9a1d-5e6f7c8b9a0d
 

--- a/mcp/.pi/architecture/decisions/ADR-003-cross-context-communication.md
+++ b/mcp/.pi/architecture/decisions/ADR-003-cross-context-communication.md
@@ -1,6 +1,6 @@
 # ADR-003: Cross-Context Communication — Trait-Based DI + EventBus
 
-**Status:** Accepted
+**Status:** Implemented (trait-based DI throughout mcp/src; engine EventBusService wired at mcp/src/main.rs:795-797)
 **Date:** 2026-07-12
 **Session:** d19b7a21-8f4c-4b3e-9a1d-5e6f7c8b9a0d
 

--- a/mcp/.pi/architecture/decisions/ADR-004-mcp-protocol-design.md
+++ b/mcp/.pi/architecture/decisions/ADR-004-mcp-protocol-design.md
@@ -1,6 +1,6 @@
 # ADR-004: MCP Protocol Design — Hand-Rolled JSON-RPC over stdio/SSE
 
-**Status:** Accepted
+**Status:** Implemented, with one deviation — hand-rolled JSON-RPC over stdio stands; the SSE transport was removed (GAP-A-10), stdio-only since
 **Date:** 2026-07-12
 **Session:** d19b7a21-8f4c-4b3e-9a1d-5e6f7c8b9a0d
 

--- a/mcp/.pi/architecture/decisions/ADR-005-authentication-and-authorization.md
+++ b/mcp/.pi/architecture/decisions/ADR-005-authentication-and-authorization.md
@@ -1,6 +1,6 @@
 # ADR-005: Authentication & Authorization — Transport-Level + Enterprise Proxy Auth
 
-**Status:** Accepted
+**Status:** Implemented (enterprise-proxy auth via enterprise.api_key; the transport-level SSE auth gate was removed with the SSE transport — GAP-A-10)
 **Date:** 2026-07-12
 **Session:** d19b7a21-8f4c-4b3e-9a1d-5e6f7c8b9a0d
 

--- a/mcp/.pi/architecture/decisions/ADR-006-cost-tracking-usage-metering.md
+++ b/mcp/.pi/architecture/decisions/ADR-006-cost-tracking-usage-metering.md
@@ -1,6 +1,6 @@
 # ADR-006: Cost Tracking & Usage Metering — Engine-Delegated + Proxy Telemetry
 
-**Status:** Accepted
+**Status:** Partial — engine-delegated usage/cost tracking is wired (execution_tools); proxy-side telemetry is not implemented (no telemetry module)
 **Date:** 2026-07-12
 **Session:** d19b7a21-8f4c-4b3e-9a1d-5e6f7c8b9a0d
 

--- a/mcp/.pi/architecture/decisions/ADR-007-compliance-engine-architecture.md
+++ b/mcp/.pi/architecture/decisions/ADR-007-compliance-engine-architecture.md
@@ -1,6 +1,6 @@
 # ADR-007: Compliance Engine Architecture — Read-Only Audit Bridge
 
-**Status:** Accepted
+**Status:** Implemented (read-only audit bridge: ReadAuditHandler/ListAuditsHandler in mcp/src/audit_tools/application/service_impl.rs)
 **Date:** 2026-07-12
 **Session:** d19b7a21-8f4c-4b3e-9a1d-5e6f7c8b9a0d
 

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -1323,20 +1323,66 @@ async fn dispatch_message(msg: JsonRpcMessage) -> Option<JsonRpcMessage> {
 // initialize handler
 // ---------------------------------------------------------------------------
 
-async fn handle_initialize(id: &RequestId, _params: &serde_json::Value) -> JsonRpcMessage {
-    let result = serde_json::json!({
-        "protocolVersion": "2025-03-26",
-        "capabilities": {
-            "tools": {},
-            "resources": {},
-            "prompts": {}
-        },
-        "serverInfo": {
-            "name": "Rigorix MCP Gateway",
-            "version": "0.1.0"
+async fn handle_initialize(id: &RequestId, params: &serde_json::Value) -> JsonRpcMessage {
+    // GAP-A-22: route initialize through the runtime McpServerService — this
+    // creates the session and negotiates the protocol version (no fabricated
+    // response).
+    let protocol_version = params
+        .get("protocolVersion")
+        .and_then(|v| v.as_str())
+        .unwrap_or("2025-03-26")
+        .to_string();
+    let client_info = {
+        let ci = params.get("clientInfo").cloned().unwrap_or_default();
+        rigorix_mcp::mcp_server::domain::value::ClientInfo {
+            name: ci
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown")
+                .to_string(),
+            version: ci
+                .get("version")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
         }
-    });
-    JsonRpcMessage::success(id.clone(), result)
+    };
+    let caps = params.get("capabilities").cloned().unwrap_or_default();
+    let input = rigorix_mcp::mcp_server::application::dto::InitializeInput {
+        protocol_version: protocol_version.clone(),
+        client_info: client_info.clone(),
+        capabilities: rigorix_mcp::mcp_server::domain::value::ClientCapabilities {
+            protocol_version: protocol_version.clone(),
+            client_name: Some(client_info.name.clone()),
+            client_version: client_info.version.clone(),
+            supports_progress: caps
+                .get("experimental")
+                .and_then(|e| e.get("progress"))
+                .and_then(|p| p.as_bool())
+                .unwrap_or(false),
+        },
+    };
+
+    match app_state().mcp_service.initialize(input).await {
+        Ok((output, _events)) => {
+            let result = serde_json::json!({
+                "protocolVersion": output.protocol_version,
+                "capabilities": {
+                    "tools": {},
+                    "resources": {},
+                    "prompts": {}
+                },
+                "serverInfo": {
+                    "name": output.server_info,
+                    "version": "0.1.0"
+                }
+            });
+            JsonRpcMessage::success(id.clone(), result)
+        }
+        Err(err) => JsonRpcMessage::error(
+            id.clone(),
+            JsonRpcError::internal_error(format!("initialize failed: {err}")),
+        ),
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/mcp/src/mcp_server/application/service_impl.rs
+++ b/mcp/src/mcp_server/application/service_impl.rs
@@ -107,7 +107,15 @@ impl McpServerService for McpServerServiceImpl {
         &self,
         input: InitializeInput,
     ) -> Result<(InitializeOutput, Vec<McpServerEvent>), McpServerError> {
-        let protocol_version = input.protocol_version.clone();
+        // GAP-A-22: protocol negotiation — echo the client's version when we
+        // support it, else fall back to our default (never fabricate).
+        const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2025-03-26", "2025-06-18", "2024-11-05"];
+        let negotiated = if SUPPORTED_PROTOCOL_VERSIONS.contains(&input.protocol_version.as_str()) {
+            input.protocol_version.clone()
+        } else {
+            "2025-03-26".to_string()
+        };
+        let protocol_version = negotiated.clone();
         let client_info = ClientInfo {
             name: input.client_info.name,
             version: input.client_info.version,
@@ -125,7 +133,7 @@ impl McpServerService for McpServerServiceImpl {
             ServerCapabilities::default_with_counts(tool_count, RESOURCE_COUNT, PROMPT_COUNT);
 
         let output = InitializeOutput {
-            protocol_version: "2025-03-26".to_string(),
+            protocol_version: negotiated,
             server_capabilities: server_caps.clone(),
             server_info: "Rigorix MCP Gateway".to_string(),
         };
@@ -356,12 +364,19 @@ impl McpServerService for McpServerServiceWithRepos {
         &self,
         input: InitializeInput,
     ) -> Result<(InitializeOutput, Vec<McpServerEvent>), McpServerError> {
+        // GAP-A-22: negotiate — echo client's version when supported.
+        const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2025-03-26", "2025-06-18", "2024-11-05"];
+        let negotiated = if SUPPORTED_PROTOCOL_VERSIONS.contains(&input.protocol_version.as_str()) {
+            input.protocol_version.clone()
+        } else {
+            "2025-03-26".to_string()
+        };
         let tool_count = 0; // Would query registry_repo
         let server_caps =
             ServerCapabilities::default_with_counts(tool_count, RESOURCE_COUNT, PROMPT_COUNT);
 
         let output = InitializeOutput {
-            protocol_version: "2025-03-26".to_string(),
+            protocol_version: negotiated,
             server_capabilities: server_caps.clone(),
             server_info: "Rigorix MCP Gateway".to_string(),
         };


### PR DESCRIPTION
feat: gap-ledger remainder — A-02/A-20/A-22 dead code + session wiring, M-09 ADRs, tooling

Gap-ledger re-verification remainder, one run (all code-verified):

- A-02: execute_graph with a missing graph now fails with a typed
  ExecutionError instead of a fake-success placeholder result. Bonus: this
  exposed + fixed a latent deadlock — notify_progress re-locked the sessions
  Mutex while callers held it (non-reentrant std Mutex); both call sites now
  release the lock before notifying; test_progress_callback_fires is the
  regression guard (3 tests converted to the fail-contract).
- A-20: CLI template loading now goes through the engine's config-gated
  template_repository_from_config (filesystem repo) — the hand-rolled
  tokio::fs loop is gone.
- A-22: handle_initialize routes through McpServerService::initialize
  (creates the session) and negotiates the protocol version (echo client's
  when supported: 2025-03-26/2025-06-18/2024-11-05, else default).
- M-09: 7 mcp ADRs + engine ADR-010 statused with code evidence. Honest
  verdicts: ADR-002 Superseded (SQLx never adopted — 0 deps), ADR-006
  Partial (proxy telemetry not implemented), ADR-004/005 qualified (SSE
  removed GAP-A-10).
- M-03: engine/deny.toml exists (claim said root — corrected).
- M-04: .githooks/pre-commit restored (fmt + clippy -D warnings).
- L-06: .pi/scripts/install_coverage_tools.sh restored.
- A-26: ledger evidence corrected (no [[bin]] in cli/Cargo.toml).
- Ledger: batch-21 outcomes recorded; M-12 confirmed already-fixed (#761,
  evidence_degraded marker — re-verification missed it, issue #776 closed).

Verified: engine 2084 / mcp 225 / cli 80 / actions 456 tests pass; local-ci 84/84.
