### PR TITLE
ci: wire real coverage measurement into CI (#4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,26 @@ jobs:
           done
         working-directory: ${{ matrix.crate }}
 
+  # ── Stage 3b: Coverage (real line coverage via cargo-llvm-cov) ──
+  coverage:
+    name: 📊 Coverage (workspace)
+    needs: [workspace, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          cache-key: coverage
+      - run: bash .pi/scripts/install_coverage_tools.sh
+      - name: Workspace coverage (gated at 60%, baseline 78.92%)
+        run: bash .pi/scripts/coverage.sh --gate --lcov
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: target/coverage.lcov
+          if-no-files-found: error
+
   # ── Stage 4: Security ─────────────────────────────────────────
   audit:
     name: 🔒 Audit

--- a/.pi/scripts/coverage.sh
+++ b/.pi/scripts/coverage.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# ============================================================================
+# coverage.sh — workspace line-coverage measurement (cargo-llvm-cov).
+#
+# Produces the REAL coverage number (not heuristic grep checks):
+#   cargo llvm-cov --workspace --summary-only
+#
+# Usage:
+#   bash .pi/scripts/coverage.sh            # measure + print summary
+#   bash .pi/scripts/coverage.sh --lcov     # also write target/coverage.lcov
+#   bash .pi/scripts/coverage.sh --gate     # fail if lines < COVERAGE_THRESHOLD
+#
+# Env:
+#   COVERAGE_THRESHOLD  minimum line-coverage % (default: 60)
+#
+# Baseline: 78.92% line coverage (2026-08-31, workspace).
+# ============================================================================
+set -uo pipefail
+
+COVERAGE_THRESHOLD="${COVERAGE_THRESHOLD:-60}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GATE=0
+LCOV=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --gate) GATE=1 ;;
+    --lcov) LCOV=1 ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if ! command -v cargo-llvm-cov >/dev/null 2>&1; then
+  echo "cargo-llvm-cov not found — run .pi/scripts/install_coverage_tools.sh" >&2
+  exit 1
+fi
+
+cd "$ROOT"
+
+echo "═══ Workspace coverage (cargo llvm-cov) ═══"
+if [ "$LCOV" -eq 1 ]; then
+  mkdir -p target
+  SUMMARY="$(cargo llvm-cov --workspace --summary-only --lcov --output-path target/coverage.lcov)"
+else
+  SUMMARY="$(cargo llvm-cov --workspace --summary-only)"
+fi
+
+# Print the per-file table + TOTAL row (summary tail), then extract the
+# TOTAL line-coverage percentage from the final line.
+echo "$SUMMARY" | tail -12
+COVERAGE="$(echo "$SUMMARY" | tail -1 | grep -oE '[0-9]+\.[0-9]+%' | head -1 | sed 's/%//')"
+echo ""
+echo "Line coverage: ${COVERAGE}% (threshold: ${COVERAGE_THRESHOLD}%)"
+
+if [ "$GATE" -eq 1 ]; then
+  if awk "BEGIN { exit !($COVERAGE >= $COVERAGE_THRESHOLD) }"; then
+    echo "✓ Coverage gate passed"
+  else
+    echo "✗ Coverage below threshold (${COVERAGE}% < ${COVERAGE_THRESHOLD}%)" >&2
+    exit 1
+  fi
+fi
+exit 0

--- a/.pi/scripts/install_coverage_tools.sh
+++ b/.pi/scripts/install_coverage_tools.sh
@@ -3,6 +3,9 @@
 # Installs cargo-llvm-cov used by the coverage proofing stage.
 set -euo pipefail
 
+# cargo-llvm-cov needs the llvm-tools-preview rustup component.
+rustup component add llvm-tools-preview || echo "llvm-tools-preview unavailable on this toolchain"
+
 if command -v cargo-llvm-cov >/dev/null 2>&1; then
     echo "cargo-llvm-cov already installed: $(cargo-llvm-cov --version)"
     exit 0

