### PR TITLE
chore: release prep — bump crates to 1.3.0

### DIFF
--- a/actions/Cargo.toml
+++ b/actions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rigorix-actions"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2024"
 description = "GitHub Actions integration for Rigorix — thin adapter over rigorix-engine"
 license = "MIT OR Apache-2.0"
@@ -12,7 +12,7 @@ name = "rigorix-action"
 path = "src/main.rs"
 
 [dependencies]
-rigorix-engine = { path = "../engine", version = "1.2.0" }
+rigorix-engine = { path = "../engine", version = "1.3.0" }
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml = "0.9"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rigorix-cli"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2024"
 description = "Template-driven DAG execution CLI — thin wrapper around rigorix-engine"
 license = "MIT OR Apache-2.0"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/rigorix-cli"
 name = "rigorix"
 
 [dependencies]
-rigorix-engine = { path = "../engine", version = "1.2.0" }
+rigorix-engine = { path = "../engine", version = "1.3.0" }
 serde.workspace = true
 serde_json.workspace = true
 toml.workspace = true

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rigorix-engine"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2024"
 description = "Template-driven DAG execution engine with bounded autonomy"
 license = "MIT OR Apache-2.0"

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rigorix-mcp"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2024"
 description = "MCP Gateway server for Rigorix — protocol types, transports, session management, tool routing, resource/prompt providers"
 license = "MIT OR Apache-2.0"
@@ -27,7 +27,7 @@ hmac = { workspace = true }
 sha2 = { workspace = true }
 
 # rigorix-engine for execution orchestration
-rigorix-engine = { path = "../engine", version = "1.2.0" }
+rigorix-engine = { path = "../engine", version = "1.3.0" }
 
 # HTTP client for enterprise proxy
 reqwest = { workspace = true }


### PR DESCRIPTION
chore: release prep — bump crates to 1.3.0

All four crates 1.2.0 -> 1.3.0 (workspace feature work since 1.2.0:
batches 8-21 — governance mode, scored-eval backend selection, repository
implementations, session handshake/negotiation, hooks async, L-08 unwrap
hygiene, M-15 state-format canonicalization). Internal path deps synced.

Note: 1.x consumers are unaffected unless they read state files across
versions (M-15: legacy files still hydrate) or relied on the removed
execute_graph no-graph placeholder.
