### PR TITLE
refactor: M-15 canonicalize ExecutionState node-state persistence (#758)

### DIFF
--- a/engine/.pi/architecture/gap-ledger.md
+++ b/engine/.pi/architecture/gap-ledger.md
@@ -349,6 +349,6 @@ All other rows **validated correct**:
 | M-12 | ✅ **ALREADY FIXED (missed by re-verification)** | `evidence_degraded: !input.sign` + `test_evidence_degraded_marker` landed in 5eb95f43 (#761), ancestor of HEAD. The re-verification's grep (`evidence: degraded` with colon) missed the underscore field name; the independent Validation section caught it. Unnecessary tracking issue #776 closed |
 | A-25 | ✅ verdict stands | 1 bounded poll-sleep remains in `mcp/tests/common/mod.rs:109` (deadline-loop interval) — the intended replacement for fixed sleeps |
 | L-08-global | ⬜ **Deferred** → issue #777 (backlog) | global unwrap elimination, beyond the #751 path scope |
-| M-15 | ⬜ **Deferred** → issue #758 (approval epic) | consolidate node-state vocabularies when `approval_records` lands in the state format |
+| M-15 | ✅ **RESOLVED (#758)** | canonicalize: `exec_node_states` is the single persisted representation (coarse `node_states` → `#[serde(skip_serializing)]` derived view rebuilt on hydrate; final states now persist exec states too; `update_node_state` syncs into exec). Full API removal still rides the approval epic's `approval_records` format change |
 
 **Remaining open after batch 21:** deferred to approval epic: M-15 (#758) · backlog: L-08-global (#777). All A-rows + M-09/M-03/M-04/L-06/M-12 resolved.

--- a/engine/src/orchestrator/application/orchestrator_impl.rs
+++ b/engine/src/orchestrator/application/orchestrator_impl.rs
@@ -296,7 +296,16 @@ impl OrchestratorServiceImpl {
         state_dto::SaveStateInput { state }
     }
 
-    fn make_final_state(execution_id: Uuid, status: ExecutionStatus) -> state_dto::SaveStateInput {
+    fn make_final_state(
+        execution_id: Uuid,
+        status: ExecutionStatus,
+        exec_states: Option<
+            &std::collections::HashMap<
+                uuid::Uuid,
+                crate::execution_engine::domain::NodeExecutionState,
+            >,
+        >,
+    ) -> state_dto::SaveStateInput {
         use crate::state_persistence::domain::ExecutionStatus as SpStatus;
         let sp_status = match status {
             ExecutionStatus::Completed => SpStatus::Completed,
@@ -309,6 +318,10 @@ impl OrchestratorServiceImpl {
             crate::state_persistence::domain::ExecutionState::new(execution_id, String::new());
         state.status = sp_status;
         state.completed_at = Some(chrono::Utc::now());
+        // GAP-M-15: exec_node_states is the single persisted node-state
+        // representation — final states persist it too (pause states already
+        // did), so every state file carries the canonical vocabulary.
+        state.exec_node_states = exec_states.cloned();
         state_dto::SaveStateInput { state }
     }
 
@@ -711,9 +724,10 @@ impl OrchestratorService for OrchestratorServiceImpl {
             }
         };
 
-        // 7. Save final state
+        // 7. Save final state (legacy single-flow path — no parallel
+        // execution-state map in scope, so None for exec_node_states)
         self.state_manager
-            .save_state(Self::make_final_state(execution_id, final_status))
+            .save_state(Self::make_final_state(execution_id, final_status, None))
             .await
             .map_err(|e| OrchestratorError::StatePersistenceFailed {
                 detail: e.to_string(),
@@ -1007,6 +1021,7 @@ impl OrchestratorService for OrchestratorServiceImpl {
             .save_state(Self::make_final_state(
                 input.execution_id,
                 ExecutionStatus::Cancelled,
+                None,
             ))
             .await
             .map_err(|e| OrchestratorError::StatePersistenceFailed {
@@ -1270,7 +1285,11 @@ impl OrchestratorService for OrchestratorServiceImpl {
                 .await
         } else {
             self.state_manager
-                .save_state(Self::make_final_state(execution_id, final_status))
+                .save_state(Self::make_final_state(
+                    execution_id,
+                    final_status,
+                    Some(&exec_output.result.execution_states),
+                ))
                 .await
         };
         save_out.map_err(|e| OrchestratorError::StatePersistenceFailed {

--- a/engine/src/state_persistence/application/state_manager_service_impl.rs
+++ b/engine/src/state_persistence/application/state_manager_service_impl.rs
@@ -69,6 +69,9 @@ impl StateManagerService for FileSystemStateManager {
 
         // GAP-M-01: invalidate legacy pre-GAP-3 approvals on hydrate.
         state.invalidate_legacy_approvals();
+        // GAP-M-15: node_states is derived — rebuild it from the canonical
+        // exec_node_states map (single persisted representation).
+        state.derive_node_states_from_exec();
 
         Ok(LoadStateOutput {
             state,
@@ -82,6 +85,8 @@ impl StateManagerService for FileSystemStateManager {
     ) -> Result<NodeStateChangedOutput, StateError> {
         // Load current state
         let mut state = self.repository.load(input.execution_id).await?;
+        // GAP-M-15: coarse is derived — rebuild from the canonical exec map.
+        state.derive_node_states_from_exec();
 
         // Apply the state transition based on new_status
         let node_id = input.node_id;
@@ -114,6 +119,10 @@ impl StateManagerService for FileSystemStateManager {
                 execution_id: input.execution_id.to_string(),
             })?
             .clone();
+
+        // GAP-M-15: coarse is a derived view — mirror the transition into the
+        // canonical exec_node_states map so it survives save/load.
+        state.sync_exec_from_node_states();
 
         // Save the updated state
         self.repository.save(&state).await?;
@@ -223,6 +232,15 @@ mod tests {
         assert!(matches!(result, Err(StateError::StateNotFound { .. })));
     }
 
+    /// GAP-M-15: seed the canonical exec_node_states representation (the
+    /// coarse map is derived and no longer persisted).
+    fn seed_exec_state(state: &mut ExecutionState, node_id: Uuid, name: &str) {
+        use crate::execution_engine::domain::NodeExecutionState;
+        let mut exec = std::collections::HashMap::new();
+        exec.insert(node_id, NodeExecutionState::new(node_id, name));
+        state.exec_node_states = Some(exec);
+    }
+
     #[tokio::test]
     async fn test_update_node_state_to_in_progress() {
         let (manager, _dir) = create_manager().await;
@@ -232,7 +250,7 @@ mod tests {
         // Save initial state with node
         let mut state = ExecutionState::new(execution_id, "hash".to_string());
         state.status = ExecutionStatus::Running;
-        state.init_node_states(&[node_id]);
+        seed_exec_state(&mut state, node_id, "test-node");
         manager.save_state(SaveStateInput { state }).await.unwrap();
 
         // Update node to in progress
@@ -259,10 +277,21 @@ mod tests {
 
         let mut state = ExecutionState::new(execution_id, "hash".to_string());
         state.status = ExecutionStatus::Running;
-        state.init_node_states(&[node_id]);
-        // Transition to in progress first
-        state.node_started(node_id).unwrap();
+        seed_exec_state(&mut state, node_id, "test-node");
         manager.save_state(SaveStateInput { state }).await.unwrap();
+
+        // Pending -> InProgress -> Completed (two-step, mirrors the lifecycle)
+        manager
+            .update_node_state(NodeStateChangedInput {
+                execution_id,
+                node_id,
+                new_status: NodeStatus::InProgress,
+                output: None,
+                error: None,
+                duration_ms: None,
+            })
+            .await
+            .unwrap();
 
         let output = manager
             .update_node_state(NodeStateChangedInput {
@@ -289,9 +318,21 @@ mod tests {
 
         let mut state = ExecutionState::new(execution_id, "hash".to_string());
         state.status = ExecutionStatus::Running;
-        state.init_node_states(&[node_id]);
-        state.node_started(node_id).unwrap();
+        seed_exec_state(&mut state, node_id, "test-node");
         manager.save_state(SaveStateInput { state }).await.unwrap();
+
+        // Pending -> InProgress -> Failed (two-step, mirrors the lifecycle)
+        manager
+            .update_node_state(NodeStateChangedInput {
+                execution_id,
+                node_id,
+                new_status: NodeStatus::InProgress,
+                output: None,
+                error: None,
+                duration_ms: None,
+            })
+            .await
+            .unwrap();
 
         let output = manager
             .update_node_state(NodeStateChangedInput {

--- a/engine/src/state_persistence/domain/state.rs
+++ b/engine/src/state_persistence/domain/state.rs
@@ -155,9 +155,14 @@ pub struct ExecutionState {
     /// `None` while the execution is still running.
     pub completed_at: Option<DateTime<Utc>>,
 
-    /// Per-node states keyed by node UUID.
+    /// Per-node states keyed by node UUID — **derived view** (GAP-M-15).
     ///
-    /// Uses `IndexMap` for deterministic serialization order.
+    /// Not persisted: `exec_node_states` is the single persisted node-state
+    /// representation. On hydrate this map is rebuilt from `exec_node_states`
+    /// (`derive_node_states_from_exec`); legacy pre-GAP-3 files that carry
+    /// `node_states` in JSON (and no `exec_node_states`) still deserialize
+    /// into it for backward compatibility.
+    #[serde(skip_serializing, default)]
     pub node_states: IndexMap<Uuid, NodeState>,
 
     /// SHA-256 hash of the symbol graph state at execution start.
@@ -217,6 +222,64 @@ impl ExecutionState {
     pub fn invalidate_legacy_approvals(&mut self) {
         if self.exec_node_states.is_none() && !self.approved.is_empty() {
             self.approved.clear();
+        }
+    }
+
+    /// GAP-M-15: rebuild the derived coarse `node_states` view from the
+    /// canonical `exec_node_states` map.
+    ///
+    /// When `exec_node_states` is present (GAP-3+ files) it is authoritative:
+    /// coarse statuses are mapped from the execution-engine vocabulary
+    /// (Pending/Ready -> Pending, Running/AwaitingApproval -> InProgress,
+    /// Completed/Failed/Skipped as-is). When it is `None` (legacy files) the
+    /// map is left untouched so coarse data deserialized from legacy JSON
+    /// remains available.
+    pub fn derive_node_states_from_exec(&mut self) {
+        use crate::execution_engine::domain::NodeStatus as ExecStatus;
+        let Some(exec_states) = &self.exec_node_states else {
+            return;
+        };
+        self.node_states.clear();
+        for (node_id, exec) in exec_states {
+            let mut ns = NodeState::new(*node_id);
+            ns.status = match exec.status {
+                ExecStatus::Pending | ExecStatus::Ready => NodeStatus::Pending,
+                ExecStatus::Running | ExecStatus::AwaitingApproval => NodeStatus::InProgress,
+                ExecStatus::Completed => NodeStatus::Completed,
+                ExecStatus::Failed => NodeStatus::Failed,
+                ExecStatus::Skipped => NodeStatus::Skipped,
+            };
+            ns.error = exec.last_error.clone();
+            ns.retries = exec.retry_attempts;
+            ns.duration_ms = exec.last_duration_ms;
+            self.node_states.insert(*node_id, ns);
+        }
+    }
+
+    /// GAP-M-15: mirror the derived coarse `node_states` back into the
+    /// canonical `exec_node_states` map before persisting (used by the
+    /// `update_node_state` service so its coarse transition survives a
+    /// save/load round trip).
+    pub fn sync_exec_from_node_states(&mut self) {
+        use crate::execution_engine::domain::NodeStatus as ExecStatus;
+        let exec = self.exec_node_states.get_or_insert_with(Default::default);
+        for (node_id, ns) in self.node_states.iter() {
+            let entry = exec.entry(*node_id).or_insert_with(|| {
+                crate::execution_engine::domain::NodeExecutionState::new(
+                    *node_id,
+                    ns.node_id.to_string(),
+                )
+            });
+            entry.status = match ns.status {
+                NodeStatus::Pending => ExecStatus::Pending,
+                NodeStatus::InProgress => ExecStatus::Running,
+                NodeStatus::Completed => ExecStatus::Completed,
+                NodeStatus::Failed => ExecStatus::Failed,
+                NodeStatus::Skipped => ExecStatus::Skipped,
+            };
+            entry.last_error = ns.error.clone();
+            entry.retry_attempts = ns.retries;
+            entry.last_duration_ms = ns.duration_ms;
         }
     }
 

--- a/engine/src/state_persistence/infrastructure/filesystem_state_repository.rs
+++ b/engine/src/state_persistence/infrastructure/filesystem_state_repository.rs
@@ -198,30 +198,28 @@ impl StateRepository for FileSystemStateRepository {
 mod tests {
     use super::*;
 
-    use indexmap::IndexMap;
     use tempfile::TempDir;
 
-    use crate::state_persistence::domain::{ExecutionStatus, NodeState, NodeStatus};
+    use crate::state_persistence::domain::ExecutionStatus;
 
     fn create_test_state(execution_id: Uuid) -> ExecutionState {
+        // GAP-M-15: seed the canonical exec_node_states vocabulary (coarse is
+        // derived and no longer persisted).
+        use crate::execution_engine::domain::{NodeExecutionState, NodeStatus as ExecStatus};
         let mut state = ExecutionState::new(execution_id, "test_hash_123".to_string());
         state.status = ExecutionStatus::Running;
 
-        let mut node_states = IndexMap::new();
         let node_id_1 = Uuid::new_v4();
         let node_id_2 = Uuid::new_v4();
 
-        let mut node1 = NodeState::new(node_id_1);
-        node1.status = NodeStatus::Completed;
-        node1.output = Some("test output".to_string());
-        node1.duration_ms = Some(100);
-
-        let mut node2 = NodeState::new(node_id_2);
-        node2.status = NodeStatus::Pending;
-
-        node_states.insert(node_id_1, node1);
-        node_states.insert(node_id_2, node2);
-        state.node_states = node_states;
+        let mut exec = std::collections::HashMap::new();
+        let mut n1 = NodeExecutionState::new(node_id_1, "node1");
+        n1.status = ExecStatus::Completed;
+        n1.last_duration_ms = Some(100);
+        let n2 = NodeExecutionState::new(node_id_2, "node2"); // Pending
+        exec.insert(node_id_1, n1);
+        exec.insert(node_id_2, n2);
+        state.exec_node_states = Some(exec);
 
         state
     }
@@ -242,10 +240,15 @@ mod tests {
 
         repo.save(&state).await.unwrap();
 
-        let loaded = repo.load(execution_id).await.unwrap();
+        let mut loaded = repo.load(execution_id).await.unwrap();
         assert_eq!(loaded.execution_id, execution_id);
         assert_eq!(loaded.status, ExecutionStatus::Running);
         assert_eq!(loaded.symbol_graph_hash, "test_hash_123");
+        // GAP-M-15: the persisted vocabulary is exec_node_states; coarse is
+        // derived on demand (manager.load_state does this automatically).
+        assert_eq!(loaded.exec_node_states.as_ref().map(|m| m.len()), Some(2));
+        assert!(loaded.node_states.is_empty());
+        loaded.derive_node_states_from_exec();
         assert_eq!(loaded.node_states.len(), 2);
     }
 

--- a/engine/src/state_persistence/serialization_tests.rs
+++ b/engine/src/state_persistence/serialization_tests.rs
@@ -10,37 +10,60 @@ use crate::state_persistence::domain::{ExecutionState, ExecutionStatus, NodeStat
 use uuid::Uuid;
 
 fn sample_state() -> ExecutionState {
+    // GAP-M-15: exec_node_states is the persisted node-state vocabulary.
     let mut state = ExecutionState::new(Uuid::new_v4(), "hash-v1".to_string());
     let node_id = Uuid::new_v4();
-    state.init_node_states(&[node_id]);
-    state.node_started(node_id).unwrap();
-    state
-        .node_completed(node_id, Some("output".to_string()), 10)
-        .unwrap();
+    let mut exec = crate::execution_engine::domain::NodeExecutionState::new(node_id, "sample");
+    exec.status = crate::execution_engine::domain::NodeStatus::Completed;
+    exec.last_duration_ms = Some(10);
+    let mut map = std::collections::HashMap::new();
+    map.insert(node_id, exec);
+    state.exec_node_states = Some(map);
     state
 }
 
 #[test]
 fn test_full_state_serialize_deserialize_round_trip() {
     let mut state = sample_state();
-    let node_id = *state.node_states.keys().next().unwrap();
+    let node_id = *state
+        .exec_node_states
+        .as_ref()
+        .expect("sample_state seeds exec")
+        .keys()
+        .next()
+        .unwrap();
     state.status = ExecutionStatus::Completed;
     state.completed_at = Some(chrono::Utc::now());
     state.approved = vec![node_id];
 
     let json = serde_json::to_string(&state).unwrap();
-    let back: ExecutionState = serde_json::from_str(&json).unwrap();
+    // GAP-M-15: coarse node_states is NOT serialized (derived view) — the
+    // persisted representation is exec_node_states.
+    // NB: "exec_node_states" contains the substring — check the exact key form.
+    assert!(
+        !json.contains("\"node_states\":"),
+        "coarse map must not be persisted"
+    );
+    assert!(
+        json.contains("exec_node_states"),
+        "exec map must be persisted"
+    );
+    let mut back: ExecutionState = serde_json::from_str(&json).unwrap();
 
     assert_eq!(back.execution_id, state.execution_id);
     assert_eq!(back.status, ExecutionStatus::Completed);
     assert_eq!(back.symbol_graph_hash, "hash-v1");
     assert_eq!(back.approved, vec![node_id]);
+    // Coarse is empty until derived from the canonical exec map.
+    assert!(back.node_states.is_empty());
+    back.derive_node_states_from_exec();
     assert_eq!(back.node_states.len(), 1);
     let node = back.node_states.get(&node_id).unwrap();
     assert_eq!(
         node.status,
         crate::state_persistence::domain::NodeStatus::Completed
     );
+    assert_eq!(node.duration_ms, Some(10));
     assert!(back.completed_at.is_some());
 }
 
@@ -99,7 +122,13 @@ fn test_legacy_approved_invalidated_on_hydrate_migration_rule() {
 fn test_gap3_state_preserves_approved_on_hydrate() {
     // GAP-3+ files carry exec_node_states — their approved set is preserved.
     let mut state = sample_state();
-    let node_id = *state.node_states.keys().next().unwrap();
+    let node_id = *state
+        .exec_node_states
+        .as_ref()
+        .expect("sample_state seeds exec")
+        .keys()
+        .next()
+        .unwrap();
     state.approved = vec![node_id];
     state.exec_node_states = Some(std::collections::HashMap::new());
 

--- a/mcp/src/template_tools/infrastructure/filesystem_repository.rs
+++ b/mcp/src/template_tools/infrastructure/filesystem_repository.rs
@@ -733,7 +733,8 @@ mod tests {
             author: None,
         };
 
-        let plan = engine_template_to_plan_template(&engine_tmpl).expect("valid engine template converts");
+        let plan =
+            engine_template_to_plan_template(&engine_tmpl).expect("valid engine template converts");
         let steps = plan.steps();
         assert_eq!(steps.len(), 2);
         assert!(


### PR DESCRIPTION
refactor: M-15 canonicalize ExecutionState node-state persistence (#758)

Coarse `node_states` was prod-dead: the orchestrator persist path never
populated it (always-empty map), resume read only `exec_node_states`, and
summaries reported node_count: 0 on real runs. The execution-engine
NodeStatus vocabulary (Pending/Ready/Running/AwaitingApproval/Completed/
Failed/Skipped) is a superset of the coarse one.

Consolidation (single persisted representation, tests preserved+corrected):
- `exec_node_states` is canonical; coarse `node_states` is now a
  #[serde(skip_serializing, default)] DERIVED view — not written to state
  files. Legacy files that carry coarse JSON still deserialize (backward
  compat); new files carry only the exec vocabulary.
- ExecutionState::derive_node_states_from_exec(): rebuilds coarse from exec
  on hydrate (status mapping Pending/Ready→Pending, Running/AwaitingApproval
  →InProgress, else direct; error/retries/duration mirrored).
- ExecutionState::sync_exec_from_node_states(): mirrors coarse transitions
  back into exec so update_node_state mutations survive save/load.
- load_state + update_node_state derive on load.
- Final states now persist exec_node_states too (make_final_state takes the
  result map) — previously only approval-pause states did; every state file
  now carries the canonical vocabulary (run()/cancel paths pass None where
  no parallel exec-state map exists).
- node_count/status_summary now report REAL numbers on hydrated states.

Tests corrected (not deleted) to the canonical vocabulary:
- state_manager update_node_state tests seed exec + two-step lifecycle
- serialization round-trip asserts exec persisted / coarse derived (and the
  substring gotcha: "exec_node_states" contains "node_states")
- filesystem repo roundtrip asserts exec len + derives coarse

Verified: engine 2084 / mcp 227 / cli 80 / actions 456; clippy clean.
Ledger M-15 → resolved (full API removal still rides approval_records).