--- a/.pi/scripts/local-ci.sh
+++ b/.pi/scripts/local-ci.sh
@@ -215,6 +215,14 @@ if should_run "security"; then
 fi
 
 # ═════════════════════════════════════════════════════════════════
+# ═════════════════════════════════════════════════════════════════
+# Stage 4b: Coverage (real line-coverage measurement via cargo-llvm-cov)
+# ═════════════════════════════════════════════════════════════════
+if should_run "coverage"; then
+    header "Stage 4b: Coverage"
+    run_cmd "coverage (workspace, gated >=${COVERAGE_THRESHOLD:-60}%)" bash .pi/scripts/coverage.sh --gate
+fi
+
 # Stage 5: Documentation
 # ═════════════════════════════════════════════════════════════════
 if should_run "docs"; then

--- a/engine/.pi/architecture/gap-ledger.md
+++ b/engine/.pi/architecture/gap-ledger.md
@@ -344,7 +344,7 @@ All other rows **validated correct**:
 | M-09 | ✅ **RESOLVED** | 7 mcp ADRs + engine ADR-010 statused with code evidence. **Honest verdicts:** ADR-002 = **Superseded** (SQLx never adopted — 0 deps); ADR-006 = **Partial** (engine-delegated usage yes; proxy telemetry not implemented); ADR-004/005 qualified (SSE removed, GAP-A-10) |
 | M-03 | ✅ **RESOLVED** | `engine/deny.toml` exists (claim said repo root — corrected to actual location) |
 | M-04 | ✅ **RESOLVED** | `.githooks/pre-commit` restored: `cargo fmt --check` + `cargo clippy --workspace --all-targets -D warnings` |
-| L-06 | ✅ **RESOLVED** | `.pi/scripts/install_coverage_tools.sh` restored (cargo-llvm-cov installer) |
+| L-06 | ✅ **RESOLVED** | `.pi/scripts/install_coverage_tools.sh` restored **and wired**: real workspace coverage via `cargo llvm-cov` (`.pi/scripts/coverage.sh`) runs in local-ci (Stage 4b) + a dedicated CI job — baseline **78.92% line coverage**, gated ≥60% |
 | A-26 | ✅ **Evidence corrected** | No `[[bin]]` exists in cli/Cargo.toml (prior evidence was fictional); README→`rigorix-cli` fix stands |
 | M-12 | ✅ **ALREADY FIXED (missed by re-verification)** | `evidence_degraded: !input.sign` + `test_evidence_degraded_marker` landed in 5eb95f43 (#761), ancestor of HEAD. The re-verification's grep (`evidence: degraded` with colon) missed the underscore field name; the independent Validation section caught it. Unnecessary tracking issue #776 closed |
 | A-25 | ✅ verdict stands | 1 bounded poll-sleep remains in `mcp/tests/common/mod.rs:109` (deadline-loop interval) — the intended replacement for fixed sleeps |


### PR DESCRIPTION
ci: wire real coverage measurement into CI — the number now exists (#4)

The tooling existed but the number didn't: the per-crate `*_coverage.sh`
scripts are heuristic grep checks (test counts, entity mentions) and ci.yml
explicitly skipped them. No actual line-coverage was ever measured.

- .pi/scripts/coverage.sh (new): workspace coverage via cargo llvm-cov.
  Baseline: **78.92% line coverage** (81,689 lines, 17,222 uncovered;
  branches 75.27%). Supports --gate (COVERAGE_THRESHOLD, default 60% —
  a conservative floor ~19 pts under baseline) and --lcov (artifact).
- local-ci.sh: Stage 4b runs coverage.sh --gate → local-ci now 85 steps.
- ci.yml: new 📊 Coverage job (after test) — installs llvm-tools-preview +
  cargo-llvm-cov via install_coverage_tools.sh (updated to add the rustup
  component), runs the gated measurement, uploads target/coverage.lcov.
- Ledger L-06 updated: restored → wired.

Verified: local-ci 85/85; coverage 78.92%, gate passes.
