### PR TITLE
fix(repo): restore guardian-manifest.json tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,9 +88,7 @@ mcp/.rigorix/
 # Guardian pipeline/epic state + manifests
 .guardian-*.json
 .guardian-kanban.json
-guardian-manifest.json
 **/.guardian-*.json
-**/guardian-manifest.json
 
 # CLI runtime state + demo media
 cli/.rigorix/state/

--- a/actions/guardian-manifest.json
+++ b/actions/guardian-manifest.json
@@ -1,0 +1,973 @@
+{
+  "schemaVersion": "0.1",
+  "frameworkVersion": "0.1.0",
+  "source": "pi",
+  "tools": [
+    "pi"
+  ],
+  "language": "rust",
+  "repoTool": "gh",
+  "archMode": "strict",
+  "groupId": "com.rigorix-oss",
+  "validators": [
+    "ci",
+    "tests",
+    "security",
+    "operations",
+    "integration",
+    "architecture",
+    "canonical"
+  ],
+  "workflows": [
+    "feature-development",
+    "bug-fix",
+    "hotfix",
+    "refactoring",
+    "issue-implementation-series",
+    "epic-plan",
+    "issue-draft",
+    "git-issues",
+    "issue-closeout",
+    "issue-merge",
+    "plan-to-issues",
+    "blueprint-validate",
+    "sync-check",
+    "context-refresh",
+    "scope-analyzer",
+    "pattern-extract",
+    "blueprint-update"
+  ],
+  "files": {
+    ".pi/context/checklists.md": {
+      "category": "framework",
+      "originalHash": "sha256:8f3e52628b0d1abe439d84f3b29848c4141110c485e2d42dd7ae0fb0fd234806",
+      "status": "unchanged"
+    },
+    ".pi/context/domain-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:f92b43bdc715fd5cd8d3ab292c236e705e1ad155e58cb343efe4c6605eacd717",
+      "status": "unchanged"
+    },
+    ".pi/context/project.md": {
+      "category": "user",
+      "originalHash": "sha256:2dd4ff55bd49f0524108fbcbb344acfce74eb7d66772a212261b505880b1b019",
+      "status": "unchanged"
+    },
+    ".pi/context/patterns.md": {
+      "category": "user",
+      "originalHash": "sha256:51a1ffa9ad2fc4631fa3b15d60da3a66414d1457ccd523c1a0866592bb373c30",
+      "status": "unchanged"
+    },
+    ".pi/context/output-formats.md": {
+      "category": "framework",
+      "originalHash": "sha256:57700883af3a4bac040a49c7a00e34040ef64fe66fe45502fa44dd6a49dada1f",
+      "status": "unchanged"
+    },
+    ".pi/context/patterns-base.md": {
+      "category": "framework",
+      "originalHash": "sha256:8d9bf4d5c7ab81f060b0fadf8138cbb615b26119860988215f2ebd405c42bd1e",
+      "status": "unchanged"
+    },
+    ".pi/workpad.md": {
+      "category": "framework",
+      "originalHash": "sha256:c15373fbf3ad0317a1281066c7605a9f2c0823c1a3c5e946e0620b808c6bf67b",
+      "status": "unchanged"
+    },
+    ".pi/agents/issue-factory.md": {
+      "category": "framework",
+      "originalHash": "sha256:8e1d2a8211e7634736c51f6fe5af2ae48d3263a39d54ddc7cb23c9183537ae06",
+      "status": "unchanged"
+    },
+    ".pi/agents/architecture-coordinator.md": {
+      "category": "framework",
+      "originalHash": "sha256:0449f8b3d33b1d479e0699303eea0e6c6d512f38972e99cb1b8c0da0f7b37f8c",
+      "status": "unchanged"
+    },
+    ".pi/agents/bootstrap-implementer.md": {
+      "category": "framework",
+      "originalHash": "sha256:77662fa88c70fe139f7ff526c8763a3226d7dff6c249081a7a63d02e1ac72041",
+      "status": "unchanged"
+    },
+    ".pi/agents/operations-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:e64c119a9f0fc7c9fcebf813f47bd43b091c8049a6fd32a2789da69ec1c1fbde",
+      "status": "unchanged"
+    },
+    ".pi/agents/security-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:6cd0cd853582cb8f60d27c7bb9e339977928a07f3b4fb8fb66bf894bd6fad728",
+      "status": "unchanged"
+    },
+    ".pi/agents/architecture-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:3fbae65130cbb256e5be0c0e3b784de9fd681a9a54629bb270617e29886fcc9c",
+      "status": "unchanged"
+    },
+    ".pi/agent/AGENTS.md": {
+      "category": "user",
+      "originalHash": "sha256:240369371efe62367c638e1e094896657de40d09b80303ce953878345c517968",
+      "status": "unchanged"
+    },
+    ".pi/extensions/curator.ts": {
+      "category": "framework",
+      "originalHash": "sha256:7cebd53167de7c68d0b776be1ed878808f04035104125ebb8222e15367708f83",
+      "status": "unchanged"
+    },
+    ".pi/extensions/session-persistence.ts": {
+      "category": "framework",
+      "originalHash": "sha256:8994200dabf4502b4c315278cb995b9195f5060bfd7f416ba0eb1ed74008d66e",
+      "status": "unchanged"
+    },
+    ".pi/extensions/domain-explorer.ts": {
+      "category": "framework",
+      "originalHash": "sha256:cf02dd7d2a9f6a79aadf0e4ad21f65eaa8630b966620c52f1f0b99e5657a4e22",
+      "status": "unchanged"
+    },
+    ".pi/extensions/kanban.ts": {
+      "category": "framework",
+      "originalHash": "sha256:ae324cea4192f38295469343d1c841e7b4cfa33a4887cde176c873c128c7a605",
+      "status": "unchanged"
+    },
+    ".pi/extensions/project-scaffolder.ts": {
+      "category": "framework",
+      "originalHash": "sha256:a30e79c81a5f373401a038fdd87d313761d3ce933cb5dee6789e0e2842ecaa74",
+      "status": "unchanged"
+    },
+    ".pi/extensions/snippets.ts": {
+      "category": "framework",
+      "originalHash": "sha256:30d157510a72a2f5dd0ebbbe706ebfa780131eb397e2d1091c88f1b7f067ec68",
+      "status": "unchanged"
+    },
+    ".pi/extensions/read-only-mode.ts": {
+      "category": "framework",
+      "originalHash": "sha256:a579d34865fee1d53fec4d7218e905cfc3b1e08c8fafa1492a2532140f910f1e",
+      "status": "unchanged"
+    },
+    ".pi/extensions/slash-commands.ts": {
+      "category": "framework",
+      "originalHash": "sha256:e60a12667b22dd287b2da0969df554f3d8e40a7be12e85c122232310057f075f",
+      "status": "unchanged"
+    },
+    ".pi/extensions/config-reload.ts": {
+      "category": "framework",
+      "originalHash": "sha256:702c33e12f62867cadce1eeb8e94c98a491cc8b048bd88c6031daee514b957c7",
+      "status": "unchanged"
+    },
+    ".pi/extensions/pipeline.ts": {
+      "category": "framework",
+      "originalHash": "sha256:0b77763e1c78aed36fcd3710edeafb9fa8ea6ae6e101ef16a0510e32f0789982",
+      "status": "unchanged"
+    },
+    ".pi/extensions/bash-guard.ts": {
+      "category": "framework",
+      "originalHash": "sha256:0af4981f5c6235b2182f2d2aff6b7b0f1377835e6c8a7ff33a93d346b1a693c6",
+      "status": "unchanged"
+    },
+    ".pi/extensions/validation-runner.ts": {
+      "category": "framework",
+      "originalHash": "sha256:c0352feda293f89c0b1757a592c0a8341ce30274666876474ffe804d46214793",
+      "status": "unchanged"
+    },
+    ".pi/extensions/architect.ts": {
+      "category": "framework",
+      "originalHash": "sha256:e7b6d379a62c61b108341c1c0b792f90c01b9fed22e00fa27723ecc31fda55f0",
+      "status": "unchanged"
+    },
+    ".pi/extensions/architect-lib/helpers.ts": {
+      "category": "framework",
+      "originalHash": "sha256:ca513317f5bb7427f627752185df3c912cff8e2bd714ebc9dccb26535524f94a",
+      "status": "unchanged"
+    },
+    ".pi/extensions/architect-lib/generators.ts": {
+      "category": "framework",
+      "originalHash": "sha256:942c1b7061dfbfb0443484cb853b7f38641bdf4acf6f414a358d2d15ff03fe96",
+      "status": "unchanged"
+    },
+    ".pi/extensions/architect-lib/types.ts": {
+      "category": "framework",
+      "originalHash": "sha256:d4c9206f10fd179d7e312039ee3a7b4b51363d90d7a6f9c1b9898a306082f535",
+      "status": "unchanged"
+    },
+    ".pi/extensions/ask-user-question.ts": {
+      "category": "framework",
+      "originalHash": "sha256:983057f59aa40647f11c0703f1b9393e780900e23c67be0e579881d1c6729edb",
+      "status": "unchanged"
+    },
+    ".pi/extensions/filechanges.ts": {
+      "category": "framework",
+      "originalHash": "sha256:411094739728d704423b287f54dd4d265c5aab3346bb90f7f638b856aaebe244",
+      "status": "unchanged"
+    },
+    ".pi/extensions/hooks.ts": {
+      "category": "framework",
+      "originalHash": "sha256:46fa45dd6b3d7db55208fdf5e28001fd2d5e6a53570f38d78eee57537b96bf48",
+      "status": "unchanged"
+    },
+    ".pi/extensions/coordinator.ts": {
+      "category": "framework",
+      "originalHash": "sha256:070df0ef9fdb429cd284d8c7a6f3fbe1ba7f92927bf0128a941bf6d6a0f10d6e",
+      "status": "unchanged"
+    },
+    ".pi/extensions/goal-loop.ts": {
+      "category": "framework",
+      "originalHash": "sha256:6ed7949769ef9a36a7c0e023779279d8407b7a16867445c01b1102d13213688f",
+      "status": "unchanged"
+    },
+    ".pi/extensions/redaction.ts": {
+      "category": "framework",
+      "originalHash": "sha256:9f69807463e1bf305cd981e2ca18c432446ba67ffb83e8b5f518d9fdb1c691f2",
+      "status": "unchanged"
+    },
+    ".pi/extensions/plan-mode.ts": {
+      "category": "framework",
+      "originalHash": "sha256:6d0b1a68ec3c64127421b5eea7b3385790d870b69de291b24e6c967354e743d4",
+      "status": "unchanged"
+    },
+    ".pi/types.ts": {
+      "category": "framework",
+      "originalHash": "sha256:017a07fae90a46fca800dcb6b3ef19050570677c8a4a9672f85b238183f72ee4",
+      "status": "unchanged"
+    },
+    ".pi/architecture/CHANGELOG.md": {
+      "category": "framework",
+      "originalHash": "sha256:653bed6d8499cbf4b96598d1c3c6e0537989018b08654fc9422d50c85a8f20d6",
+      "status": "unchanged"
+    },
+    ".pi/architecture/diagrams/system-overview.md": {
+      "category": "framework",
+      "originalHash": "sha256:162cb1fa10bc933370390c9b37d64dcb4dad333e4ecef4e73c3d48e9d8ae91d3",
+      "status": "unchanged"
+    },
+    ".pi/architecture/decisions/ADR-template.md": {
+      "category": "framework",
+      "originalHash": "sha256:18e171fa061c7f8abd07b3b90a7d02f619bf1545124969203225f4bdd4b41531",
+      "status": "unchanged"
+    },
+    ".pi/architecture/modules/module-template.md": {
+      "category": "framework",
+      "originalHash": "sha256:4790f7bde099ad6ee10f11602ecfc281c6de4e775c7739500eb1260afc1fa849",
+      "status": "unchanged"
+    },
+    ".pi/github/instructions/architecture.instructions.md": {
+      "category": "framework",
+      "originalHash": "sha256:9f26ff4819db738887c1cdb9745537dadc43fc05ad788684b38dbc7a6dad17d5",
+      "status": "unchanged"
+    },
+    ".pi/github/instructions/validation.instructions.md": {
+      "category": "framework",
+      "originalHash": "sha256:934d64609f1275887a5c2795ce41d7d31fa5e8cf77cac35612d1b8685a44d28b",
+      "status": "unchanged"
+    },
+    ".pi/github/copilot/settings.json": {
+      "category": "framework",
+      "originalHash": "sha256:9e21c730edefe4080fee1014a02fbb96118aa300ea0f93563a53f9c6d9c4f2a1",
+      "status": "unchanged"
+    },
+    ".pi/github/workflows/01-planning-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:b7c13edf0d75fe2cc2a8784461637ec91a2bc894682768b6b208795f60a5d404",
+      "status": "unchanged"
+    },
+    ".pi/github/workflows/03-implementation-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:3b067bd1df93bb8de1eb26873825f2d5a330c46c619cb3209db127d33fde3ebb",
+      "status": "unchanged"
+    },
+    ".pi/github/workflows/04-validation-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:513bb31dd54f5961e221f71e5216fd1acde8ad0158f5523985bdad97a2bff8c8",
+      "status": "unchanged"
+    },
+    ".pi/github/workflows/02-issue-generation-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:41205400814e6d4b77ddbcf351d8e1f0701d11c618225eabf6ed3d3b630d56dd",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/architecture-validator.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:04e7cb86758e135b55abc556b9d043d6f68cd5566dd5b0a882cedc615fbde065",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/issue-factory.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:ef97de04d6f99a3b2edd04182ab8cf73a7da564b99d091f5c3d2056175fd686b",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/architecture-coordinator.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:9e376f5ba69f3fc30672b83e9792bb2cb961abc61d6fddda057a5df2ce398e0e",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/epic-planner.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:859599d908d8d1a5bc41d82eaea9414f147a1a16b8d37a99630f3d700f37c0ca",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/bootstrap-implementer.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:2a0b8f2d37ab6c9112d0fa0101429ad5afe3d2c39328b3d132eee1eeb454a3ee",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/security-validator.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:e9081be418d7f432fbd9b4a63d8181b44e797c93a8b6065ec330e2a5fa4b6109",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/operations-validator.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:464860fa7eabcad393471c8dc434268d2f55e72eda0889386abee02f88315ec3",
+      "status": "unchanged"
+    },
+    ".pi/github/copilot-instructions.md": {
+      "category": "framework",
+      "originalHash": "sha256:f82b95c50d87175e42851487b9c9f8891cfc1b5d74d784fdcbc2c4a221ddd19f",
+      "status": "unchanged"
+    },
+    ".pi/INDEX.md": {
+      "category": "framework",
+      "originalHash": "sha256:e166bc3e698236cbe4ef3fcca2f866c8ac2a28cd4ea293ca74c598a0dfea44ed",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-operations.sh": {
+      "category": "generated",
+      "originalHash": "sha256:4fb994c9056b90f565fe536633795586da3197a2a2b8f745baea9af8db4440d5",
+      "status": "unchanged"
+    },
+    ".pi/scripts/create-feature-branch.sh": {
+      "category": "framework",
+      "originalHash": "sha256:33ff4c76faba418025dbe88a998f2a04a6cafd282d11fc644a50de014cc580d0",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-architecture.sh": {
+      "category": "generated",
+      "originalHash": "sha256:241df1a4517e0a04aff9cfc4efddbdcb4b3859e65bd35cb8c558a172dfe7cf4d",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-ubiquitous-language.sh": {
+      "category": "framework",
+      "originalHash": "sha256:fdae16e0bf2030b87c9bb5263eceb73cd5510066bbe85d7925a35dd92a2a13f8",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:1ebac9c09ebfebc1e9cffdfa474c792f28bbe386a923ca49a0695bddee93df40",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/run_hardening_stages.sh": {
+      "category": "framework",
+      "originalHash": "sha256:8a67c21f7154e1cd4987f6e5e56dbbd476f3bf6d7846d4c167289008979d4a65",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_remaining.sh": {
+      "category": "framework",
+      "originalHash": "sha256:396b75ec9fb00224781e9eca66ac51a9ec7f05876d5175f80070560fdf629fe5",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/check_planning_packet.py": {
+      "category": "framework",
+      "originalHash": "sha256:214e1ce18ed2226f344f25687fde9dd586b061f1af8efd6f54c27bd09dabae67",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_package_build.sh": {
+      "category": "framework",
+      "originalHash": "sha256:67b0f705398369fb171c993c1e673f8cce16e4016cd6c1ca72c8996ce3bda7c4",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/validate_agent_output.py": {
+      "category": "framework",
+      "originalHash": "sha256:51cbdbed1921620608a25c2f4db67dbfd088a3d43cb96a03ec425c181d6ce4c9",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/run_preflight.sh": {
+      "category": "framework",
+      "originalHash": "sha256:137294de31aebfa339ae28ba878cb85720bdbe1b4298a2dd19ca184754bd67c4",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_migration_verify.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d25a4de5ddcb3946fca19e82828dd03f726d2084c71dbe4ecf0e222d1da1b67b",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_unit.sh": {
+      "category": "framework",
+      "originalHash": "sha256:64c8b8a4c6266725962b238a1c9814ea110c0f067e90ca9d38287a40074a5f19",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_release_readiness.sh": {
+      "category": "framework",
+      "originalHash": "sha256:0d62822ea089f0469e66561d501bf03cd5e9bb0dbedb199e0ca39286c3ffaa7c",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_docs_policy.sh": {
+      "category": "framework",
+      "originalHash": "sha256:8b13849d612e4dde20a43e3e2ef23c9279869c14683e29506213749e4f2e29ec",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/validate_agent_output.sh": {
+      "category": "framework",
+      "originalHash": "sha256:26816f935433df71266651dfe393c9ff3b7c3975426e05a93b7308c6fc3b80bf",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:a9617cd791ef4ebc72a519ca5169c287f94ba128e14c19f75a6db24267cf42ec",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/run_stage.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ade2b65032142b6f03fc08ed99828964c0bf6a7121d82969871ac963dac14fe1",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_lint.sh": {
+      "category": "framework",
+      "originalHash": "sha256:b5ce9794af4d271f7e04a82f6a35fe7e254d64ff4e71518cf201e4210c1b6560",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/check_architecture_conformance.sh": {
+      "category": "framework",
+      "originalHash": "sha256:eaee494fb728fdc422fa9d83b4c8abdbe52041bd31e53fa8ba85f91196ea765d",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_static_analysis.sh": {
+      "category": "framework",
+      "originalHash": "sha256:5d40980d65b39245bb3db064f0ae60b977b33cb0e7f86b0d211020cb894bafa7",
+      "status": "unchanged"
+    },
+    ".pi/scripts/merge-mr.sh": {
+      "category": "framework",
+      "originalHash": "sha256:726ff4212cf5097de646668bb2a48c0ff63de02cb0132686474f6dc91e047afb",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-architecture-readiness.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d460c6ccd94a3382d3fde7fff1e9d9f7c10abba76a3f6a3e41238283e81354d5",
+      "status": "unchanged"
+    },
+    ".pi/scripts/fetch-issues.sh": {
+      "category": "framework",
+      "originalHash": "sha256:e9b6c563b9d242e925de55bb120e667e69ed2e6d544a248828b6cc2d0cf514fe",
+      "status": "unchanged"
+    },
+    ".pi/scripts/categorize-issues.sh": {
+      "category": "framework",
+      "originalHash": "sha256:172e09a69b56e3b502d184f740c447f570647893f4658e2dd91451595f77dc93",
+      "status": "unchanged"
+    },
+    ".pi/scripts/create-mr.sh": {
+      "category": "framework",
+      "originalHash": "sha256:6670010595a85cbf518fb02d760c417922e480b27979351e418ec4bcd0571b29",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validation-cache.sh": {
+      "category": "generated",
+      "originalHash": "sha256:5fea93087bcd9852532ce8119f47ecdb61a46fd857b336e2955b087ed61aa3bd",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-operations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ab89729ca059bf5c51693c30dc088ea396c9e3cec282926eb20e0927d7c01c42",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:250210026e0e228def1481a26f9bfc85c032734edc867d1aa153ee5ea4b09e6d",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ce3a057d27fbdcffb0e8043aece29acceea9e9eb69e61dae276f6a7205bdbb8e",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-canonical.sh": {
+      "category": "framework",
+      "originalHash": "sha256:c0e145a8e1c16024062bf928945c2cd45c4d1c0a78c942e547a7f3f4ededc80b",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d27898b08963a4ddfa0a62227ded3e91e61e81ecd4859c1549c3660abc09ec51",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:11a8b41544e1bd36379f724cd4fefc6ef4c608aca5f093d1db22b840d04d133f",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-tests.sh": {
+      "category": "framework",
+      "originalHash": "sha256:7538f07f8a432ba2c25ca1f53fc2778a3cbe1f811d77f26eff7015915b3471c9",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-security.sh": {
+      "category": "generated",
+      "originalHash": "sha256:0a9453d133e9b8e86cd767cec2f130bd6dc74db93d2169d2e43858af81438630",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-canonical.sh": {
+      "category": "generated",
+      "originalHash": "sha256:66d2e6887f040d7179e811f79f8c9f367066c6fd6a100c462ddb330556d54228",
+      "status": "unchanged"
+    },
+    ".pi/scripts/generate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d4e48b44eacf98df17eab6ad97fb67c58f2569a2200481632ca4cf348ec1daf7",
+      "status": "unchanged"
+    },
+    ".pi/scripts/mr-validation.sh": {
+      "category": "framework",
+      "originalHash": "sha256:4ff040e1c2cda028d317740d0c6f0dc5b8536a3986dcd79b7f90c70e1f16a0d3",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-ci.sh": {
+      "category": "generated",
+      "originalHash": "sha256:d5ae9a470c0e738063a103f8cedd9bb08ebc38dabd35883c6d16874228d08c45",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-integration.sh": {
+      "category": "generated",
+      "originalHash": "sha256:01c0dc34f6a94dcb46428049e4a090c89756c67755f0f16068dcfcb0b4df2ea0",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-tests.sh": {
+      "category": "generated",
+      "originalHash": "sha256:ff7840a569b1571782ae8c4174a6b871345c6a354c65ff4ca5784b898ba15466",
+      "status": "unchanged"
+    },
+    ".pi/scripts/git/close-epic.sh": {
+      "category": "framework",
+      "originalHash": "sha256:fade48608d4bfc267ec7bae6b374c6fb2a40b709a2d226ec06c36ede853f5c2a",
+      "status": "unchanged"
+    },
+    ".pi/scripts/git/close-issue.sh": {
+      "category": "framework",
+      "originalHash": "sha256:8984749dc0957659553108265bb16463166ade0f6e7acd8742be003bf92f990e",
+      "status": "unchanged"
+    },
+    ".pi/scripts/git/update-tracking-issue.sh": {
+      "category": "framework",
+      "originalHash": "sha256:4701dc3b3afca2884071db20a4b4a2665d12e6af5498b349a75b598da0fe7cbe",
+      "status": "unchanged"
+    },
+    ".pi/scripts/git/link-issue-to-epic.sh": {
+      "category": "framework",
+      "originalHash": "sha256:a1dd8606544bba38b0e4a90bce111c6c0d0d578bf63e6a752b6aaede54a6d7e3",
+      "status": "unchanged"
+    },
+    ".pi/scripts/git/create-tracking-issue.sh": {
+      "category": "framework",
+      "originalHash": "sha256:3b221bb26e7c0fcb9b073de037c382db8031eb6b8b921d27f4f5e76cd2ddfec5",
+      "status": "unchanged"
+    },
+    ".pi/prompts/blueprint-validate.md": {
+      "category": "framework",
+      "originalHash": "sha256:b73c83cb10e9afbb6b462063cd0a1ad588f301ade22735c2fb03272696d396e6",
+      "status": "unchanged"
+    },
+    ".pi/prompts/bug-fix.md": {
+      "category": "framework",
+      "originalHash": "sha256:0af6405b22d77066427d69b2486f13de2b5d7ceb00a69af78778bdb5bfeb011a",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-implementation-series.md": {
+      "category": "framework",
+      "originalHash": "sha256:983e2b90b70424403a9223b7ed30840878fe7cf4d10b39f8fcf547a4ae0fd1cd",
+      "status": "unchanged"
+    },
+    ".pi/prompts/pattern-extract.md": {
+      "category": "framework",
+      "originalHash": "sha256:3433fa6188bf8717c4aa8a052c4f3b9c6aaa7ed3e01dc8b816ffc1e0cb7f475a",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-draft.md": {
+      "category": "framework",
+      "originalHash": "sha256:e50f0fb5a7d49d0316259e05e798ac44797b156394c8f7e22407907941309c14",
+      "status": "unchanged"
+    },
+    ".pi/prompts/epic-plan.md": {
+      "category": "framework",
+      "originalHash": "sha256:3633e445bb94ecdd41567490c3c31086784d6597e99ef3e86677628e00feb4b6",
+      "status": "unchanged"
+    },
+    ".pi/prompts/sync-check.md": {
+      "category": "framework",
+      "originalHash": "sha256:06c09fefa4521254c0c0e43b587985d809749a4fa0f9e462fc85f33e8182b382",
+      "status": "unchanged"
+    },
+    ".pi/prompts/blueprint-update.md": {
+      "category": "framework",
+      "originalHash": "sha256:e56adc41911876bbca89fa2d5947c7a76e5ebb4af423f8749d61e700fe4a95f4",
+      "status": "unchanged"
+    },
+    ".pi/prompts/hotfix.md": {
+      "category": "framework",
+      "originalHash": "sha256:ce1c5a45625d678c57094d2d3f7b80d05bb8d19c12afe7e6bf12c1d50ec43f6e",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-template.md": {
+      "category": "framework",
+      "originalHash": "sha256:0171d092bd362617327b5ef14e3b58b06052482ddd338338da3ccfb404ee0e93",
+      "status": "unchanged"
+    },
+    ".pi/prompts/epic-template.md": {
+      "category": "framework",
+      "originalHash": "sha256:cdc5b784ed287871d651ebcedeacddd74091b4c1ac3b7e696890d78353b94afc",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-closeout.md": {
+      "category": "framework",
+      "originalHash": "sha256:a2c88df36dd87fec9e87f2efcc0ff0ab694b75b5952090763c7081f9bcde5681",
+      "status": "unchanged"
+    },
+    ".pi/prompts/scope-analyzer.md": {
+      "category": "framework",
+      "originalHash": "sha256:be1d74366bbe8e5f7dd5949d45e9adb89b17b6015dc471921e32b6fc2e110633",
+      "status": "unchanged"
+    },
+    ".pi/prompts/ci-blueprint.md": {
+      "category": "framework",
+      "originalHash": "sha256:b2847a4ec3b26f3a77e6c06d8ebe2595032703ec2d8c1529a8f76204bc03c58f",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-template-set.md": {
+      "category": "framework",
+      "originalHash": "sha256:cf6e8b0f1db914475264e6c153cd1945bffc537210501f898c6d01661c9dc027",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-merge.md": {
+      "category": "framework",
+      "originalHash": "sha256:adfc1e0dd785efe556945f74e4f84c1a8f1efbd33d6ad68e50514cacf0b5511c",
+      "status": "unchanged"
+    },
+    ".pi/prompts/context-refresh.md": {
+      "category": "framework",
+      "originalHash": "sha256:09fdc06700827a1aec1906c6710c6c9b2a7419cc984359edcae9339c53114e47",
+      "status": "unchanged"
+    },
+    ".pi/prompts/git-issues.md": {
+      "category": "framework",
+      "originalHash": "sha256:000effa78e9a2bdbe06307eb4de3c879051e59ec728687b20df39db21a69f34c",
+      "status": "unchanged"
+    },
+    ".pi/prompts/feature-development.md": {
+      "category": "framework",
+      "originalHash": "sha256:f388ede538c684a91f3fd59bbac710be8f027a7e5214717f83caeb4325289909",
+      "status": "unchanged"
+    },
+    ".pi/prompts/plan-to-issues.md": {
+      "category": "framework",
+      "originalHash": "sha256:1cc665bad7a5aa45a8b769d22a8dbc5c7288ccaa2e8e017935b9ce7f6fd13fe8",
+      "status": "unchanged"
+    },
+    ".pi/prompts/refactoring.md": {
+      "category": "framework",
+      "originalHash": "sha256:fb65f0efee082ea47aa893bde7ac6f4d6014512e3dec3f9b820d86f1bcf6037a",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/slash-commands.md": {
+      "category": "framework",
+      "originalHash": "sha256:d9783d8d481ae7a02c2c91db52f8600c7fb6821418dcbd5f589ca37f314b6a1b",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/pipeline.md": {
+      "category": "framework",
+      "originalHash": "sha256:c458c79492c2b97fac0dedb343bfe5f688e0c0f41f3b945db0b4bd766aae179a",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/debug.md": {
+      "category": "framework",
+      "originalHash": "sha256:65368b250d343f208d3ad07d63b23fee8a178f3e9a3a65079d1b05ccb954b7ed",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/issue-factory.md": {
+      "category": "framework",
+      "originalHash": "sha256:078e16f2b69c44ea7bc3d356dc3b8a3bf861b220a3ce3fc4c2a0dd2e949848ac",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/architecture-coordinator.md": {
+      "category": "framework",
+      "originalHash": "sha256:87877ea4cc689c98f6ab8d661d85b0d0af8debe06f6840ab62c891370ba112f7",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/snippets.md": {
+      "category": "framework",
+      "originalHash": "sha256:4bf69877925a542de4d6f84f0205654ae2c53ac56ba740674eb849f1a7d1ce95",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/architecture-generator.md": {
+      "category": "framework",
+      "originalHash": "sha256:6b2763ece59b22d86a95e1d1712b118cbb700e0cce5d941435604b4acca3fd4b",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/land.md": {
+      "category": "framework",
+      "originalHash": "sha256:099bedd22bfd99ac6d061d376f0c5d0314bd7ddd351166d2816122d9ae210207",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/push.md": {
+      "category": "framework",
+      "originalHash": "sha256:93a9a3f3e154743e342ccc75f3780cca9efd2738d90545bd43bdc5518a2b310d",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/curator.md": {
+      "category": "framework",
+      "originalHash": "sha256:3a6ef64758000d80c5a126356afb1b7539e76b83f9a2dd6a42da2f99ebb435d3",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/kanban.md": {
+      "category": "framework",
+      "originalHash": "sha256:e82cc278ab29c86e93a0bdb222717f36088a3c0c02f5fa4e86b2fe28be723dab",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/ci-mr-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:ad5ae29d0043ac16c3a082488932e79f9f21132142616977d00aaf1f8bf26767",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/session-persistence.md": {
+      "category": "framework",
+      "originalHash": "sha256:3bdcb4d1008894d807773b28cc8a2c4ff3c933a5ecd296930a2bb1559b867d73",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/subagent-registry.md": {
+      "category": "framework",
+      "originalHash": "sha256:4b89ea68c8fca289a90a232ef86ff0b1b37c096482cbeb2a8450d28f2fb68a86",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/pull.md": {
+      "category": "framework",
+      "originalHash": "sha256:4d837457b90163de6b0a59ab425855f23e8efd0bf5cd7e945fa7ba4adead65d4",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/operations-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:86ee49c63e881afc18c5a0438d614d3918cb18c468720c9bb4d1f7ab5f37c298",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/issue-creator.md": {
+      "category": "framework",
+      "originalHash": "sha256:78e72f5e3ecb7e8737449c96ae17ac4b5c48bb31ed2a1e2fc929277462a02648",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/plan-mode.md": {
+      "category": "framework",
+      "originalHash": "sha256:7a37581c5005995fc0afa0fb77c1991de3384fa0dd2326610207927d28a6032c",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/hooks.md": {
+      "category": "framework",
+      "originalHash": "sha256:5ffafef4d3861be81760dd5bc7792ec865de37d6e668cde9636e607fd851c95b",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/security-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:1f5ab8b7f01f5dc0342c5c90dcf745f81b8f00858fd0d8283a979ee22e91581b",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/integration-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:c3894b281c5d79473002a9d8d5f81fbfe2909705c65e756415175972a6ebb62d",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/goal-loop.md": {
+      "category": "framework",
+      "originalHash": "sha256:5aacf58ec91fa18ec7b2a19dc511607a57c8a89974fdc864fa13f1e85bc53bca",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/documentation-maintainer.md": {
+      "category": "framework",
+      "originalHash": "sha256:dea9a6b86b2de03a78f1e042649f6a54a1729286ffbea8fb943a9ec61baa281a",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/commit.md": {
+      "category": "framework",
+      "originalHash": "sha256:e137745830577995cfc2a8ff26ed4ffcbd6da49e56065a755b06ce8725765916",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/architecture-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:fc468492fe93b5b4c2d460195a9b379f79b58913db59443ff1c25f54ae1b1310",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/code-developer.md": {
+      "category": "framework",
+      "originalHash": "sha256:3d7c29308ff76af77c5c098e1b326ca7b95b5e96ff3acd70440ff9228c974bd1",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/test-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:37557feb88715946a1d3e11cdaa67ab2395e785b0c13866f7038cc97c798f825",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/security-guards.md": {
+      "category": "framework",
+      "originalHash": "sha256:df4d2135c38aeea2cc781e6acd3fad5caac5ceb226c58dd14a7a0dfae51402b9",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/context-compaction.md": {
+      "category": "framework",
+      "originalHash": "sha256:2f238359167f08f4acee8cc76945a572e1203fb61027b93bcdc722e079591445",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/operations-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:363b53637cf49af6268f59bf53e70bec2e0f81366c9db192e771a1c2fb2bf7cc",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/model-registry.md": {
+      "category": "framework",
+      "originalHash": "sha256:82b1604c59f2b38e7ecb3b9a99ddca40ff2a886f559af2f8b8b2f1d6fa1262c2",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/security-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:34a70bb93cb256f30463519967601ce2f4e44c7dc0284d5f034a7120a79ef4ec",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/integration-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:10d21f097ff8e86312318538cf342ad56a0de18a56ddbeb80c44c98cd1ee00c0",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/system-prompt-tiers.md": {
+      "category": "framework",
+      "originalHash": "sha256:e4977fe1ad0c2ce8248deb136031a3aba59f6fed75f52850fc5e306027277aeb",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/architecture-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:7ef93c32dfffb458b6c1301ebf621bada00f4cf5573f5d030c552327579551bd",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/test-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:3709ea4476727c6e7db56a40dd3be5902140cfaf76ab990cb94b52847d4a92bb",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/ci-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:9abee72b24b7322a0130bb91da5ff20d39064cb75abddd25d2c589f442a22839",
+      "status": "unchanged"
+    },
+    ".pi/validators/default.toml": {
+      "category": "framework",
+      "originalHash": "sha256:b9fea586ef6035733f7873cab8ba3399426a6ea67de10f5ebb4f8110620436d4",
+      "status": "unchanged"
+    },
+    ".pi/validators/README.md": {
+      "category": "framework",
+      "originalHash": "sha256:ae67775d2cd23d35a28f8850161f88666fbf5a9bc2b62e91bf3de31d5c3a0ace",
+      "status": "unchanged"
+    },
+    ".pi/validators/spring.toml": {
+      "category": "framework",
+      "originalHash": "sha256:afc0f8b49b5228869f296a7683b1d8a5f6ffc72f366f889a4ab7f5a8a4cc2b1e",
+      "status": "unchanged"
+    },
+    ".pi/preflight_report.json": {
+      "category": "framework",
+      "originalHash": "sha256:c739bbb27fde3d3d9ea1e47a453b8d07d46a04d42674854cf7472d5a5d406148",
+      "status": "unchanged"
+    },
+    ".pi/domain/ubiquitous-language.md": {
+      "category": "user",
+      "originalHash": "sha256:b047dbd6d32bfcf6c220c3319642c79b4f97787c67e58ac03c5fc18f57ba62cb",
+      "status": "unchanged"
+    },
+    ".pi/domain/exploration.md": {
+      "category": "user",
+      "originalHash": "sha256:368e9c5bf2f5b06cdab3ef1cef24d85c1af4790fe2e9fc1567be178348771c15",
+      "status": "unchanged"
+    },
+    ".pi/skills/architecture-coordinator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:2ef459699d8a0f38c55224af6b0aefc4e3f94bdc822b2bfc00eea59862561dc0",
+      "status": "unchanged"
+    },
+    ".pi/skills/architecture-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:07186ebdd2621e5b0a052639988676456751601095e8103734597dd36bf57b48",
+      "status": "unchanged"
+    },
+    ".pi/skills/security-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:83f38d77d58dc81d861cb80fded733d0329b25e173793a611622a301f6db558e",
+      "status": "unchanged"
+    },
+    ".pi/skills/operations-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:96012748345b1065418ce30937a8e4b97068d8fd6298f07708c1ce28b82d4108",
+      "status": "unchanged"
+    },
+    ".pi/skills/test-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:6d88bbb2045c1278d2123a1fc3871557ed7f1c6de70a8234f7aff41e9c949098",
+      "status": "unchanged"
+    },
+    ".pi/skills/integration-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:728b21526f50dc7d35df402beab38fefd84c0336379a48eceacff6d3cf7196de",
+      "status": "unchanged"
+    },
+    ".pi/skills/ci-mr-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:41da17979b8d233865f6f3f770c60eb4683401f3a129cb700dbe2c6d442997bf",
+      "status": "unchanged"
+    },
+    ".pi/skills/code-developer/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:217ce033e46a730320a56987cf35a6359d82217c5fe5e58b9dc1da0d9758793c",
+      "status": "unchanged"
+    },
+    ".pi/skills/issue-creator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:048c2b93595179788dfffd1acddbe9efccfed699abfc64ec16ea08bcb71882e5",
+      "status": "unchanged"
+    },
+    ".pi/skills/documentation-maintainer/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:6e3d490c33bdfc43aeb88c8f5b69bc0674542fbb0aefe6d734aa9dbd956249ac",
+      "status": "unchanged"
+    },
+    ".pi/README.md": {
+      "category": "generated",
+      "originalHash": "sha256:46adb3cb48b79ee5e26595b06cdd22992cb3252f643ded3ec7a6f7f8677b0ca1",
+      "status": "unchanged"
+    },
+    ".gitignore": {
+      "category": "framework",
+      "originalHash": "sha256:b071663b414d6bf1004373057662f2b2809fd42367e53d2484c27e54c1ab5fb7",
+      "status": "unchanged"
+    },
+    "WORKFLOW.md": {
+      "category": "framework",
+      "originalHash": "sha256:9808142326406a2f271bb22491fe4f1355dda06c59c2f5267012b75bbde62d57",
+      "status": "unchanged"
+    }
+  },
+  "exports": {},
+  "templateContext": {
+    "projectName": "rigorix-oss",
+    "projectVersion": "0.1.0",
+    "language": "rust",
+    "repository": "arman-jalili/rigorix-oss",
+    "repoTool": "gh",
+    "groupId": "com.rigorix-oss",
+    "buildCommand": "cargo build",
+    "testCommand": "cargo test --all",
+    "lintCommand": "cargo clippy -- -D warnings",
+    "formatCommand": "cargo fmt",
+    "formatCheckCommand": "cargo fmt --check",
+    "securityAuditCommand": "cargo audit",
+    "errorHandlingPattern": "Result<T, E> pattern",
+    "tracingPattern": "tracing crate with structured spans",
+    "cancellationPattern": "CancellationToken pattern",
+    "atomicWritePattern": "tempfile + rename pattern",
+    "keyFile1": "src/index.ts",
+    "keyFile1Purpose": "Main entry point",
+    "keyFile2": "src/lib/core.ts",
+    "keyFile2Purpose": "Core library functions",
+    "domainDescription": "github actions for rigorix"
+  },
+  "scaffoldedAt": "2026-06-20T10:42:00.062Z",
+  "lastUpdatedAt": "2026-06-20T10:42:00.137Z"
+}

--- a/cli/guardian-manifest.json
+++ b/cli/guardian-manifest.json
@@ -1,0 +1,1455 @@
+{
+  "schemaVersion": "0.1",
+  "frameworkVersion": "0.1.97",
+  "source": "pi",
+  "tools": [
+    "pi",
+    "claude"
+  ],
+  "language": "rust",
+  "repoTool": "gh",
+  "archMode": "strict",
+  "groupId": "com.rigorix-oss",
+  "validators": [
+    "ci",
+    "tests",
+    "security",
+    "operations",
+    "integration",
+    "architecture",
+    "canonical"
+  ],
+  "workflows": [
+    "feature-development",
+    "bug-fix",
+    "hotfix",
+    "refactoring",
+    "issue-implementation-series",
+    "epic-plan",
+    "issue-draft",
+    "git-issues",
+    "issue-closeout",
+    "issue-merge",
+    "plan-to-issues",
+    "blueprint-validate",
+    "sync-check",
+    "context-refresh",
+    "scope-analyzer",
+    "pattern-extract",
+    "blueprint-update"
+  ],
+  "files": {
+    ".pi/context/checklists.md": {
+      "category": "framework",
+      "originalHash": "sha256:8f3e52628b0d1abe439d84f3b29848c4141110c485e2d42dd7ae0fb0fd234806",
+      "status": "unchanged"
+    },
+    ".pi/context/domain-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:f92b43bdc715fd5cd8d3ab292c236e705e1ad155e58cb343efe4c6605eacd717",
+      "status": "unchanged"
+    },
+    ".pi/context/project.md": {
+      "category": "user",
+      "originalHash": "sha256:2dd4ff55bd49f0524108fbcbb344acfce74eb7d66772a212261b505880b1b019",
+      "status": "modified"
+    },
+    ".pi/context/patterns.md": {
+      "category": "user",
+      "originalHash": "sha256:51a1ffa9ad2fc4631fa3b15d60da3a66414d1457ccd523c1a0866592bb373c30",
+      "status": "modified"
+    },
+    ".pi/context/output-formats.md": {
+      "category": "framework",
+      "originalHash": "sha256:57700883af3a4bac040a49c7a00e34040ef64fe66fe45502fa44dd6a49dada1f",
+      "status": "unchanged"
+    },
+    ".pi/context/patterns-base.md": {
+      "category": "framework",
+      "originalHash": "sha256:8d9bf4d5c7ab81f060b0fadf8138cbb615b26119860988215f2ebd405c42bd1e",
+      "status": "unchanged"
+    },
+    ".pi/workpad.md": {
+      "category": "framework",
+      "originalHash": "sha256:c15373fbf3ad0317a1281066c7605a9f2c0823c1a3c5e946e0620b808c6bf67b",
+      "status": "unchanged"
+    },
+    ".pi/agents/issue-factory.md": {
+      "category": "framework",
+      "originalHash": "sha256:8e1d2a8211e7634736c51f6fe5af2ae48d3263a39d54ddc7cb23c9183537ae06",
+      "status": "unchanged"
+    },
+    ".pi/agents/architecture-coordinator.md": {
+      "category": "framework",
+      "originalHash": "sha256:0449f8b3d33b1d479e0699303eea0e6c6d512f38972e99cb1b8c0da0f7b37f8c",
+      "status": "unchanged"
+    },
+    ".pi/agents/bootstrap-implementer.md": {
+      "category": "framework",
+      "originalHash": "sha256:77662fa88c70fe139f7ff526c8763a3226d7dff6c249081a7a63d02e1ac72041",
+      "status": "unchanged"
+    },
+    ".pi/agents/operations-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:e64c119a9f0fc7c9fcebf813f47bd43b091c8049a6fd32a2789da69ec1c1fbde",
+      "status": "unchanged"
+    },
+    ".pi/agents/security-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:6cd0cd853582cb8f60d27c7bb9e339977928a07f3b4fb8fb66bf894bd6fad728",
+      "status": "unchanged"
+    },
+    ".pi/agents/architecture-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:3fbae65130cbb256e5be0c0e3b784de9fd681a9a54629bb270617e29886fcc9c",
+      "status": "unchanged"
+    },
+    ".pi/agent/AGENTS.md": {
+      "category": "user",
+      "originalHash": "sha256:240369371efe62367c638e1e094896657de40d09b80303ce953878345c517968",
+      "status": "modified"
+    },
+    ".pi/extensions/curator.ts": {
+      "category": "framework",
+      "originalHash": "sha256:7cebd53167de7c68d0b776be1ed878808f04035104125ebb8222e15367708f83",
+      "status": "modified"
+    },
+    ".pi/extensions/session-persistence.ts": {
+      "category": "framework",
+      "originalHash": "sha256:8994200dabf4502b4c315278cb995b9195f5060bfd7f416ba0eb1ed74008d66e",
+      "status": "modified"
+    },
+    ".pi/extensions/domain-explorer.ts": {
+      "category": "framework",
+      "originalHash": "sha256:58367153935b2aa08d3b3cb44e33a5caa42bf65964f76f9adda3ed2a2e9c921a",
+      "status": "modified"
+    },
+    ".pi/extensions/kanban.ts": {
+      "category": "framework",
+      "originalHash": "sha256:ae324cea4192f38295469343d1c841e7b4cfa33a4887cde176c873c128c7a605",
+      "status": "modified"
+    },
+    ".pi/extensions/project-scaffolder.ts": {
+      "category": "framework",
+      "originalHash": "sha256:a30e79c81a5f373401a038fdd87d313761d3ce933cb5dee6789e0e2842ecaa74",
+      "status": "modified"
+    },
+    ".pi/extensions/snippets.ts": {
+      "category": "framework",
+      "originalHash": "sha256:30d157510a72a2f5dd0ebbbe706ebfa780131eb397e2d1091c88f1b7f067ec68",
+      "status": "modified"
+    },
+    ".pi/extensions/read-only-mode.ts": {
+      "category": "framework",
+      "originalHash": "sha256:a579d34865fee1d53fec4d7218e905cfc3b1e08c8fafa1492a2532140f910f1e",
+      "status": "modified"
+    },
+    ".pi/extensions/slash-commands.ts": {
+      "category": "framework",
+      "originalHash": "sha256:e60a12667b22dd287b2da0969df554f3d8e40a7be12e85c122232310057f075f",
+      "status": "modified"
+    },
+    ".pi/extensions/config-reload.ts": {
+      "category": "framework",
+      "originalHash": "sha256:702c33e12f62867cadce1eeb8e94c98a491cc8b048bd88c6031daee514b957c7",
+      "status": "modified"
+    },
+    ".pi/extensions/pipeline.ts": {
+      "category": "framework",
+      "originalHash": "sha256:0b77763e1c78aed36fcd3710edeafb9fa8ea6ae6e101ef16a0510e32f0789982",
+      "status": "modified"
+    },
+    ".pi/extensions/bash-guard.ts": {
+      "category": "framework",
+      "originalHash": "sha256:0af4981f5c6235b2182f2d2aff6b7b0f1377835e6c8a7ff33a93d346b1a693c6",
+      "status": "modified"
+    },
+    ".pi/extensions/validation-runner.ts": {
+      "category": "framework",
+      "originalHash": "sha256:c0352feda293f89c0b1757a592c0a8341ce30274666876474ffe804d46214793",
+      "status": "modified"
+    },
+    ".pi/extensions/architect.ts": {
+      "category": "framework",
+      "originalHash": "sha256:e7b6d379a62c61b108341c1c0b792f90c01b9fed22e00fa27723ecc31fda55f0",
+      "status": "modified"
+    },
+    ".pi/extensions/architect-lib/helpers.ts": {
+      "category": "framework",
+      "originalHash": "sha256:ca513317f5bb7427f627752185df3c912cff8e2bd714ebc9dccb26535524f94a",
+      "status": "modified"
+    },
+    ".pi/extensions/architect-lib/generators.ts": {
+      "category": "framework",
+      "originalHash": "sha256:942c1b7061dfbfb0443484cb853b7f38641bdf4acf6f414a358d2d15ff03fe96",
+      "status": "modified"
+    },
+    ".pi/extensions/architect-lib/types.ts": {
+      "category": "framework",
+      "originalHash": "sha256:d4c9206f10fd179d7e312039ee3a7b4b51363d90d7a6f9c1b9898a306082f535",
+      "status": "modified"
+    },
+    ".pi/extensions/ask-user-question.ts": {
+      "category": "framework",
+      "originalHash": "sha256:983057f59aa40647f11c0703f1b9393e780900e23c67be0e579881d1c6729edb",
+      "status": "modified"
+    },
+    ".pi/extensions/filechanges.ts": {
+      "category": "framework",
+      "originalHash": "sha256:411094739728d704423b287f54dd4d265c5aab3346bb90f7f638b856aaebe244",
+      "status": "modified"
+    },
+    ".pi/extensions/hooks.ts": {
+      "category": "framework",
+      "originalHash": "sha256:46fa45dd6b3d7db55208fdf5e28001fd2d5e6a53570f38d78eee57537b96bf48",
+      "status": "modified"
+    },
+    ".pi/extensions/coordinator.ts": {
+      "category": "framework",
+      "originalHash": "sha256:070df0ef9fdb429cd284d8c7a6f3fbe1ba7f92927bf0128a941bf6d6a0f10d6e",
+      "status": "modified"
+    },
+    ".pi/extensions/goal-loop.ts": {
+      "category": "framework",
+      "originalHash": "sha256:6ed7949769ef9a36a7c0e023779279d8407b7a16867445c01b1102d13213688f",
+      "status": "modified"
+    },
+    ".pi/extensions/redaction.ts": {
+      "category": "framework",
+      "originalHash": "sha256:9f69807463e1bf305cd981e2ca18c432446ba67ffb83e8b5f518d9fdb1c691f2",
+      "status": "modified"
+    },
+    ".pi/extensions/plan-mode.ts": {
+      "category": "framework",
+      "originalHash": "sha256:6d0b1a68ec3c64127421b5eea7b3385790d870b69de291b24e6c967354e743d4",
+      "status": "modified"
+    },
+    ".pi/types.ts": {
+      "category": "framework",
+      "originalHash": "sha256:017a07fae90a46fca800dcb6b3ef19050570677c8a4a9672f85b238183f72ee4",
+      "status": "unchanged"
+    },
+    ".pi/architecture/CHANGELOG.md": {
+      "category": "framework",
+      "originalHash": "sha256:653bed6d8499cbf4b96598d1c3c6e0537989018b08654fc9422d50c85a8f20d6",
+      "status": "modified"
+    },
+    ".pi/architecture/diagrams/system-overview.md": {
+      "category": "framework",
+      "originalHash": "sha256:162cb1fa10bc933370390c9b37d64dcb4dad333e4ecef4e73c3d48e9d8ae91d3",
+      "status": "modified"
+    },
+    ".pi/architecture/decisions/ADR-template.md": {
+      "category": "framework",
+      "originalHash": "sha256:18e171fa061c7f8abd07b3b90a7d02f619bf1545124969203225f4bdd4b41531",
+      "status": "unchanged"
+    },
+    ".pi/architecture/modules/module-template.md": {
+      "category": "framework",
+      "originalHash": "sha256:4790f7bde099ad6ee10f11602ecfc281c6de4e775c7739500eb1260afc1fa849",
+      "status": "modified"
+    },
+    ".pi/github/instructions/architecture.instructions.md": {
+      "category": "framework",
+      "originalHash": "sha256:9f26ff4819db738887c1cdb9745537dadc43fc05ad788684b38dbc7a6dad17d5",
+      "status": "unchanged"
+    },
+    ".pi/github/instructions/validation.instructions.md": {
+      "category": "framework",
+      "originalHash": "sha256:934d64609f1275887a5c2795ce41d7d31fa5e8cf77cac35612d1b8685a44d28b",
+      "status": "unchanged"
+    },
+    ".pi/github/copilot/settings.json": {
+      "category": "framework",
+      "originalHash": "sha256:9e21c730edefe4080fee1014a02fbb96118aa300ea0f93563a53f9c6d9c4f2a1",
+      "status": "unchanged"
+    },
+    ".pi/github/workflows/01-planning-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:b7c13edf0d75fe2cc2a8784461637ec91a2bc894682768b6b208795f60a5d404",
+      "status": "unchanged"
+    },
+    ".pi/github/workflows/03-implementation-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:3b067bd1df93bb8de1eb26873825f2d5a330c46c619cb3209db127d33fde3ebb",
+      "status": "unchanged"
+    },
+    ".pi/github/workflows/04-validation-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:513bb31dd54f5961e221f71e5216fd1acde8ad0158f5523985bdad97a2bff8c8",
+      "status": "unchanged"
+    },
+    ".pi/github/workflows/02-issue-generation-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:41205400814e6d4b77ddbcf351d8e1f0701d11c618225eabf6ed3d3b630d56dd",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/architecture-validator.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:04e7cb86758e135b55abc556b9d043d6f68cd5566dd5b0a882cedc615fbde065",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/issue-factory.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:ef97de04d6f99a3b2edd04182ab8cf73a7da564b99d091f5c3d2056175fd686b",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/architecture-coordinator.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:9e376f5ba69f3fc30672b83e9792bb2cb961abc61d6fddda057a5df2ce398e0e",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/epic-planner.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:859599d908d8d1a5bc41d82eaea9414f147a1a16b8d37a99630f3d700f37c0ca",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/bootstrap-implementer.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:2a0b8f2d37ab6c9112d0fa0101429ad5afe3d2c39328b3d132eee1eeb454a3ee",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/security-validator.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:e9081be418d7f432fbd9b4a63d8181b44e797c93a8b6065ec330e2a5fa4b6109",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/operations-validator.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:464860fa7eabcad393471c8dc434268d2f55e72eda0889386abee02f88315ec3",
+      "status": "unchanged"
+    },
+    ".pi/github/copilot-instructions.md": {
+      "category": "framework",
+      "originalHash": "sha256:f82b95c50d87175e42851487b9c9f8891cfc1b5d74d784fdcbc2c4a221ddd19f",
+      "status": "unchanged"
+    },
+    ".pi/INDEX.md": {
+      "category": "framework",
+      "originalHash": "sha256:e166bc3e698236cbe4ef3fcca2f866c8ac2a28cd4ea293ca74c598a0dfea44ed",
+      "status": "modified"
+    },
+    ".pi/scripts/validate-operations.sh": {
+      "category": "generated",
+      "originalHash": "sha256:4fb994c9056b90f565fe536633795586da3197a2a2b8f745baea9af8db4440d5",
+      "status": "unchanged"
+    },
+    ".pi/scripts/create-feature-branch.sh": {
+      "category": "framework",
+      "originalHash": "sha256:33ff4c76faba418025dbe88a998f2a04a6cafd282d11fc644a50de014cc580d0",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-architecture.sh": {
+      "category": "generated",
+      "originalHash": "sha256:241df1a4517e0a04aff9cfc4efddbdcb4b3859e65bd35cb8c558a172dfe7cf4d",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-ubiquitous-language.sh": {
+      "category": "framework",
+      "originalHash": "sha256:fdae16e0bf2030b87c9bb5263eceb73cd5510066bbe85d7925a35dd92a2a13f8",
+      "status": "modified"
+    },
+    ".pi/scripts/ci/stage_security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:1ebac9c09ebfebc1e9cffdfa474c792f28bbe386a923ca49a0695bddee93df40",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/run_hardening_stages.sh": {
+      "category": "framework",
+      "originalHash": "sha256:8a67c21f7154e1cd4987f6e5e56dbbd476f3bf6d7846d4c167289008979d4a65",
+      "status": "modified"
+    },
+    ".pi/scripts/ci/stage_remaining.sh": {
+      "category": "framework",
+      "originalHash": "sha256:396b75ec9fb00224781e9eca66ac51a9ec7f05876d5175f80070560fdf629fe5",
+      "status": "modified"
+    },
+    ".pi/scripts/ci/check_planning_packet.py": {
+      "category": "framework",
+      "originalHash": "sha256:214e1ce18ed2226f344f25687fde9dd586b061f1af8efd6f54c27bd09dabae67",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_package_build.sh": {
+      "category": "framework",
+      "originalHash": "sha256:67b0f705398369fb171c993c1e673f8cce16e4016cd6c1ca72c8996ce3bda7c4",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/validate_agent_output.py": {
+      "category": "framework",
+      "originalHash": "sha256:51cbdbed1921620608a25c2f4db67dbfd088a3d43cb96a03ec425c181d6ce4c9",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/run_preflight.sh": {
+      "category": "framework",
+      "originalHash": "sha256:137294de31aebfa339ae28ba878cb85720bdbe1b4298a2dd19ca184754bd67c4",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_migration_verify.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d25a4de5ddcb3946fca19e82828dd03f726d2084c71dbe4ecf0e222d1da1b67b",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_unit.sh": {
+      "category": "framework",
+      "originalHash": "sha256:64c8b8a4c6266725962b238a1c9814ea110c0f067e90ca9d38287a40074a5f19",
+      "status": "modified"
+    },
+    ".pi/scripts/ci/stage_release_readiness.sh": {
+      "category": "framework",
+      "originalHash": "sha256:0d62822ea089f0469e66561d501bf03cd5e9bb0dbedb199e0ca39286c3ffaa7c",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_docs_policy.sh": {
+      "category": "framework",
+      "originalHash": "sha256:8b13849d612e4dde20a43e3e2ef23c9279869c14683e29506213749e4f2e29ec",
+      "status": "modified"
+    },
+    ".pi/scripts/ci/validate_agent_output.sh": {
+      "category": "framework",
+      "originalHash": "sha256:26816f935433df71266651dfe393c9ff3b7c3975426e05a93b7308c6fc3b80bf",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:a9617cd791ef4ebc72a519ca5169c287f94ba128e14c19f75a6db24267cf42ec",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/run_stage.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ade2b65032142b6f03fc08ed99828964c0bf6a7121d82969871ac963dac14fe1",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_lint.sh": {
+      "category": "framework",
+      "originalHash": "sha256:b5ce9794af4d271f7e04a82f6a35fe7e254d64ff4e71518cf201e4210c1b6560",
+      "status": "modified"
+    },
+    ".pi/scripts/ci/check_architecture_conformance.sh": {
+      "category": "framework",
+      "originalHash": "sha256:eaee494fb728fdc422fa9d83b4c8abdbe52041bd31e53fa8ba85f91196ea765d",
+      "status": "modified"
+    },
+    ".pi/scripts/ci/stage_static_analysis.sh": {
+      "category": "framework",
+      "originalHash": "sha256:5d40980d65b39245bb3db064f0ae60b977b33cb0e7f86b0d211020cb894bafa7",
+      "status": "modified"
+    },
+    ".pi/scripts/merge-mr.sh": {
+      "category": "framework",
+      "originalHash": "sha256:048a02090a777c3d30c61aa80cccfb3b3a7bb521c1f96c097ed3c06222ffcb7c",
+      "status": "modified"
+    },
+    ".pi/scripts/validate-architecture-readiness.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d460c6ccd94a3382d3fde7fff1e9d9f7c10abba76a3f6a3e41238283e81354d5",
+      "status": "modified"
+    },
+    ".pi/scripts/fetch-issues.sh": {
+      "category": "framework",
+      "originalHash": "sha256:c7a7bd71e2359b2ea3ef1b54d7af4fe368e86e045ce0d0e0348104d4ef91c58b",
+      "status": "modified"
+    },
+    ".pi/scripts/categorize-issues.sh": {
+      "category": "framework",
+      "originalHash": "sha256:172e09a69b56e3b502d184f740c447f570647893f4658e2dd91451595f77dc93",
+      "status": "unchanged"
+    },
+    ".pi/scripts/create-mr.sh": {
+      "category": "framework",
+      "originalHash": "sha256:bd9fdfdfa31c9da56d441566249060cc23bc93b0b5a2aa59e8f07d04eab3e05b",
+      "status": "modified"
+    },
+    ".pi/scripts/validation-cache.sh": {
+      "category": "generated",
+      "originalHash": "sha256:5fea93087bcd9852532ce8119f47ecdb61a46fd857b336e2955b087ed61aa3bd",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-operations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ab89729ca059bf5c51693c30dc088ea396c9e3cec282926eb20e0927d7c01c42",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:250210026e0e228def1481a26f9bfc85c032734edc867d1aa153ee5ea4b09e6d",
+      "status": "modified"
+    },
+    ".pi/scripts/languages/rust/validate-security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ce3a057d27fbdcffb0e8043aece29acceea9e9eb69e61dae276f6a7205bdbb8e",
+      "status": "modified"
+    },
+    ".pi/scripts/languages/rust/validate-canonical.sh": {
+      "category": "framework",
+      "originalHash": "sha256:c0e145a8e1c16024062bf928945c2cd45c4d1c0a78c942e547a7f3f4ededc80b",
+      "status": "modified"
+    },
+    ".pi/scripts/languages/rust/validate-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d27898b08963a4ddfa0a62227ded3e91e61e81ecd4859c1549c3660abc09ec51",
+      "status": "modified"
+    },
+    ".pi/scripts/languages/rust/validate-integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:11a8b41544e1bd36379f724cd4fefc6ef4c608aca5f093d1db22b840d04d133f",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-tests.sh": {
+      "category": "framework",
+      "originalHash": "sha256:7538f07f8a432ba2c25ca1f53fc2778a3cbe1f811d77f26eff7015915b3471c9",
+      "status": "modified"
+    },
+    ".pi/scripts/validate-security.sh": {
+      "category": "generated",
+      "originalHash": "sha256:0a9453d133e9b8e86cd767cec2f130bd6dc74db93d2169d2e43858af81438630",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-canonical.sh": {
+      "category": "generated",
+      "originalHash": "sha256:66d2e6887f040d7179e811f79f8c9f367066c6fd6a100c462ddb330556d54228",
+      "status": "unchanged"
+    },
+    ".pi/scripts/generate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d4e48b44eacf98df17eab6ad97fb67c58f2569a2200481632ca4cf348ec1daf7",
+      "status": "unchanged"
+    },
+    ".pi/scripts/mr-validation.sh": {
+      "category": "framework",
+      "originalHash": "sha256:21a72f1f485a07fceff2ea4eb54eea5f27dca902a9cf7d577de240ae14015205",
+      "status": "modified"
+    },
+    ".pi/scripts/validate-ci.sh": {
+      "category": "generated",
+      "originalHash": "sha256:d5ae9a470c0e738063a103f8cedd9bb08ebc38dabd35883c6d16874228d08c45",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-integration.sh": {
+      "category": "generated",
+      "originalHash": "sha256:01c0dc34f6a94dcb46428049e4a090c89756c67755f0f16068dcfcb0b4df2ea0",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-tests.sh": {
+      "category": "generated",
+      "originalHash": "sha256:ff7840a569b1571782ae8c4174a6b871345c6a354c65ff4ca5784b898ba15466",
+      "status": "unchanged"
+    },
+    ".pi/scripts/git/close-epic.sh": {
+      "category": "framework",
+      "originalHash": "sha256:579f97aa0e21a601b1592e2e9d44e5e90c543987a6a05d8699a13b0d88c81e94",
+      "status": "modified"
+    },
+    ".pi/scripts/git/close-issue.sh": {
+      "category": "framework",
+      "originalHash": "sha256:62758103b0b0a4f00fbc68d4deb7bb2a3c54be799692c86b52a07866ffc95a31",
+      "status": "modified"
+    },
+    ".pi/scripts/git/update-tracking-issue.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d736fc1688795edfcf16d9ce98a4568f8212195b66f270dd5240719d97806094",
+      "status": "modified"
+    },
+    ".pi/scripts/git/link-issue-to-epic.sh": {
+      "category": "framework",
+      "originalHash": "sha256:54d998ff6d7882829886af667e8d65dfc74f0d3f3b3ee12ad16a2a9c9a858937",
+      "status": "modified"
+    },
+    ".pi/scripts/git/create-tracking-issue.sh": {
+      "category": "framework",
+      "originalHash": "sha256:5c968d6473746edc54077688a2ac779e5e2910b41f8cc57d0db576cd724c2beb",
+      "status": "modified"
+    },
+    ".pi/prompts/blueprint-validate.md": {
+      "category": "framework",
+      "originalHash": "sha256:b73c83cb10e9afbb6b462063cd0a1ad588f301ade22735c2fb03272696d396e6",
+      "status": "unchanged"
+    },
+    ".pi/prompts/bug-fix.md": {
+      "category": "framework",
+      "originalHash": "sha256:0af6405b22d77066427d69b2486f13de2b5d7ceb00a69af78778bdb5bfeb011a",
+      "status": "modified"
+    },
+    ".pi/prompts/issue-implementation-series.md": {
+      "category": "framework",
+      "originalHash": "sha256:983e2b90b70424403a9223b7ed30840878fe7cf4d10b39f8fcf547a4ae0fd1cd",
+      "status": "modified"
+    },
+    ".pi/prompts/pattern-extract.md": {
+      "category": "framework",
+      "originalHash": "sha256:3433fa6188bf8717c4aa8a052c4f3b9c6aaa7ed3e01dc8b816ffc1e0cb7f475a",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-draft.md": {
+      "category": "framework",
+      "originalHash": "sha256:e50f0fb5a7d49d0316259e05e798ac44797b156394c8f7e22407907941309c14",
+      "status": "unchanged"
+    },
+    ".pi/prompts/epic-plan.md": {
+      "category": "framework",
+      "originalHash": "sha256:3633e445bb94ecdd41567490c3c31086784d6597e99ef3e86677628e00feb4b6",
+      "status": "unchanged"
+    },
+    ".pi/prompts/sync-check.md": {
+      "category": "framework",
+      "originalHash": "sha256:06c09fefa4521254c0c0e43b587985d809749a4fa0f9e462fc85f33e8182b382",
+      "status": "unchanged"
+    },
+    ".pi/prompts/blueprint-update.md": {
+      "category": "framework",
+      "originalHash": "sha256:e56adc41911876bbca89fa2d5947c7a76e5ebb4af423f8749d61e700fe4a95f4",
+      "status": "unchanged"
+    },
+    ".pi/prompts/hotfix.md": {
+      "category": "framework",
+      "originalHash": "sha256:ce1c5a45625d678c57094d2d3f7b80d05bb8d19c12afe7e6bf12c1d50ec43f6e",
+      "status": "modified"
+    },
+    ".pi/prompts/issue-template.md": {
+      "category": "framework",
+      "originalHash": "sha256:0171d092bd362617327b5ef14e3b58b06052482ddd338338da3ccfb404ee0e93",
+      "status": "modified"
+    },
+    ".pi/prompts/epic-template.md": {
+      "category": "framework",
+      "originalHash": "sha256:cdc5b784ed287871d651ebcedeacddd74091b4c1ac3b7e696890d78353b94afc",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-closeout.md": {
+      "category": "framework",
+      "originalHash": "sha256:a2c88df36dd87fec9e87f2efcc0ff0ab694b75b5952090763c7081f9bcde5681",
+      "status": "unchanged"
+    },
+    ".pi/prompts/scope-analyzer.md": {
+      "category": "framework",
+      "originalHash": "sha256:be1d74366bbe8e5f7dd5949d45e9adb89b17b6015dc471921e32b6fc2e110633",
+      "status": "unchanged"
+    },
+    ".pi/prompts/ci-blueprint.md": {
+      "category": "framework",
+      "originalHash": "sha256:b2847a4ec3b26f3a77e6c06d8ebe2595032703ec2d8c1529a8f76204bc03c58f",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-template-set.md": {
+      "category": "framework",
+      "originalHash": "sha256:cf6e8b0f1db914475264e6c153cd1945bffc537210501f898c6d01661c9dc027",
+      "status": "modified"
+    },
+    ".pi/prompts/issue-merge.md": {
+      "category": "framework",
+      "originalHash": "sha256:adfc1e0dd785efe556945f74e4f84c1a8f1efbd33d6ad68e50514cacf0b5511c",
+      "status": "unchanged"
+    },
+    ".pi/prompts/context-refresh.md": {
+      "category": "framework",
+      "originalHash": "sha256:09fdc06700827a1aec1906c6710c6c9b2a7419cc984359edcae9339c53114e47",
+      "status": "unchanged"
+    },
+    ".pi/prompts/git-issues.md": {
+      "category": "framework",
+      "originalHash": "sha256:000effa78e9a2bdbe06307eb4de3c879051e59ec728687b20df39db21a69f34c",
+      "status": "unchanged"
+    },
+    ".pi/prompts/feature-development.md": {
+      "category": "framework",
+      "originalHash": "sha256:f388ede538c684a91f3fd59bbac710be8f027a7e5214717f83caeb4325289909",
+      "status": "modified"
+    },
+    ".pi/prompts/plan-to-issues.md": {
+      "category": "framework",
+      "originalHash": "sha256:1cc665bad7a5aa45a8b769d22a8dbc5c7288ccaa2e8e017935b9ce7f6fd13fe8",
+      "status": "unchanged"
+    },
+    ".pi/prompts/refactoring.md": {
+      "category": "framework",
+      "originalHash": "sha256:fb65f0efee082ea47aa893bde7ac6f4d6014512e3dec3f9b820d86f1bcf6037a",
+      "status": "modified"
+    },
+    ".pi/skills/agents/slash-commands.md": {
+      "category": "framework",
+      "originalHash": "sha256:d9783d8d481ae7a02c2c91db52f8600c7fb6821418dcbd5f589ca37f314b6a1b",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/pipeline.md": {
+      "category": "framework",
+      "originalHash": "sha256:619398512a775ba23612a7c436da7ae125af2ddc3a6ae63829a190d1716822ed",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/debug.md": {
+      "category": "framework",
+      "originalHash": "sha256:65368b250d343f208d3ad07d63b23fee8a178f3e9a3a65079d1b05ccb954b7ed",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/issue-factory.md": {
+      "category": "framework",
+      "originalHash": "sha256:078e16f2b69c44ea7bc3d356dc3b8a3bf861b220a3ce3fc4c2a0dd2e949848ac",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/architecture-coordinator.md": {
+      "category": "framework",
+      "originalHash": "sha256:87877ea4cc689c98f6ab8d661d85b0d0af8debe06f6840ab62c891370ba112f7",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/snippets.md": {
+      "category": "framework",
+      "originalHash": "sha256:4bf69877925a542de4d6f84f0205654ae2c53ac56ba740674eb849f1a7d1ce95",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/architecture-generator.md": {
+      "category": "framework",
+      "originalHash": "sha256:6b2763ece59b22d86a95e1d1712b118cbb700e0cce5d941435604b4acca3fd4b",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/land.md": {
+      "category": "framework",
+      "originalHash": "sha256:099bedd22bfd99ac6d061d376f0c5d0314bd7ddd351166d2816122d9ae210207",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/push.md": {
+      "category": "framework",
+      "originalHash": "sha256:93a9a3f3e154743e342ccc75f3780cca9efd2738d90545bd43bdc5518a2b310d",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/curator.md": {
+      "category": "framework",
+      "originalHash": "sha256:3a6ef64758000d80c5a126356afb1b7539e76b83f9a2dd6a42da2f99ebb435d3",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/kanban.md": {
+      "category": "framework",
+      "originalHash": "sha256:e82cc278ab29c86e93a0bdb222717f36088a3c0c02f5fa4e86b2fe28be723dab",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/ci-mr-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:ad5ae29d0043ac16c3a082488932e79f9f21132142616977d00aaf1f8bf26767",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/session-persistence.md": {
+      "category": "framework",
+      "originalHash": "sha256:3bdcb4d1008894d807773b28cc8a2c4ff3c933a5ecd296930a2bb1559b867d73",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/subagent-registry.md": {
+      "category": "framework",
+      "originalHash": "sha256:4b89ea68c8fca289a90a232ef86ff0b1b37c096482cbeb2a8450d28f2fb68a86",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/pull.md": {
+      "category": "framework",
+      "originalHash": "sha256:4d837457b90163de6b0a59ab425855f23e8efd0bf5cd7e945fa7ba4adead65d4",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/operations-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:86ee49c63e881afc18c5a0438d614d3918cb18c468720c9bb4d1f7ab5f37c298",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/issue-creator.md": {
+      "category": "framework",
+      "originalHash": "sha256:78e72f5e3ecb7e8737449c96ae17ac4b5c48bb31ed2a1e2fc929277462a02648",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/plan-mode.md": {
+      "category": "framework",
+      "originalHash": "sha256:7a37581c5005995fc0afa0fb77c1991de3384fa0dd2326610207927d28a6032c",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/hooks.md": {
+      "category": "framework",
+      "originalHash": "sha256:5ffafef4d3861be81760dd5bc7792ec865de37d6e668cde9636e607fd851c95b",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/security-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:1f5ab8b7f01f5dc0342c5c90dcf745f81b8f00858fd0d8283a979ee22e91581b",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/integration-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:c3894b281c5d79473002a9d8d5f81fbfe2909705c65e756415175972a6ebb62d",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/goal-loop.md": {
+      "category": "framework",
+      "originalHash": "sha256:5aacf58ec91fa18ec7b2a19dc511607a57c8a89974fdc864fa13f1e85bc53bca",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/documentation-maintainer.md": {
+      "category": "framework",
+      "originalHash": "sha256:dea9a6b86b2de03a78f1e042649f6a54a1729286ffbea8fb943a9ec61baa281a",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/commit.md": {
+      "category": "framework",
+      "originalHash": "sha256:e137745830577995cfc2a8ff26ed4ffcbd6da49e56065a755b06ce8725765916",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/architecture-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:fc468492fe93b5b4c2d460195a9b379f79b58913db59443ff1c25f54ae1b1310",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/code-developer.md": {
+      "category": "framework",
+      "originalHash": "sha256:05c8f2729446681f546af7d5f78009f39112b5008ea8e86fb70184db1065463f",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/test-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:37557feb88715946a1d3e11cdaa67ab2395e785b0c13866f7038cc97c798f825",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/security-guards.md": {
+      "category": "framework",
+      "originalHash": "sha256:df4d2135c38aeea2cc781e6acd3fad5caac5ceb226c58dd14a7a0dfae51402b9",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/context-compaction.md": {
+      "category": "framework",
+      "originalHash": "sha256:2f238359167f08f4acee8cc76945a572e1203fb61027b93bcdc722e079591445",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/operations-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:363b53637cf49af6268f59bf53e70bec2e0f81366c9db192e771a1c2fb2bf7cc",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/model-registry.md": {
+      "category": "framework",
+      "originalHash": "sha256:82b1604c59f2b38e7ecb3b9a99ddca40ff2a886f559af2f8b8b2f1d6fa1262c2",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/security-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:34a70bb93cb256f30463519967601ce2f4e44c7dc0284d5f034a7120a79ef4ec",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/integration-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:10d21f097ff8e86312318538cf342ad56a0de18a56ddbeb80c44c98cd1ee00c0",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/system-prompt-tiers.md": {
+      "category": "framework",
+      "originalHash": "sha256:e4977fe1ad0c2ce8248deb136031a3aba59f6fed75f52850fc5e306027277aeb",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/architecture-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:7ef93c32dfffb458b6c1301ebf621bada00f4cf5573f5d030c552327579551bd",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/test-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:3709ea4476727c6e7db56a40dd3be5902140cfaf76ab990cb94b52847d4a92bb",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/ci-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:9abee72b24b7322a0130bb91da5ff20d39064cb75abddd25d2c589f442a22839",
+      "status": "unchanged"
+    },
+    ".pi/validators/default.toml": {
+      "category": "framework",
+      "originalHash": "sha256:b9fea586ef6035733f7873cab8ba3399426a6ea67de10f5ebb4f8110620436d4",
+      "status": "modified"
+    },
+    ".pi/validators/README.md": {
+      "category": "framework",
+      "originalHash": "sha256:ae67775d2cd23d35a28f8850161f88666fbf5a9bc2b62e91bf3de31d5c3a0ace",
+      "status": "unchanged"
+    },
+    ".pi/validators/spring.toml": {
+      "category": "framework",
+      "originalHash": "sha256:afc0f8b49b5228869f296a7683b1d8a5f6ffc72f366f889a4ab7f5a8a4cc2b1e",
+      "status": "unchanged"
+    },
+    ".pi/preflight_report.json": {
+      "category": "framework",
+      "originalHash": "sha256:d621e39f625c29933f6572b142c14d3b512b8cb7c9abdf02ea8cf734f2e3e948",
+      "status": "modified"
+    },
+    ".pi/domain/ubiquitous-language.md": {
+      "category": "user",
+      "originalHash": "sha256:b047dbd6d32bfcf6c220c3319642c79b4f97787c67e58ac03c5fc18f57ba62cb",
+      "status": "modified"
+    },
+    ".pi/domain/exploration.md": {
+      "category": "user",
+      "originalHash": "sha256:d2028780f7d98161d69352e172886d6409358b4a6111187ca4fc9c523bdb1507",
+      "status": "modified"
+    },
+    ".pi/skills/architecture-coordinator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:9ee8dec69e586ce76212637f5ea4af3bbf9bda8c62a1be34ee637887e7e7853c",
+      "status": "unchanged"
+    },
+    ".pi/skills/architecture-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:173484cb73e211f9992298a6d31453316d920e6584dfe7eec821ed24cbed132c",
+      "status": "unchanged"
+    },
+    ".pi/skills/security-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:6bdf2727400483ceccefcab27738cdc5cbc202d0619f65d7763ffefce558fdd1",
+      "status": "unchanged"
+    },
+    ".pi/skills/operations-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:a6b5477d1d5360afe57c2e388bc4fd2dde95a2e767fdd822c4de8c0232d4a949",
+      "status": "unchanged"
+    },
+    ".pi/skills/test-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:d3cb5d302d75404cd5eb25e5bd21657408c8a6384d7058488107aaaf3980abd2",
+      "status": "unchanged"
+    },
+    ".pi/skills/integration-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:3e8b2633d74e72c95823a0c8d1c1aa113df951a1189e744d05636ea0eafdba92",
+      "status": "unchanged"
+    },
+    ".pi/skills/ci-mr-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:a02261fde3f57b06fbdf1aac8b50c07751d37fc18b4dcabbdd49c4dd768c9891",
+      "status": "unchanged"
+    },
+    ".pi/skills/code-developer/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:4de040029d0cb8d770c24628b261b79734898d9934ac1420bc261bca7a90ba07",
+      "status": "unchanged"
+    },
+    ".pi/skills/issue-creator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:a3fc83765d76736c66a7ebc270abac4e3c6b2779e8e3672563df97b3b8df506a",
+      "status": "unchanged"
+    },
+    ".pi/skills/documentation-maintainer/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:a525a631a09ad44d3306a6893b2ffe22a6c86aebc4a678721c09c8f17101562d",
+      "status": "unchanged"
+    },
+    ".pi/README.md": {
+      "category": "generated",
+      "originalHash": "sha256:46adb3cb48b79ee5e26595b06cdd22992cb3252f643ded3ec7a6f7f8677b0ca1",
+      "status": "unchanged"
+    },
+    ".claude/CLAUDE.md": {
+      "category": "generated",
+      "originalHash": "sha256:90fc20ed9988cceeac4702a119db0b176e93a524f23a2c85b39e6290476095e1",
+      "status": "unchanged"
+    },
+    ".claude/context/patterns.md": {
+      "category": "generated",
+      "originalHash": "sha256:4112d8039404cd27789eec23638f151e707d7d09150691eecea384bec52e7b68",
+      "status": "unchanged"
+    },
+    ".claude/context/checklists.md": {
+      "category": "generated",
+      "originalHash": "sha256:9109e716ec5a175c2deb32c69c8a915868e98300c3e8937ab09eb4b4eb704338",
+      "status": "unchanged"
+    },
+    ".claude/context/output-formats.md": {
+      "category": "generated",
+      "originalHash": "sha256:28ee6b953f5f4b49152362c4bcbc2983e1fc32aa9517d3e718011fae8fdcc81e",
+      "status": "unchanged"
+    },
+    ".claude/context/project.md": {
+      "category": "generated",
+      "originalHash": "sha256:e73bedd9edcceb32498a41520d639e7909fe2bef59cfa164c838653b7aadd1a8",
+      "status": "unchanged"
+    },
+    ".claude/architecture/CHANGELOG.md": {
+      "category": "generated",
+      "originalHash": "sha256:5f9974438a25f6dab13ed274457aa2794b326fa01ca3b51635f80afddf348b77",
+      "status": "unchanged"
+    },
+    ".claude/agents/orchestrators/architecture-coordinator.md": {
+      "category": "generated",
+      "originalHash": "sha256:de32815f4bcb95aa83ef33e9b72932f651b96484ba8b06b967b3708c58903a3e",
+      "status": "unchanged"
+    },
+    ".claude/agents/validators/architecture-validator.md": {
+      "category": "generated",
+      "originalHash": "sha256:157ed5578ade0adc724cbebbdff3325a729988d454ce78d7c50b8757497bb99c",
+      "status": "unchanged"
+    },
+    ".claude/agents/validators/security-validator.md": {
+      "category": "generated",
+      "originalHash": "sha256:7841fee35b4ee4e8a5807cdde7601b40526bc2369b3fab33eec396b086799321",
+      "status": "unchanged"
+    },
+    ".claude/agents/validators/operations-validator.md": {
+      "category": "generated",
+      "originalHash": "sha256:ff0ca44985a2f83ed3219d2adffa809c1497b106443db0995364297726378678",
+      "status": "unchanged"
+    },
+    ".claude/agents/validators/test-validator.md": {
+      "category": "generated",
+      "originalHash": "sha256:f2aa822de21f6422ddae6a35db2fe2610779083e0c8b1c5b95e507113559bb7d",
+      "status": "unchanged"
+    },
+    ".claude/agents/validators/integration-validator.md": {
+      "category": "generated",
+      "originalHash": "sha256:8fff0a0393592b5a5b7ed0e23ff4402f471540da21a3e0bb4b02cf32a1ba2612",
+      "status": "unchanged"
+    },
+    ".claude/agents/validators/ci-mr-validator.md": {
+      "category": "generated",
+      "originalHash": "sha256:b9b4876f220aebaf8fd6aa3f377364849191baa028cca5b99ae3d49abcf90afc",
+      "status": "unchanged"
+    },
+    ".claude/agents/implementers/code-developer.md": {
+      "category": "generated",
+      "originalHash": "sha256:41ea049e6437770662c713aeccf5f8608026602457a1c3a24e3f618dda5e780f",
+      "status": "unchanged"
+    },
+    ".claude/agents/implementers/issue-creator.md": {
+      "category": "generated",
+      "originalHash": "sha256:20a6bfd6b81e13b8072ae2f94d8a73714a9838911990e2fbd6488e00d121815b",
+      "status": "unchanged"
+    },
+    ".claude/agents/implementers/documentation-maintainer.md": {
+      "category": "generated",
+      "originalHash": "sha256:960e9005eb9eacf63819e8dd2d7e4eb203c73a4d444d4dc093a3a0941176df83",
+      "status": "unchanged"
+    },
+    ".claude/workflows/feature-development.md": {
+      "category": "generated",
+      "originalHash": "sha256:9492fc5e899dd3d7c514e864090984d7b2c966d76dde169b559b5c1717387dfc",
+      "status": "unchanged"
+    },
+    ".claude/workflows/bug-fix.md": {
+      "category": "generated",
+      "originalHash": "sha256:2542fa08d95679192df9139de6ebdfe4e2afd108a1b6aba55897c57bf2da6447",
+      "status": "unchanged"
+    },
+    ".claude/workflows/hotfix.md": {
+      "category": "generated",
+      "originalHash": "sha256:cc379ec1d5f05896efe224d624a52a1e3b07f4a72ea691526e3f6938e0fadc33",
+      "status": "unchanged"
+    },
+    ".claude/workflows/refactoring.md": {
+      "category": "generated",
+      "originalHash": "sha256:4260e61f9e2788ecae8b254b5a943b0fd7f46319d4bf7d31e0a0a904ecf43485",
+      "status": "unchanged"
+    },
+    ".claude/workflows/epic-plan.md": {
+      "category": "generated",
+      "originalHash": "sha256:344202f63d6b54b0717bfc8cd0952f2ea39a615bb11c8ddfc19d59b731416d22",
+      "status": "unchanged"
+    },
+    ".claude/workflows/issue-draft.md": {
+      "category": "generated",
+      "originalHash": "sha256:71fd869d38a44ffdda1f5efb05e29e1579a6ea7484c3e53a35055313b8cacdb0",
+      "status": "unchanged"
+    },
+    ".claude/workflows/git-issues.md": {
+      "category": "generated",
+      "originalHash": "sha256:377526f7194e33c82fdd867bd661ae11fc161b9c000b6f84ed6eae0754aaa27a",
+      "status": "unchanged"
+    },
+    ".claude/workflows/issue-closeout.md": {
+      "category": "generated",
+      "originalHash": "sha256:d04911ed2964403a2f2e3a13bd4d79beb8a06ad964c3e6f7e41cc7e79add62e8",
+      "status": "unchanged"
+    },
+    ".claude/workflows/issue-merge.md": {
+      "category": "generated",
+      "originalHash": "sha256:5035ecf6ec52619e54e44421a2d00e2e8ec2edcc672b2c6cc0ae446ac9b77b2a",
+      "status": "unchanged"
+    },
+    ".claude/workflows/plan-to-issues.md": {
+      "category": "generated",
+      "originalHash": "sha256:b7d4bc8867b8c155da1daa728a2641074c21f25e397006aa06e42a23a7c1212f",
+      "status": "unchanged"
+    },
+    ".claude/workflows/blueprint-validate.md": {
+      "category": "generated",
+      "originalHash": "sha256:19a645aca2b82b19912c391fa9378df2a25ffbc0241eb3d14fa94239a7bbfaed",
+      "status": "unchanged"
+    },
+    ".claude/workflows/sync-check.md": {
+      "category": "generated",
+      "originalHash": "sha256:0a0dc61c8241db50a4021b5c336b54c312d635d50012586f6e6a83e64e0ef144",
+      "status": "unchanged"
+    },
+    ".claude/workflows/context-refresh.md": {
+      "category": "generated",
+      "originalHash": "sha256:8fe632cc68eb1003ad01063da90baa9a0e0125ba108432e2d5cba9e19123581c",
+      "status": "unchanged"
+    },
+    ".claude/workflows/scope-analyzer.md": {
+      "category": "generated",
+      "originalHash": "sha256:eda5547ab8fa1ea3394679eb521166d901d301878521cfea92e23a44969507dc",
+      "status": "unchanged"
+    },
+    ".claude/workflows/pattern-extract.md": {
+      "category": "generated",
+      "originalHash": "sha256:012d5af8d12a7c62cf3572cdedb92e3ef58a2c5cfd7e9eb1139c99970e431426",
+      "status": "unchanged"
+    },
+    ".claude/workflows/blueprint-update.md": {
+      "category": "generated",
+      "originalHash": "sha256:97da9c72c3592034c9e0891895c5e3a31e2151afbc0e4cf785f4f4ac377da5ba",
+      "status": "unchanged"
+    },
+    ".claude/context/INDEX.md": {
+      "category": "generated",
+      "originalHash": "sha256:f7383eee8c1c78b0a1f53edf77858dfea44e4dd8209836790b1ecc78ca3ee045",
+      "status": "unchanged"
+    },
+    ".claude/scripts/validate-ci.sh": {
+      "category": "generated",
+      "originalHash": "sha256:d5ae9a470c0e738063a103f8cedd9bb08ebc38dabd35883c6d16874228d08c45",
+      "status": "unchanged"
+    },
+    ".claude/scripts/validate-tests.sh": {
+      "category": "generated",
+      "originalHash": "sha256:ff7840a569b1571782ae8c4174a6b871345c6a354c65ff4ca5784b898ba15466",
+      "status": "unchanged"
+    },
+    ".claude/scripts/validate-security.sh": {
+      "category": "generated",
+      "originalHash": "sha256:0a9453d133e9b8e86cd767cec2f130bd6dc74db93d2169d2e43858af81438630",
+      "status": "unchanged"
+    },
+    ".claude/scripts/validate-operations.sh": {
+      "category": "generated",
+      "originalHash": "sha256:4fb994c9056b90f565fe536633795586da3197a2a2b8f745baea9af8db4440d5",
+      "status": "unchanged"
+    },
+    ".claude/scripts/validate-integration.sh": {
+      "category": "generated",
+      "originalHash": "sha256:01c0dc34f6a94dcb46428049e4a090c89756c67755f0f16068dcfcb0b4df2ea0",
+      "status": "unchanged"
+    },
+    ".claude/scripts/validate-architecture.sh": {
+      "category": "generated",
+      "originalHash": "sha256:241df1a4517e0a04aff9cfc4efddbdcb4b3859e65bd35cb8c558a172dfe7cf4d",
+      "status": "unchanged"
+    },
+    ".claude/scripts/validate-canonical.sh": {
+      "category": "generated",
+      "originalHash": "sha256:66d2e6887f040d7179e811f79f8c9f367066c6fd6a100c462ddb330556d54228",
+      "status": "unchanged"
+    },
+    ".claude/scripts/validation-cache.sh": {
+      "category": "generated",
+      "originalHash": "sha256:5fea93087bcd9852532ce8119f47ecdb61a46fd857b336e2955b087ed61aa3bd",
+      "status": "unchanged"
+    },
+    ".claude/README.md": {
+      "category": "generated",
+      "originalHash": "sha256:bab86da6c49ec624c9caabe5a7a271c8fc94c4c4dbe411253ea1c8ba9263a395",
+      "status": "unchanged"
+    },
+    ".gitignore": {
+      "category": "framework",
+      "originalHash": "sha256:b071663b414d6bf1004373057662f2b2809fd42367e53d2484c27e54c1ab5fb7",
+      "status": "unchanged"
+    },
+    "WORKFLOW.md": {
+      "category": "framework",
+      "originalHash": "sha256:9808142326406a2f271bb22491fe4f1355dda06c59c2f5267012b75bbde62d57",
+      "status": "unchanged"
+    },
+    ".pi/extensions/architect-lib/forge-adapter.ts": {
+      "category": "framework",
+      "originalHash": "sha256:c93c6f998544d5b3d148663d2c4a09a95b8bbae2d0fba93c845ff1f51678d3a6",
+      "status": "configured"
+    },
+    ".pi/extensions/architect-lib/tdd-generator.ts": {
+      "category": "framework",
+      "originalHash": "sha256:a583891e8a9352dacc526a5c04d658f3a67a0e73a50e473e253f12d5c7c59066",
+      "status": "configured"
+    },
+    ".pi/extensions/tsconfig.json": {
+      "category": "framework",
+      "originalHash": "sha256:d00580bfe8a5492c24b0eb13bce2ee699d56b98ce5ef4f71af2918b1ddc0b309",
+      "status": "configured"
+    },
+    ".pi/architecture/implementation-roadmap.md": {
+      "category": "user",
+      "originalHash": "sha256:277e4ba1207cb122d73eccc09dba04d76fba0d8e3e5004dd348e1ee34aaa10ba",
+      "status": "configured"
+    },
+    ".pi/scripts/ci/local-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:98d8181260d31fd3303eebf92bc70412590131a75385fefb679e038574b2d54e",
+      "status": "configured"
+    },
+    ".pi/scripts/ci/check_ddd_structure.sh": {
+      "category": "framework",
+      "originalHash": "sha256:f2fb90658b34c25f4c85a083ffc35c8e6b388459fbd0ac1b475c0624472cbec3",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/go/validate-operations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:2b6745a33274d3a271a00e8329988f6a40e736ba7e74d0174d2d176b07872e82",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/go/validate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:b6015897f70de7b5edbe1e153655f4b982704586d4d8fac03927d41ad640967f",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/go/validate-security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:bf5377f544e859f1ad99fc3ee0a5e2c8bdb19dcee611e858b0f6ccac4a6516ec",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/go/validate-canonical.sh": {
+      "category": "framework",
+      "originalHash": "sha256:36c34500a75c020cee85b73fea050d1f0c70353248c24fe2572a3f9cd282f9b7",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/go/validate-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:3614692f8dc60c3a29f03673691a663f6c68e3963a84b963db82c1e114581102",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/go/validate-integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:fe3616e2a6db18b783813c5cb22a021daded3c8fc87a6a3c0d4e030a61a18078",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/go/validate-tests.sh": {
+      "category": "framework",
+      "originalHash": "sha256:7e3285166dcbbabf89d4ded78ef336767c3dd03befc25dc6f1ca50513edc2451",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/python/validate-operations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:7050c2345b7ba2bd34cba6f101f4f2c46412155b70e0c461285240c55c71d10b",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/python/validate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:b6f1c2112ffdaf7a0dc835f105ec27c7aa1cd5abfe646725591bc6e0549f31d4",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/python/validate-security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:8d5d076a170c0e36dbcbb14f8099d30d812e022f07d719d14cdae00c31701009",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/python/validate-canonical.sh": {
+      "category": "framework",
+      "originalHash": "sha256:a103e9eabe98aed37b8e52531163212e7dfc15dc554a2be303c4f454d2430b79",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/python/validate-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:2c8c941fa81256d542fb3e900c81134d52d727f6314f759eff6c62d46be58bbf",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/python/validate-integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:065c60cfe9aba2d4f5e52bf752f0e1db97e48ffd093758b1a00ebc0958047e7f",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/python/validate-tests.sh": {
+      "category": "framework",
+      "originalHash": "sha256:0fc7350224acdea5566f5387e007cdd5d619364ad72ac4df82813273fd57fc0b",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/typescript/validate-operations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:61c6c9f26dc06e7027685807c3eba18c0ee6527e69a070fd1ef8cc08f1ca0c92",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/typescript/validate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:27fda438aea3c16685e5630ab8fcbefe9f35a2c41ab010ef9ec26769c46f572f",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/typescript/validate-security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:244280a285eedc000ba540f9aa281965487a632866e5a0a867191b90a747b5fc",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/typescript/validate-canonical.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ead8ae65e342b653fb52197af44cc22a14cf96b355213da31a8606ba186505c6",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/typescript/validate-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ac623eb9b00815e309d2406f354ffeaabd3eea75082e494ec01fdf8f47dc5114",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/typescript/validate-integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ea04b21a89fa59c3b15a3e1988a8341a5cb2b965d0ebf11fe6afd19cc5818676",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/typescript/validate-tests.sh": {
+      "category": "framework",
+      "originalHash": "sha256:0766f2a81e347933eb5165a52f85c6ef187f295a870bb62b14de23d928757a3c",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/java/validate-operations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:85ba34bd70b8bb363f434ff8135bd88eebfa09860f90fd6e98faa2bcacd99d16",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/java/validate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:860df0ab3d3405c665775ff330d3ccc42b04532d9e3e52e8381f6a251ef0d043",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/java/validate-spring-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:7cfba1009c4d01389d8483f08e4707f2e04bfd39d92ee88306052c9199cd2bfa",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/java/validate-annotations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d41f71ecd7bc7bedb32cbc2710b7404d4cdc34d049953a48a2cba293a58fed74",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/java/validate-security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:096d0110bb1e6a41270b6a1b6fbab4754d5545ee399b0c0dc2ceda8e36556883",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/java/validate-canonical.sh": {
+      "category": "framework",
+      "originalHash": "sha256:2305270475030599a2b8e27166f0e6c0f5025b396bf237afcaa3175ad5ec1bcc",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/java/validate-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:fae27bc8b709c88e3d64b6367f9e4604334770d59b4b9e741e06608d08891b12",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/java/validate-integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ff677d9afbc2ba1503d5bbf935a5a96d77930b8ea85e463e175d46680e188ba3",
+      "status": "configured"
+    },
+    ".pi/scripts/languages/java/validate-tests.sh": {
+      "category": "framework",
+      "originalHash": "sha256:e98017ceb722bd3aa6a283000af07d30ed074051e96dbaa76e1081f69274244b",
+      "status": "configured"
+    },
+    ".pi/skills/tdd-practice.md": {
+      "category": "framework",
+      "originalHash": "sha256:8c2a7fbb809dda355bae934cc725b09f5198e4e730a5951819306db76eb2403f",
+      "status": "configured"
+    },
+    ".pi/skills/go-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:5ee2969b7d30428a862240cb1b17b5a19554da2c146912e53557756f0c58c1c0",
+      "status": "configured"
+    },
+    ".pi/skills/angular-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:b8143821f913809df3303f9c20c858ca5aa161eccc7bbc8b69b75050a13088d7",
+      "status": "configured"
+    },
+    ".pi/skills/typescript-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:c4b25b5f5e76e84e2a7ab8af0043993bfb5d47d1c689f6f5377645cca7378ae6",
+      "status": "configured"
+    },
+    ".pi/skills/design-system-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:14e0a6726d32cbb83663f4a181788512e54759662567360624aed4dcb371d7d1",
+      "status": "configured"
+    },
+    ".pi/skills/rust-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:08fde54fe7481b8c997c092344bec1d96db05f6a0a5c038ecd5ba58484a8d9b0",
+      "status": "configured"
+    },
+    ".pi/skills/agents/rust-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:28a65bf73032376577341d8b75b8d9f9788cd6058ae388e1cf1c7c7473e3a835",
+      "status": "configured"
+    },
+    ".pi/skills/agents/typescript-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:09e2ff0b0dea87356ce03347bb7119d2fc669755d25793dd96291b86c55e54b5",
+      "status": "configured"
+    },
+    ".pi/skills/agents/nextjs-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:80900886ae62aa59a1b6e47430849fe1372649244f9814d3d8be00820942c61a",
+      "status": "configured"
+    },
+    ".pi/skills/agents/design-system-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:562a9bc395096fef10911c22ff9480824c0aed48cea7e000e9c1db588c5dfb14",
+      "status": "configured"
+    },
+    ".pi/skills/agents/python-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:a7f573566bd0d90b4d2d4262c43e3de9c0a0379f07f59f185b73730915c14563",
+      "status": "configured"
+    },
+    ".pi/skills/agents/angular-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:ede820cc2fc4f86f11bd2a97e8c03f8a8832944d6e2e33819091f4cb7b5290e9",
+      "status": "configured"
+    },
+    ".pi/skills/agents/java-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:8fe7500823e7b41ee04cc4f0fcb9386aabec2c1b9003e8ce39de09b7cf78fdd3",
+      "status": "configured"
+    },
+    ".pi/skills/agents/go-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:7453a53e9ae8d5b91825aab32ed29c8cc6d16bb07610724a5cfd10a3106db745",
+      "status": "configured"
+    },
+    ".pi/skills/java-spring-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:5d68093293c887875634b9f567c6c886373ebfcf7cf248f4156da42e6c19b490",
+      "status": "configured"
+    },
+    ".pi/skills/python-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:e5f8b0b4a0524ab6efc96ac63e5def6d7f995620ed9caa0044c11288bc301086",
+      "status": "configured"
+    },
+    ".pi/skills/nextjs-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:f1041e806a170fdbc391f6543033322cbe4b9baab82ee19b68b53751652a54cc",
+      "status": "configured"
+    }
+  },
+  "exports": {
+    "claude": {
+      "path": ".claude/",
+      "generatedAt": "2026-06-16T04:28:48.006Z",
+      "sourceHash": "sha256:57ed27756b75ac9a812d3c22c0617cd5fff87abfe1113be6c2dbdfb32cf74d06"
+    }
+  },
+  "templateContext": {
+    "projectName": "rigorix-oss",
+    "projectVersion": "0.1.0",
+    "language": "rust",
+    "repository": "arman-jalili/rigorix-oss",
+    "repoTool": "gh",
+    "groupId": "com.rigorix-oss",
+    "buildCommand": "cargo build",
+    "testCommand": "cargo test --all",
+    "lintCommand": "cargo clippy -- -D warnings",
+    "formatCommand": "cargo fmt",
+    "formatCheckCommand": "cargo fmt --check",
+    "securityAuditCommand": "cargo audit",
+    "errorHandlingPattern": "Result<T, E> pattern",
+    "tracingPattern": "tracing crate with structured spans",
+    "cancellationPattern": "CancellationToken pattern",
+    "atomicWritePattern": "tempfile + rename pattern",
+    "keyFile1": "src/index.ts",
+    "keyFile1Purpose": "Main entry point",
+    "keyFile2": "src/lib/core.ts",
+    "keyFile2Purpose": "Core library functions",
+    "domainDescription": "cli module for rigorix"
+  },
+  "scaffoldedAt": "2026-06-16T04:28:47.905Z",
+  "lastUpdatedAt": "2026-07-17T21:11:39.581Z"
+}

--- a/engine/guardian-manifest.json
+++ b/engine/guardian-manifest.json
@@ -1,0 +1,1237 @@
+{
+  "schemaVersion": "0.1",
+  "frameworkVersion": "0.1.97",
+  "source": "pi",
+  "tools": [
+    "pi"
+  ],
+  "language": "rust",
+  "repoTool": "gh",
+  "groupId": "com.rigorix-oss",
+  "validators": [
+    "ci",
+    "tests",
+    "security",
+    "operations",
+    "integration",
+    "architecture",
+    "canonical"
+  ],
+  "workflows": [
+    "feature-development",
+    "bug-fix",
+    "hotfix",
+    "refactoring",
+    "issue-implementation-series",
+    "epic-plan",
+    "issue-draft",
+    "git-issues",
+    "issue-closeout",
+    "issue-merge",
+    "plan-to-issues",
+    "blueprint-validate",
+    "sync-check",
+    "context-refresh",
+    "scope-analyzer",
+    "pattern-extract",
+    "blueprint-update"
+  ],
+  "files": {
+    ".pi/context/checklists.md": {
+      "category": "framework",
+      "originalHash": "sha256:8f3e52628b0d1abe439d84f3b29848c4141110c485e2d42dd7ae0fb0fd234806",
+      "status": "unchanged"
+    },
+    ".pi/context/domain-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:97dd59742baf08d935f2967f2a99257c23763a122f88f05d5f79a4b429b3fe5d",
+      "status": "modified"
+    },
+    ".pi/context/project.md": {
+      "category": "user",
+      "originalHash": "sha256:2dd4ff55bd49f0524108fbcbb344acfce74eb7d66772a212261b505880b1b019",
+      "status": "modified"
+    },
+    ".pi/context/patterns.md": {
+      "category": "user",
+      "originalHash": "sha256:51a1ffa9ad2fc4631fa3b15d60da3a66414d1457ccd523c1a0866592bb373c30",
+      "status": "modified"
+    },
+    ".pi/context/output-formats.md": {
+      "category": "framework",
+      "originalHash": "sha256:57700883af3a4bac040a49c7a00e34040ef64fe66fe45502fa44dd6a49dada1f",
+      "status": "unchanged"
+    },
+    ".pi/context/patterns-base.md": {
+      "category": "framework",
+      "originalHash": "sha256:8d9bf4d5c7ab81f060b0fadf8138cbb615b26119860988215f2ebd405c42bd1e",
+      "status": "unchanged"
+    },
+    ".pi/workpad.md": {
+      "category": "framework",
+      "originalHash": "sha256:c15373fbf3ad0317a1281066c7605a9f2c0823c1a3c5e946e0620b808c6bf67b",
+      "status": "unchanged"
+    },
+    ".pi/agents/issue-factory.md": {
+      "category": "framework",
+      "originalHash": "sha256:8e1d2a8211e7634736c51f6fe5af2ae48d3263a39d54ddc7cb23c9183537ae06",
+      "status": "unchanged"
+    },
+    ".pi/agents/architecture-coordinator.md": {
+      "category": "framework",
+      "originalHash": "sha256:0449f8b3d33b1d479e0699303eea0e6c6d512f38972e99cb1b8c0da0f7b37f8c",
+      "status": "unchanged"
+    },
+    ".pi/agents/bootstrap-implementer.md": {
+      "category": "framework",
+      "originalHash": "sha256:77662fa88c70fe139f7ff526c8763a3226d7dff6c249081a7a63d02e1ac72041",
+      "status": "unchanged"
+    },
+    ".pi/agents/operations-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:e64c119a9f0fc7c9fcebf813f47bd43b091c8049a6fd32a2789da69ec1c1fbde",
+      "status": "unchanged"
+    },
+    ".pi/agents/security-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:6cd0cd853582cb8f60d27c7bb9e339977928a07f3b4fb8fb66bf894bd6fad728",
+      "status": "unchanged"
+    },
+    ".pi/agents/architecture-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:3fbae65130cbb256e5be0c0e3b784de9fd681a9a54629bb270617e29886fcc9c",
+      "status": "unchanged"
+    },
+    ".pi/agent/AGENTS.md": {
+      "category": "user",
+      "originalHash": "sha256:240369371efe62367c638e1e094896657de40d09b80303ce953878345c517968",
+      "status": "modified"
+    },
+    ".pi/extensions/curator.ts": {
+      "category": "framework",
+      "originalHash": "sha256:7cebd53167de7c68d0b776be1ed878808f04035104125ebb8222e15367708f83",
+      "status": "modified"
+    },
+    ".pi/extensions/session-persistence.ts": {
+      "category": "framework",
+      "originalHash": "sha256:8994200dabf4502b4c315278cb995b9195f5060bfd7f416ba0eb1ed74008d66e",
+      "status": "modified"
+    },
+    ".pi/extensions/domain-explorer.ts": {
+      "category": "framework",
+      "originalHash": "sha256:083c88fb73dc7c0238158e24a496bfd993c30e4220ac88dfbe9c7b91b1b0cbb3",
+      "status": "modified"
+    },
+    ".pi/extensions/kanban.ts": {
+      "category": "framework",
+      "originalHash": "sha256:ae324cea4192f38295469343d1c841e7b4cfa33a4887cde176c873c128c7a605",
+      "status": "modified"
+    },
+    ".pi/extensions/project-scaffolder.ts": {
+      "category": "framework",
+      "originalHash": "sha256:a30e79c81a5f373401a038fdd87d313761d3ce933cb5dee6789e0e2842ecaa74",
+      "status": "modified"
+    },
+    ".pi/extensions/snippets.ts": {
+      "category": "framework",
+      "originalHash": "sha256:30d157510a72a2f5dd0ebbbe706ebfa780131eb397e2d1091c88f1b7f067ec68",
+      "status": "modified"
+    },
+    ".pi/extensions/read-only-mode.ts": {
+      "category": "framework",
+      "originalHash": "sha256:a579d34865fee1d53fec4d7218e905cfc3b1e08c8fafa1492a2532140f910f1e",
+      "status": "modified"
+    },
+    ".pi/extensions/slash-commands.ts": {
+      "category": "framework",
+      "originalHash": "sha256:e60a12667b22dd287b2da0969df554f3d8e40a7be12e85c122232310057f075f",
+      "status": "modified"
+    },
+    ".pi/extensions/config-reload.ts": {
+      "category": "framework",
+      "originalHash": "sha256:702c33e12f62867cadce1eeb8e94c98a491cc8b048bd88c6031daee514b957c7",
+      "status": "modified"
+    },
+    ".pi/extensions/pipeline.ts": {
+      "category": "framework",
+      "originalHash": "sha256:97e5ba0bb53857a920540528fd2f96a0c79b29eac75c6543ab70574497e75567",
+      "status": "modified"
+    },
+    ".pi/extensions/bash-guard.ts": {
+      "category": "framework",
+      "originalHash": "sha256:0af4981f5c6235b2182f2d2aff6b7b0f1377835e6c8a7ff33a93d346b1a693c6",
+      "status": "modified"
+    },
+    ".pi/extensions/validation-runner.ts": {
+      "category": "framework",
+      "originalHash": "sha256:c0352feda293f89c0b1757a592c0a8341ce30274666876474ffe804d46214793",
+      "status": "modified"
+    },
+    ".pi/extensions/architect.ts": {
+      "category": "framework",
+      "originalHash": "sha256:767c5a196c65fc1376b80b8a129729f6d3f5485ca0ed8d3c0a64f4f1dc995a29",
+      "status": "modified"
+    },
+    ".pi/extensions/architect-lib/helpers.ts": {
+      "category": "framework",
+      "originalHash": "sha256:f465a65307fe72a48da7ad2f3afe6f2821970131655240b2da3722308d8df6aa",
+      "status": "modified"
+    },
+    ".pi/extensions/architect-lib/generators.ts": {
+      "category": "framework",
+      "originalHash": "sha256:942c1b7061dfbfb0443484cb853b7f38641bdf4acf6f414a358d2d15ff03fe96",
+      "status": "modified"
+    },
+    ".pi/extensions/architect-lib/types.ts": {
+      "category": "framework",
+      "originalHash": "sha256:d4c9206f10fd179d7e312039ee3a7b4b51363d90d7a6f9c1b9898a306082f535",
+      "status": "modified"
+    },
+    ".pi/extensions/ask-user-question.ts": {
+      "category": "framework",
+      "originalHash": "sha256:983057f59aa40647f11c0703f1b9393e780900e23c67be0e579881d1c6729edb",
+      "status": "modified"
+    },
+    ".pi/extensions/filechanges.ts": {
+      "category": "framework",
+      "originalHash": "sha256:411094739728d704423b287f54dd4d265c5aab3346bb90f7f638b856aaebe244",
+      "status": "modified"
+    },
+    ".pi/extensions/hooks.ts": {
+      "category": "framework",
+      "originalHash": "sha256:46fa45dd6b3d7db55208fdf5e28001fd2d5e6a53570f38d78eee57537b96bf48",
+      "status": "modified"
+    },
+    ".pi/extensions/coordinator.ts": {
+      "category": "framework",
+      "originalHash": "sha256:7d7717d602cc4bd3966ab7d3187e44534d7812f24c431206d6f75b7cce9fe033",
+      "status": "modified"
+    },
+    ".pi/extensions/goal-loop.ts": {
+      "category": "framework",
+      "originalHash": "sha256:6ed7949769ef9a36a7c0e023779279d8407b7a16867445c01b1102d13213688f",
+      "status": "modified"
+    },
+    ".pi/extensions/redaction.ts": {
+      "category": "framework",
+      "originalHash": "sha256:9f69807463e1bf305cd981e2ca18c432446ba67ffb83e8b5f518d9fdb1c691f2",
+      "status": "modified"
+    },
+    ".pi/extensions/plan-mode.ts": {
+      "category": "framework",
+      "originalHash": "sha256:6d0b1a68ec3c64127421b5eea7b3385790d870b69de291b24e6c967354e743d4",
+      "status": "modified"
+    },
+    ".pi/types.ts": {
+      "category": "framework",
+      "originalHash": "sha256:017a07fae90a46fca800dcb6b3ef19050570677c8a4a9672f85b238183f72ee4",
+      "status": "unchanged"
+    },
+    ".pi/architecture/CHANGELOG.md": {
+      "category": "framework",
+      "originalHash": "sha256:653bed6d8499cbf4b96598d1c3c6e0537989018b08654fc9422d50c85a8f20d6",
+      "status": "modified"
+    },
+    ".pi/architecture/diagrams/system-overview.md": {
+      "category": "framework",
+      "originalHash": "sha256:162cb1fa10bc933370390c9b37d64dcb4dad333e4ecef4e73c3d48e9d8ae91d3",
+      "status": "modified"
+    },
+    ".pi/architecture/decisions/ADR-template.md": {
+      "category": "framework",
+      "originalHash": "sha256:18e171fa061c7f8abd07b3b90a7d02f619bf1545124969203225f4bdd4b41531",
+      "status": "unchanged"
+    },
+    ".pi/architecture/modules/module-template.md": {
+      "category": "framework",
+      "originalHash": "sha256:4790f7bde099ad6ee10f11602ecfc281c6de4e775c7739500eb1260afc1fa849",
+      "status": "modified"
+    },
+    ".pi/github/instructions/architecture.instructions.md": {
+      "category": "framework",
+      "originalHash": "sha256:9f26ff4819db738887c1cdb9745537dadc43fc05ad788684b38dbc7a6dad17d5",
+      "status": "unchanged"
+    },
+    ".pi/github/instructions/validation.instructions.md": {
+      "category": "framework",
+      "originalHash": "sha256:934d64609f1275887a5c2795ce41d7d31fa5e8cf77cac35612d1b8685a44d28b",
+      "status": "unchanged"
+    },
+    ".pi/github/copilot/settings.json": {
+      "category": "framework",
+      "originalHash": "sha256:9e21c730edefe4080fee1014a02fbb96118aa300ea0f93563a53f9c6d9c4f2a1",
+      "status": "unchanged"
+    },
+    ".pi/github/workflows/01-planning-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:b7c13edf0d75fe2cc2a8784461637ec91a2bc894682768b6b208795f60a5d404",
+      "status": "unchanged"
+    },
+    ".pi/github/workflows/03-implementation-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:3b067bd1df93bb8de1eb26873825f2d5a330c46c619cb3209db127d33fde3ebb",
+      "status": "unchanged"
+    },
+    ".pi/github/workflows/04-validation-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:513bb31dd54f5961e221f71e5216fd1acde8ad0158f5523985bdad97a2bff8c8",
+      "status": "unchanged"
+    },
+    ".pi/github/workflows/02-issue-generation-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:41205400814e6d4b77ddbcf351d8e1f0701d11c618225eabf6ed3d3b630d56dd",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/architecture-validator.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:04e7cb86758e135b55abc556b9d043d6f68cd5566dd5b0a882cedc615fbde065",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/issue-factory.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:ef97de04d6f99a3b2edd04182ab8cf73a7da564b99d091f5c3d2056175fd686b",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/architecture-coordinator.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:9e376f5ba69f3fc30672b83e9792bb2cb961abc61d6fddda057a5df2ce398e0e",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/epic-planner.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:859599d908d8d1a5bc41d82eaea9414f147a1a16b8d37a99630f3d700f37c0ca",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/bootstrap-implementer.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:2a0b8f2d37ab6c9112d0fa0101429ad5afe3d2c39328b3d132eee1eeb454a3ee",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/security-validator.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:e9081be418d7f432fbd9b4a63d8181b44e797c93a8b6065ec330e2a5fa4b6109",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/operations-validator.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:464860fa7eabcad393471c8dc434268d2f55e72eda0889386abee02f88315ec3",
+      "status": "unchanged"
+    },
+    ".pi/github/copilot-instructions.md": {
+      "category": "framework",
+      "originalHash": "sha256:f82b95c50d87175e42851487b9c9f8891cfc1b5d74d784fdcbc2c4a221ddd19f",
+      "status": "unchanged"
+    },
+    ".pi/INDEX.md": {
+      "category": "framework",
+      "originalHash": "sha256:e166bc3e698236cbe4ef3fcca2f866c8ac2a28cd4ea293ca74c598a0dfea44ed",
+      "status": "modified"
+    },
+    ".pi/scripts/validate-operations.sh": {
+      "category": "generated",
+      "originalHash": "sha256:4fb994c9056b90f565fe536633795586da3197a2a2b8f745baea9af8db4440d5",
+      "status": "unchanged"
+    },
+    ".pi/scripts/create-feature-branch.sh": {
+      "category": "framework",
+      "originalHash": "sha256:33ff4c76faba418025dbe88a998f2a04a6cafd282d11fc644a50de014cc580d0",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-architecture.sh": {
+      "category": "generated",
+      "originalHash": "sha256:241df1a4517e0a04aff9cfc4efddbdcb4b3859e65bd35cb8c558a172dfe7cf4d",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-ubiquitous-language.sh": {
+      "category": "framework",
+      "originalHash": "sha256:fdae16e0bf2030b87c9bb5263eceb73cd5510066bbe85d7925a35dd92a2a13f8",
+      "status": "modified"
+    },
+    ".pi/scripts/ci/stage_security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:1ebac9c09ebfebc1e9cffdfa474c792f28bbe386a923ca49a0695bddee93df40",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/run_hardening_stages.sh": {
+      "category": "framework",
+      "originalHash": "sha256:8a67c21f7154e1cd4987f6e5e56dbbd476f3bf6d7846d4c167289008979d4a65",
+      "status": "modified"
+    },
+    ".pi/scripts/ci/stage_remaining.sh": {
+      "category": "framework",
+      "originalHash": "sha256:396b75ec9fb00224781e9eca66ac51a9ec7f05876d5175f80070560fdf629fe5",
+      "status": "modified"
+    },
+    ".pi/scripts/ci/check_planning_packet.py": {
+      "category": "framework",
+      "originalHash": "sha256:214e1ce18ed2226f344f25687fde9dd586b061f1af8efd6f54c27bd09dabae67",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_package_build.sh": {
+      "category": "framework",
+      "originalHash": "sha256:67b0f705398369fb171c993c1e673f8cce16e4016cd6c1ca72c8996ce3bda7c4",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/validate_agent_output.py": {
+      "category": "framework",
+      "originalHash": "sha256:51cbdbed1921620608a25c2f4db67dbfd088a3d43cb96a03ec425c181d6ce4c9",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/run_preflight.sh": {
+      "category": "framework",
+      "originalHash": "sha256:137294de31aebfa339ae28ba878cb85720bdbe1b4298a2dd19ca184754bd67c4",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_migration_verify.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d25a4de5ddcb3946fca19e82828dd03f726d2084c71dbe4ecf0e222d1da1b67b",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_unit.sh": {
+      "category": "framework",
+      "originalHash": "sha256:64c8b8a4c6266725962b238a1c9814ea110c0f067e90ca9d38287a40074a5f19",
+      "status": "modified"
+    },
+    ".pi/scripts/ci/stage_release_readiness.sh": {
+      "category": "framework",
+      "originalHash": "sha256:0d62822ea089f0469e66561d501bf03cd5e9bb0dbedb199e0ca39286c3ffaa7c",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_docs_policy.sh": {
+      "category": "framework",
+      "originalHash": "sha256:8b13849d612e4dde20a43e3e2ef23c9279869c14683e29506213749e4f2e29ec",
+      "status": "modified"
+    },
+    ".pi/scripts/ci/validate_agent_output.sh": {
+      "category": "framework",
+      "originalHash": "sha256:26816f935433df71266651dfe393c9ff3b7c3975426e05a93b7308c6fc3b80bf",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:a9617cd791ef4ebc72a519ca5169c287f94ba128e14c19f75a6db24267cf42ec",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/run_stage.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ade2b65032142b6f03fc08ed99828964c0bf6a7121d82969871ac963dac14fe1",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_lint.sh": {
+      "category": "framework",
+      "originalHash": "sha256:b5ce9794af4d271f7e04a82f6a35fe7e254d64ff4e71518cf201e4210c1b6560",
+      "status": "modified"
+    },
+    ".pi/scripts/ci/check_architecture_conformance.sh": {
+      "category": "framework",
+      "originalHash": "sha256:eaee494fb728fdc422fa9d83b4c8abdbe52041bd31e53fa8ba85f91196ea765d",
+      "status": "modified"
+    },
+    ".pi/scripts/ci/stage_static_analysis.sh": {
+      "category": "framework",
+      "originalHash": "sha256:5d40980d65b39245bb3db064f0ae60b977b33cb0e7f86b0d211020cb894bafa7",
+      "status": "modified"
+    },
+    ".pi/scripts/merge-mr.sh": {
+      "category": "framework",
+      "originalHash": "sha256:048a02090a777c3d30c61aa80cccfb3b3a7bb521c1f96c097ed3c06222ffcb7c",
+      "status": "modified"
+    },
+    ".pi/scripts/validate-architecture-readiness.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d460c6ccd94a3382d3fde7fff1e9d9f7c10abba76a3f6a3e41238283e81354d5",
+      "status": "modified"
+    },
+    ".pi/scripts/fetch-issues.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d25b14f67c9f2fda6b82b6cdfba14a0aebe27083fbdbda874f5459d58f99597f",
+      "status": "modified"
+    },
+    ".pi/scripts/categorize-issues.sh": {
+      "category": "framework",
+      "originalHash": "sha256:172e09a69b56e3b502d184f740c447f570647893f4658e2dd91451595f77dc93",
+      "status": "unchanged"
+    },
+    ".pi/scripts/create-mr.sh": {
+      "category": "framework",
+      "originalHash": "sha256:bd9fdfdfa31c9da56d441566249060cc23bc93b0b5a2aa59e8f07d04eab3e05b",
+      "status": "modified"
+    },
+    ".pi/scripts/validation-cache.sh": {
+      "category": "generated",
+      "originalHash": "sha256:5fea93087bcd9852532ce8119f47ecdb61a46fd857b336e2955b087ed61aa3bd",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-operations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ab89729ca059bf5c51693c30dc088ea396c9e3cec282926eb20e0927d7c01c42",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:250210026e0e228def1481a26f9bfc85c032734edc867d1aa153ee5ea4b09e6d",
+      "status": "modified"
+    },
+    ".pi/scripts/languages/rust/validate-security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ce3a057d27fbdcffb0e8043aece29acceea9e9eb69e61dae276f6a7205bdbb8e",
+      "status": "modified"
+    },
+    ".pi/scripts/languages/rust/validate-canonical.sh": {
+      "category": "framework",
+      "originalHash": "sha256:c0e145a8e1c16024062bf928945c2cd45c4d1c0a78c942e547a7f3f4ededc80b",
+      "status": "modified"
+    },
+    ".pi/scripts/languages/rust/validate-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d27898b08963a4ddfa0a62227ded3e91e61e81ecd4859c1549c3660abc09ec51",
+      "status": "modified"
+    },
+    ".pi/scripts/languages/rust/validate-integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:11a8b41544e1bd36379f724cd4fefc6ef4c608aca5f093d1db22b840d04d133f",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-tests.sh": {
+      "category": "framework",
+      "originalHash": "sha256:7538f07f8a432ba2c25ca1f53fc2778a3cbe1f811d77f26eff7015915b3471c9",
+      "status": "modified"
+    },
+    ".pi/scripts/validate-security.sh": {
+      "category": "generated",
+      "originalHash": "sha256:0a9453d133e9b8e86cd767cec2f130bd6dc74db93d2169d2e43858af81438630",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-canonical.sh": {
+      "category": "generated",
+      "originalHash": "sha256:66d2e6887f040d7179e811f79f8c9f367066c6fd6a100c462ddb330556d54228",
+      "status": "unchanged"
+    },
+    ".pi/scripts/generate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d4e48b44eacf98df17eab6ad97fb67c58f2569a2200481632ca4cf348ec1daf7",
+      "status": "unchanged"
+    },
+    ".pi/scripts/mr-validation.sh": {
+      "category": "framework",
+      "originalHash": "sha256:82aa5f05b3d36007434e8df510bf0070be55d59b3d07be9554af4527822505c8",
+      "status": "modified"
+    },
+    ".pi/scripts/validate-ci.sh": {
+      "category": "generated",
+      "originalHash": "sha256:d5ae9a470c0e738063a103f8cedd9bb08ebc38dabd35883c6d16874228d08c45",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-integration.sh": {
+      "category": "generated",
+      "originalHash": "sha256:01c0dc34f6a94dcb46428049e4a090c89756c67755f0f16068dcfcb0b4df2ea0",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-tests.sh": {
+      "category": "generated",
+      "originalHash": "sha256:ff7840a569b1571782ae8c4174a6b871345c6a354c65ff4ca5784b898ba15466",
+      "status": "unchanged"
+    },
+    ".pi/scripts/git/close-epic.sh": {
+      "category": "framework",
+      "originalHash": "sha256:579f97aa0e21a601b1592e2e9d44e5e90c543987a6a05d8699a13b0d88c81e94",
+      "status": "modified"
+    },
+    ".pi/scripts/git/close-issue.sh": {
+      "category": "framework",
+      "originalHash": "sha256:62758103b0b0a4f00fbc68d4deb7bb2a3c54be799692c86b52a07866ffc95a31",
+      "status": "modified"
+    },
+    ".pi/scripts/git/update-tracking-issue.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d736fc1688795edfcf16d9ce98a4568f8212195b66f270dd5240719d97806094",
+      "status": "modified"
+    },
+    ".pi/scripts/git/link-issue-to-epic.sh": {
+      "category": "framework",
+      "originalHash": "sha256:54d998ff6d7882829886af667e8d65dfc74f0d3f3b3ee12ad16a2a9c9a858937",
+      "status": "modified"
+    },
+    ".pi/scripts/git/create-tracking-issue.sh": {
+      "category": "framework",
+      "originalHash": "sha256:5c968d6473746edc54077688a2ac779e5e2910b41f8cc57d0db576cd724c2beb",
+      "status": "modified"
+    },
+    ".pi/prompts/blueprint-validate.md": {
+      "category": "framework",
+      "originalHash": "sha256:b73c83cb10e9afbb6b462063cd0a1ad588f301ade22735c2fb03272696d396e6",
+      "status": "unchanged"
+    },
+    ".pi/prompts/bug-fix.md": {
+      "category": "framework",
+      "originalHash": "sha256:0af6405b22d77066427d69b2486f13de2b5d7ceb00a69af78778bdb5bfeb011a",
+      "status": "modified"
+    },
+    ".pi/prompts/issue-implementation-series.md": {
+      "category": "framework",
+      "originalHash": "sha256:983e2b90b70424403a9223b7ed30840878fe7cf4d10b39f8fcf547a4ae0fd1cd",
+      "status": "modified"
+    },
+    ".pi/prompts/pattern-extract.md": {
+      "category": "framework",
+      "originalHash": "sha256:3433fa6188bf8717c4aa8a052c4f3b9c6aaa7ed3e01dc8b816ffc1e0cb7f475a",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-draft.md": {
+      "category": "framework",
+      "originalHash": "sha256:e50f0fb5a7d49d0316259e05e798ac44797b156394c8f7e22407907941309c14",
+      "status": "unchanged"
+    },
+    ".pi/prompts/epic-plan.md": {
+      "category": "framework",
+      "originalHash": "sha256:3633e445bb94ecdd41567490c3c31086784d6597e99ef3e86677628e00feb4b6",
+      "status": "unchanged"
+    },
+    ".pi/prompts/sync-check.md": {
+      "category": "framework",
+      "originalHash": "sha256:06c09fefa4521254c0c0e43b587985d809749a4fa0f9e462fc85f33e8182b382",
+      "status": "unchanged"
+    },
+    ".pi/prompts/blueprint-update.md": {
+      "category": "framework",
+      "originalHash": "sha256:e56adc41911876bbca89fa2d5947c7a76e5ebb4af423f8749d61e700fe4a95f4",
+      "status": "unchanged"
+    },
+    ".pi/prompts/hotfix.md": {
+      "category": "framework",
+      "originalHash": "sha256:ce1c5a45625d678c57094d2d3f7b80d05bb8d19c12afe7e6bf12c1d50ec43f6e",
+      "status": "modified"
+    },
+    ".pi/prompts/issue-template.md": {
+      "category": "framework",
+      "originalHash": "sha256:0171d092bd362617327b5ef14e3b58b06052482ddd338338da3ccfb404ee0e93",
+      "status": "modified"
+    },
+    ".pi/prompts/epic-template.md": {
+      "category": "framework",
+      "originalHash": "sha256:cdc5b784ed287871d651ebcedeacddd74091b4c1ac3b7e696890d78353b94afc",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-closeout.md": {
+      "category": "framework",
+      "originalHash": "sha256:a2c88df36dd87fec9e87f2efcc0ff0ab694b75b5952090763c7081f9bcde5681",
+      "status": "unchanged"
+    },
+    ".pi/prompts/scope-analyzer.md": {
+      "category": "framework",
+      "originalHash": "sha256:be1d74366bbe8e5f7dd5949d45e9adb89b17b6015dc471921e32b6fc2e110633",
+      "status": "unchanged"
+    },
+    ".pi/prompts/ci-blueprint.md": {
+      "category": "framework",
+      "originalHash": "sha256:b2847a4ec3b26f3a77e6c06d8ebe2595032703ec2d8c1529a8f76204bc03c58f",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-template-set.md": {
+      "category": "framework",
+      "originalHash": "sha256:cf6e8b0f1db914475264e6c153cd1945bffc537210501f898c6d01661c9dc027",
+      "status": "modified"
+    },
+    ".pi/prompts/issue-merge.md": {
+      "category": "framework",
+      "originalHash": "sha256:adfc1e0dd785efe556945f74e4f84c1a8f1efbd33d6ad68e50514cacf0b5511c",
+      "status": "unchanged"
+    },
+    ".pi/prompts/context-refresh.md": {
+      "category": "framework",
+      "originalHash": "sha256:09fdc06700827a1aec1906c6710c6c9b2a7419cc984359edcae9339c53114e47",
+      "status": "unchanged"
+    },
+    ".pi/prompts/git-issues.md": {
+      "category": "framework",
+      "originalHash": "sha256:000effa78e9a2bdbe06307eb4de3c879051e59ec728687b20df39db21a69f34c",
+      "status": "unchanged"
+    },
+    ".pi/prompts/feature-development.md": {
+      "category": "framework",
+      "originalHash": "sha256:f388ede538c684a91f3fd59bbac710be8f027a7e5214717f83caeb4325289909",
+      "status": "modified"
+    },
+    ".pi/prompts/plan-to-issues.md": {
+      "category": "framework",
+      "originalHash": "sha256:1cc665bad7a5aa45a8b769d22a8dbc5c7288ccaa2e8e017935b9ce7f6fd13fe8",
+      "status": "unchanged"
+    },
+    ".pi/prompts/refactoring.md": {
+      "category": "framework",
+      "originalHash": "sha256:fb65f0efee082ea47aa893bde7ac6f4d6014512e3dec3f9b820d86f1bcf6037a",
+      "status": "modified"
+    },
+    ".pi/skills/agents/slash-commands.md": {
+      "category": "framework",
+      "originalHash": "sha256:d9783d8d481ae7a02c2c91db52f8600c7fb6821418dcbd5f589ca37f314b6a1b",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/pipeline.md": {
+      "category": "framework",
+      "originalHash": "sha256:e44a23d8ff5d49b6a1ae08b6b50f5ecbf09f774be2944dc3e60d98f57f7a6ca3",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/debug.md": {
+      "category": "framework",
+      "originalHash": "sha256:65368b250d343f208d3ad07d63b23fee8a178f3e9a3a65079d1b05ccb954b7ed",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/issue-factory.md": {
+      "category": "framework",
+      "originalHash": "sha256:078e16f2b69c44ea7bc3d356dc3b8a3bf861b220a3ce3fc4c2a0dd2e949848ac",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/architecture-coordinator.md": {
+      "category": "framework",
+      "originalHash": "sha256:87877ea4cc689c98f6ab8d661d85b0d0af8debe06f6840ab62c891370ba112f7",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/snippets.md": {
+      "category": "framework",
+      "originalHash": "sha256:4bf69877925a542de4d6f84f0205654ae2c53ac56ba740674eb849f1a7d1ce95",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/architecture-generator.md": {
+      "category": "framework",
+      "originalHash": "sha256:6b2763ece59b22d86a95e1d1712b118cbb700e0cce5d941435604b4acca3fd4b",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/land.md": {
+      "category": "framework",
+      "originalHash": "sha256:099bedd22bfd99ac6d061d376f0c5d0314bd7ddd351166d2816122d9ae210207",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/push.md": {
+      "category": "framework",
+      "originalHash": "sha256:93a9a3f3e154743e342ccc75f3780cca9efd2738d90545bd43bdc5518a2b310d",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/curator.md": {
+      "category": "framework",
+      "originalHash": "sha256:3a6ef64758000d80c5a126356afb1b7539e76b83f9a2dd6a42da2f99ebb435d3",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/kanban.md": {
+      "category": "framework",
+      "originalHash": "sha256:e82cc278ab29c86e93a0bdb222717f36088a3c0c02f5fa4e86b2fe28be723dab",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/ci-mr-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:ad5ae29d0043ac16c3a082488932e79f9f21132142616977d00aaf1f8bf26767",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/session-persistence.md": {
+      "category": "framework",
+      "originalHash": "sha256:3bdcb4d1008894d807773b28cc8a2c4ff3c933a5ecd296930a2bb1559b867d73",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/subagent-registry.md": {
+      "category": "framework",
+      "originalHash": "sha256:4b89ea68c8fca289a90a232ef86ff0b1b37c096482cbeb2a8450d28f2fb68a86",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/pull.md": {
+      "category": "framework",
+      "originalHash": "sha256:4d837457b90163de6b0a59ab425855f23e8efd0bf5cd7e945fa7ba4adead65d4",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/operations-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:86ee49c63e881afc18c5a0438d614d3918cb18c468720c9bb4d1f7ab5f37c298",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/issue-creator.md": {
+      "category": "framework",
+      "originalHash": "sha256:78e72f5e3ecb7e8737449c96ae17ac4b5c48bb31ed2a1e2fc929277462a02648",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/plan-mode.md": {
+      "category": "framework",
+      "originalHash": "sha256:7a37581c5005995fc0afa0fb77c1991de3384fa0dd2326610207927d28a6032c",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/hooks.md": {
+      "category": "framework",
+      "originalHash": "sha256:5ffafef4d3861be81760dd5bc7792ec865de37d6e668cde9636e607fd851c95b",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/security-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:1f5ab8b7f01f5dc0342c5c90dcf745f81b8f00858fd0d8283a979ee22e91581b",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/integration-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:c3894b281c5d79473002a9d8d5f81fbfe2909705c65e756415175972a6ebb62d",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/goal-loop.md": {
+      "category": "framework",
+      "originalHash": "sha256:5aacf58ec91fa18ec7b2a19dc511607a57c8a89974fdc864fa13f1e85bc53bca",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/documentation-maintainer.md": {
+      "category": "framework",
+      "originalHash": "sha256:dea9a6b86b2de03a78f1e042649f6a54a1729286ffbea8fb943a9ec61baa281a",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/commit.md": {
+      "category": "framework",
+      "originalHash": "sha256:e137745830577995cfc2a8ff26ed4ffcbd6da49e56065a755b06ce8725765916",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/architecture-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:fc468492fe93b5b4c2d460195a9b379f79b58913db59443ff1c25f54ae1b1310",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/code-developer.md": {
+      "category": "framework",
+      "originalHash": "sha256:a1497671fe07dde01d159919c12f7cdcaaf2a37df5b1ba38ca7736ef5c77180b",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/test-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:37557feb88715946a1d3e11cdaa67ab2395e785b0c13866f7038cc97c798f825",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/security-guards.md": {
+      "category": "framework",
+      "originalHash": "sha256:df4d2135c38aeea2cc781e6acd3fad5caac5ceb226c58dd14a7a0dfae51402b9",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/context-compaction.md": {
+      "category": "framework",
+      "originalHash": "sha256:2f238359167f08f4acee8cc76945a572e1203fb61027b93bcdc722e079591445",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/operations-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:363b53637cf49af6268f59bf53e70bec2e0f81366c9db192e771a1c2fb2bf7cc",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/model-registry.md": {
+      "category": "framework",
+      "originalHash": "sha256:82b1604c59f2b38e7ecb3b9a99ddca40ff2a886f559af2f8b8b2f1d6fa1262c2",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/security-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:34a70bb93cb256f30463519967601ce2f4e44c7dc0284d5f034a7120a79ef4ec",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/integration-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:10d21f097ff8e86312318538cf342ad56a0de18a56ddbeb80c44c98cd1ee00c0",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/system-prompt-tiers.md": {
+      "category": "framework",
+      "originalHash": "sha256:e4977fe1ad0c2ce8248deb136031a3aba59f6fed75f52850fc5e306027277aeb",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/architecture-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:7ef93c32dfffb458b6c1301ebf621bada00f4cf5573f5d030c552327579551bd",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/test-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:3709ea4476727c6e7db56a40dd3be5902140cfaf76ab990cb94b52847d4a92bb",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/ci-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:9abee72b24b7322a0130bb91da5ff20d39064cb75abddd25d2c589f442a22839",
+      "status": "unchanged"
+    },
+    ".pi/validators/default.toml": {
+      "category": "framework",
+      "originalHash": "sha256:b9fea586ef6035733f7873cab8ba3399426a6ea67de10f5ebb4f8110620436d4",
+      "status": "modified"
+    },
+    ".pi/validators/README.md": {
+      "category": "framework",
+      "originalHash": "sha256:ae67775d2cd23d35a28f8850161f88666fbf5a9bc2b62e91bf3de31d5c3a0ace",
+      "status": "unchanged"
+    },
+    ".pi/validators/spring.toml": {
+      "category": "framework",
+      "originalHash": "sha256:afc0f8b49b5228869f296a7683b1d8a5f6ffc72f366f889a4ab7f5a8a4cc2b1e",
+      "status": "unchanged"
+    },
+    ".pi/preflight_report.json": {
+      "category": "framework",
+      "originalHash": "sha256:8275443a6bea3c1abe6ea5ac871e85ebf109330fb4a1ae6833f70491a8ad812b",
+      "status": "modified"
+    },
+    ".pi/domain/ubiquitous-language.md": {
+      "category": "user",
+      "originalHash": "sha256:b047dbd6d32bfcf6c220c3319642c79b4f97787c67e58ac03c5fc18f57ba62cb",
+      "status": "modified"
+    },
+    ".pi/domain/exploration.md": {
+      "category": "user",
+      "originalHash": "sha256:e6a4048d165eed292ef138c05e93b30900e09143a45668e8f58e3e0b7ecbc71b",
+      "status": "modified"
+    },
+    ".pi/skills/architecture-coordinator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:e1298ffa1b08cef134d790a7c1b54e1f16d1669600da444f31a7dcb36daa7fad",
+      "status": "unchanged"
+    },
+    ".pi/skills/architecture-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:8b138ef77f61b1770d95568b178565d0c5ac8501527585b9a07d9fa56310f66f",
+      "status": "unchanged"
+    },
+    ".pi/skills/security-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:0fb9393e4d4a91e6936e5e7c27d560061ea817f728679d6e0a6969aeaa9e53eb",
+      "status": "unchanged"
+    },
+    ".pi/skills/operations-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:0235cde0327ca5be1460538aa7b96a871229c04c85e0b354522acb89f7a51b92",
+      "status": "unchanged"
+    },
+    ".pi/skills/test-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:9986896971a27e4c7d1fb2f9dedde9160b53b74ecc89087b13d7fe6f0e757be6",
+      "status": "unchanged"
+    },
+    ".pi/skills/integration-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:16e8ad02fbf714fc0a02fd36916aa69053e98c053f5b71934b924490ffa3d537",
+      "status": "unchanged"
+    },
+    ".pi/skills/ci-mr-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:333e22010409512dae2d999a50f89808506eee9a90bd6c7d88aba96a67e5664d",
+      "status": "unchanged"
+    },
+    ".pi/skills/code-developer/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:14d000cf25c1dc522a23df4ee127d04a8e0a571ce9bca57b55adbf7f8a221d88",
+      "status": "unchanged"
+    },
+    ".pi/skills/issue-creator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:1ef7ebb6f2fb8782219574397ebfb4a99a647d661ca45b1077e9aac2a6a9a3e7",
+      "status": "unchanged"
+    },
+    ".pi/skills/documentation-maintainer/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:48e60721c72d968d57e7fef848c92c9a264d2d8f71b0c4169c76ba830ebb52af",
+      "status": "unchanged"
+    },
+    ".pi/README.md": {
+      "category": "generated",
+      "originalHash": "sha256:46adb3cb48b79ee5e26595b06cdd22992cb3252f643ded3ec7a6f7f8677b0ca1",
+      "status": "unchanged"
+    },
+    ".gitignore": {
+      "category": "framework",
+      "originalHash": "sha256:b071663b414d6bf1004373057662f2b2809fd42367e53d2484c27e54c1ab5fb7",
+      "status": "unchanged"
+    },
+    "WORKFLOW.md": {
+      "category": "framework",
+      "originalHash": "sha256:9808142326406a2f271bb22491fe4f1355dda06c59c2f5267012b75bbde62d57",
+      "status": "unchanged"
+    },
+    ".pi/extensions/architect-lib/forge-adapter.ts": {
+      "category": "framework",
+      "originalHash": "sha256:c93c6f998544d5b3d148663d2c4a09a95b8bbae2d0fba93c845ff1f51678d3a6",
+      "status": "unchanged"
+    },
+    ".pi/extensions/architect-lib/tdd-generator.ts": {
+      "category": "framework",
+      "originalHash": "sha256:a583891e8a9352dacc526a5c04d658f3a67a0e73a50e473e253f12d5c7c59066",
+      "status": "unchanged"
+    },
+    ".pi/extensions/tsconfig.json": {
+      "category": "framework",
+      "originalHash": "sha256:d00580bfe8a5492c24b0eb13bce2ee699d56b98ce5ef4f71af2918b1ddc0b309",
+      "status": "unchanged"
+    },
+    ".pi/architecture/implementation-roadmap.md": {
+      "category": "user",
+      "originalHash": "sha256:277e4ba1207cb122d73eccc09dba04d76fba0d8e3e5004dd348e1ee34aaa10ba",
+      "status": "modified"
+    },
+    ".pi/scripts/ci/local-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:98d8181260d31fd3303eebf92bc70412590131a75385fefb679e038574b2d54e",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/check_ddd_structure.sh": {
+      "category": "framework",
+      "originalHash": "sha256:f2fb90658b34c25f4c85a083ffc35c8e6b388459fbd0ac1b475c0624472cbec3",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/go/validate-operations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:2b6745a33274d3a271a00e8329988f6a40e736ba7e74d0174d2d176b07872e82",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/go/validate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:b6015897f70de7b5edbe1e153655f4b982704586d4d8fac03927d41ad640967f",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/go/validate-security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:bf5377f544e859f1ad99fc3ee0a5e2c8bdb19dcee611e858b0f6ccac4a6516ec",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/go/validate-canonical.sh": {
+      "category": "framework",
+      "originalHash": "sha256:36c34500a75c020cee85b73fea050d1f0c70353248c24fe2572a3f9cd282f9b7",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/go/validate-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:3614692f8dc60c3a29f03673691a663f6c68e3963a84b963db82c1e114581102",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/go/validate-integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:fe3616e2a6db18b783813c5cb22a021daded3c8fc87a6a3c0d4e030a61a18078",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/go/validate-tests.sh": {
+      "category": "framework",
+      "originalHash": "sha256:7e3285166dcbbabf89d4ded78ef336767c3dd03befc25dc6f1ca50513edc2451",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/python/validate-operations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:7050c2345b7ba2bd34cba6f101f4f2c46412155b70e0c461285240c55c71d10b",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/python/validate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:b6f1c2112ffdaf7a0dc835f105ec27c7aa1cd5abfe646725591bc6e0549f31d4",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/python/validate-security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:8d5d076a170c0e36dbcbb14f8099d30d812e022f07d719d14cdae00c31701009",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/python/validate-canonical.sh": {
+      "category": "framework",
+      "originalHash": "sha256:a103e9eabe98aed37b8e52531163212e7dfc15dc554a2be303c4f454d2430b79",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/python/validate-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:2c8c941fa81256d542fb3e900c81134d52d727f6314f759eff6c62d46be58bbf",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/python/validate-integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:065c60cfe9aba2d4f5e52bf752f0e1db97e48ffd093758b1a00ebc0958047e7f",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/python/validate-tests.sh": {
+      "category": "framework",
+      "originalHash": "sha256:0fc7350224acdea5566f5387e007cdd5d619364ad72ac4df82813273fd57fc0b",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/typescript/validate-operations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:61c6c9f26dc06e7027685807c3eba18c0ee6527e69a070fd1ef8cc08f1ca0c92",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/typescript/validate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:27fda438aea3c16685e5630ab8fcbefe9f35a2c41ab010ef9ec26769c46f572f",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/typescript/validate-security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:244280a285eedc000ba540f9aa281965487a632866e5a0a867191b90a747b5fc",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/typescript/validate-canonical.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ead8ae65e342b653fb52197af44cc22a14cf96b355213da31a8606ba186505c6",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/typescript/validate-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ac623eb9b00815e309d2406f354ffeaabd3eea75082e494ec01fdf8f47dc5114",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/typescript/validate-integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ea04b21a89fa59c3b15a3e1988a8341a5cb2b965d0ebf11fe6afd19cc5818676",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/typescript/validate-tests.sh": {
+      "category": "framework",
+      "originalHash": "sha256:0766f2a81e347933eb5165a52f85c6ef187f295a870bb62b14de23d928757a3c",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-operations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:85ba34bd70b8bb363f434ff8135bd88eebfa09860f90fd6e98faa2bcacd99d16",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:860df0ab3d3405c665775ff330d3ccc42b04532d9e3e52e8381f6a251ef0d043",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-spring-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:7cfba1009c4d01389d8483f08e4707f2e04bfd39d92ee88306052c9199cd2bfa",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-annotations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d41f71ecd7bc7bedb32cbc2710b7404d4cdc34d049953a48a2cba293a58fed74",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:096d0110bb1e6a41270b6a1b6fbab4754d5545ee399b0c0dc2ceda8e36556883",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-canonical.sh": {
+      "category": "framework",
+      "originalHash": "sha256:2305270475030599a2b8e27166f0e6c0f5025b396bf237afcaa3175ad5ec1bcc",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:fae27bc8b709c88e3d64b6367f9e4604334770d59b4b9e741e06608d08891b12",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ff677d9afbc2ba1503d5bbf935a5a96d77930b8ea85e463e175d46680e188ba3",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-tests.sh": {
+      "category": "framework",
+      "originalHash": "sha256:e98017ceb722bd3aa6a283000af07d30ed074051e96dbaa76e1081f69274244b",
+      "status": "unchanged"
+    },
+    ".pi/skills/tdd-practice.md": {
+      "category": "framework",
+      "originalHash": "sha256:8c2a7fbb809dda355bae934cc725b09f5198e4e730a5951819306db76eb2403f",
+      "status": "unchanged"
+    },
+    ".pi/skills/go-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:5ee2969b7d30428a862240cb1b17b5a19554da2c146912e53557756f0c58c1c0",
+      "status": "unchanged"
+    },
+    ".pi/skills/angular-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:b8143821f913809df3303f9c20c858ca5aa161eccc7bbc8b69b75050a13088d7",
+      "status": "unchanged"
+    },
+    ".pi/skills/typescript-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:c4b25b5f5e76e84e2a7ab8af0043993bfb5d47d1c689f6f5377645cca7378ae6",
+      "status": "unchanged"
+    },
+    ".pi/skills/design-system-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:14e0a6726d32cbb83663f4a181788512e54759662567360624aed4dcb371d7d1",
+      "status": "unchanged"
+    },
+    ".pi/skills/rust-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:88aea725dd80d51748c710bc45609bb2d11472933fad54af068fc55e5979d8ba",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/rust-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:28a65bf73032376577341d8b75b8d9f9788cd6058ae388e1cf1c7c7473e3a835",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/typescript-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:09e2ff0b0dea87356ce03347bb7119d2fc669755d25793dd96291b86c55e54b5",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/nextjs-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:80900886ae62aa59a1b6e47430849fe1372649244f9814d3d8be00820942c61a",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/design-system-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:562a9bc395096fef10911c22ff9480824c0aed48cea7e000e9c1db588c5dfb14",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/python-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:a7f573566bd0d90b4d2d4262c43e3de9c0a0379f07f59f185b73730915c14563",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/angular-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:ede820cc2fc4f86f11bd2a97e8c03f8a8832944d6e2e33819091f4cb7b5290e9",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/java-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:8fe7500823e7b41ee04cc4f0fcb9386aabec2c1b9003e8ce39de09b7cf78fdd3",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/go-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:7453a53e9ae8d5b91825aab32ed29c8cc6d16bb07610724a5cfd10a3106db745",
+      "status": "unchanged"
+    },
+    ".pi/skills/java-spring-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:5d68093293c887875634b9f567c6c886373ebfcf7cf248f4156da42e6c19b490",
+      "status": "unchanged"
+    },
+    ".pi/skills/python-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:49ac7fadeda2db41887013ed6670d6f8e687c1177b2cba6d201b95527e5adaa0",
+      "status": "unchanged"
+    },
+    ".pi/skills/nextjs-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:f1041e806a170fdbc391f6543033322cbe4b9baab82ee19b68b53751652a54cc",
+      "status": "unchanged"
+    }
+  },
+  "exports": {},
+  "templateContext": {
+    "projectName": "rigorix-oss",
+    "projectVersion": "0.1.0",
+    "language": "rust",
+    "repository": "arman-jalili/rigorix-oss",
+    "repoTool": "gh",
+    "groupId": "com.rigorix-oss",
+    "buildCommand": "cargo build",
+    "testCommand": "cargo test --all",
+    "lintCommand": "cargo clippy -- -D warnings",
+    "formatCommand": "cargo fmt",
+    "formatCheckCommand": "cargo fmt --check",
+    "securityAuditCommand": "cargo audit",
+    "errorHandlingPattern": "Result<T, E> pattern",
+    "tracingPattern": "tracing crate with structured spans",
+    "cancellationPattern": "CancellationToken pattern",
+    "atomicWritePattern": "tempfile + rename pattern",
+    "keyFile1": "src/index.ts",
+    "keyFile1Purpose": "Main entry point",
+    "keyFile2": "src/lib/core.ts",
+    "keyFile2Purpose": "Core library functions",
+    "domainDescription": "**Rigorix** is a **deterministic coding CLI** built in Rust. It's a **task graph compiler with execution profiles**, NOT a multi-agent system."
+  },
+  "scaffoldedAt": "2026-06-13T04:29:03.845Z",
+  "lastUpdatedAt": "2026-07-17T21:11:22.567Z"
+}

--- a/guardian-manifest.json
+++ b/guardian-manifest.json
@@ -1,0 +1,1238 @@
+{
+  "schemaVersion": "0.1",
+  "frameworkVersion": "0.1.105",
+  "source": "pi",
+  "tools": [
+    "pi"
+  ],
+  "language": "rust",
+  "repoTool": "gh",
+  "archMode": "strict",
+  "groupId": "com.rigorix-oss",
+  "validators": [
+    "ci",
+    "tests",
+    "security",
+    "operations",
+    "integration",
+    "architecture",
+    "canonical"
+  ],
+  "workflows": [
+    "feature-development",
+    "bug-fix",
+    "hotfix",
+    "refactoring",
+    "issue-implementation-series",
+    "epic-plan",
+    "issue-draft",
+    "git-issues",
+    "issue-closeout",
+    "issue-merge",
+    "plan-to-issues",
+    "blueprint-validate",
+    "sync-check",
+    "context-refresh",
+    "scope-analyzer",
+    "pattern-extract",
+    "blueprint-update"
+  ],
+  "files": {
+    ".pi/context/checklists.md": {
+      "category": "framework",
+      "originalHash": "sha256:8f3e52628b0d1abe439d84f3b29848c4141110c485e2d42dd7ae0fb0fd234806",
+      "status": "unchanged"
+    },
+    ".pi/context/domain-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:f92b43bdc715fd5cd8d3ab292c236e705e1ad155e58cb343efe4c6605eacd717",
+      "status": "unchanged"
+    },
+    ".pi/context/project.md": {
+      "category": "user",
+      "originalHash": "sha256:2dd4ff55bd49f0524108fbcbb344acfce74eb7d66772a212261b505880b1b019",
+      "status": "modified"
+    },
+    ".pi/context/patterns.md": {
+      "category": "user",
+      "originalHash": "sha256:51a1ffa9ad2fc4631fa3b15d60da3a66414d1457ccd523c1a0866592bb373c30",
+      "status": "modified"
+    },
+    ".pi/context/output-formats.md": {
+      "category": "framework",
+      "originalHash": "sha256:57700883af3a4bac040a49c7a00e34040ef64fe66fe45502fa44dd6a49dada1f",
+      "status": "unchanged"
+    },
+    ".pi/context/patterns-base.md": {
+      "category": "framework",
+      "originalHash": "sha256:8d9bf4d5c7ab81f060b0fadf8138cbb615b26119860988215f2ebd405c42bd1e",
+      "status": "unchanged"
+    },
+    ".pi/workpad.md": {
+      "category": "framework",
+      "originalHash": "sha256:c15373fbf3ad0317a1281066c7605a9f2c0823c1a3c5e946e0620b808c6bf67b",
+      "status": "unchanged"
+    },
+    ".pi/agents/issue-factory.md": {
+      "category": "framework",
+      "originalHash": "sha256:8e1d2a8211e7634736c51f6fe5af2ae48d3263a39d54ddc7cb23c9183537ae06",
+      "status": "unchanged"
+    },
+    ".pi/agents/architecture-coordinator.md": {
+      "category": "framework",
+      "originalHash": "sha256:0449f8b3d33b1d479e0699303eea0e6c6d512f38972e99cb1b8c0da0f7b37f8c",
+      "status": "unchanged"
+    },
+    ".pi/agents/bootstrap-implementer.md": {
+      "category": "framework",
+      "originalHash": "sha256:77662fa88c70fe139f7ff526c8763a3226d7dff6c249081a7a63d02e1ac72041",
+      "status": "unchanged"
+    },
+    ".pi/agents/operations-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:e64c119a9f0fc7c9fcebf813f47bd43b091c8049a6fd32a2789da69ec1c1fbde",
+      "status": "unchanged"
+    },
+    ".pi/agents/security-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:6cd0cd853582cb8f60d27c7bb9e339977928a07f3b4fb8fb66bf894bd6fad728",
+      "status": "unchanged"
+    },
+    ".pi/agents/architecture-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:3fbae65130cbb256e5be0c0e3b784de9fd681a9a54629bb270617e29886fcc9c",
+      "status": "unchanged"
+    },
+    ".pi/agent/AGENTS.md": {
+      "category": "user",
+      "originalHash": "sha256:240369371efe62367c638e1e094896657de40d09b80303ce953878345c517968",
+      "status": "modified"
+    },
+    ".pi/extensions/curator.ts": {
+      "category": "framework",
+      "originalHash": "sha256:73e4167139e574df37fefa89271bd3ff2941f6d6f6e1abb8accfd0059a240c83",
+      "status": "unchanged"
+    },
+    ".pi/extensions/session-persistence.ts": {
+      "category": "framework",
+      "originalHash": "sha256:57ffec30b56753fd5cb676577f4a72c2feaf967470611316716825f3f50135fd",
+      "status": "unchanged"
+    },
+    ".pi/extensions/domain-explorer.ts": {
+      "category": "framework",
+      "originalHash": "sha256:da4d8fda181acc1033eca422ab07186c2ddd18054376e0660882ee1005e21a80",
+      "status": "unchanged"
+    },
+    ".pi/extensions/kanban.ts": {
+      "category": "framework",
+      "originalHash": "sha256:c6cb9c7876986c155a784cac3919a094f0c0510413e955fd0d3986b27071a7e3",
+      "status": "unchanged"
+    },
+    ".pi/extensions/project-scaffolder.ts": {
+      "category": "framework",
+      "originalHash": "sha256:d0dd4ddeb736cb45a785b92b8c912e5dfd54254756f1e67202e56934c8b1a751",
+      "status": "unchanged"
+    },
+    ".pi/extensions/snippets.ts": {
+      "category": "framework",
+      "originalHash": "sha256:700a8426ac78d7a8d3a887ad2cba8078a603a427e8afef484e65ca09da21ce89",
+      "status": "unchanged"
+    },
+    ".pi/extensions/read-only-mode.ts": {
+      "category": "framework",
+      "originalHash": "sha256:97ba2d0956971f86e9301498a1065c8f3f0400d4631e9ef16961e7f00f94778e",
+      "status": "unchanged"
+    },
+    ".pi/extensions/slash-commands.ts": {
+      "category": "framework",
+      "originalHash": "sha256:57403f17cfe8a8d68d573cf213e96d5be7928102c7565b05e18297f4d2f92c2d",
+      "status": "unchanged"
+    },
+    ".pi/extensions/config-reload.ts": {
+      "category": "framework",
+      "originalHash": "sha256:1c3bf2e7dc67f61f14ca6bd7c768aa47ed99e4477721e562467d27e8072fc57a",
+      "status": "unchanged"
+    },
+    ".pi/extensions/pipeline.ts": {
+      "category": "framework",
+      "originalHash": "sha256:7e55a3ee8addcbf31e441f7fafd380ecca97476a6463b257af68a290b82d117d",
+      "status": "unchanged"
+    },
+    ".pi/extensions/bash-guard.ts": {
+      "category": "framework",
+      "originalHash": "sha256:faac81ad49dc7585f34db4be51d609349cfddb1685ae39047f6bcba305c6ba04",
+      "status": "unchanged"
+    },
+    ".pi/extensions/validation-runner.ts": {
+      "category": "framework",
+      "originalHash": "sha256:c00de33ce0f3b28da4fe486c503542311fc55888cd06b056aa25d1242030fc5c",
+      "status": "unchanged"
+    },
+    ".pi/extensions/architect.ts": {
+      "category": "framework",
+      "originalHash": "sha256:1c7232b7fb9bd24ed9cd10b37ad0064577f5dbeb1186ef1712a27e3b1829dbc4",
+      "status": "unchanged"
+    },
+    ".pi/extensions/architect-lib/helpers.ts": {
+      "category": "framework",
+      "originalHash": "sha256:a447ff900952ea8383080b8ae5aaf322c25621b5e63508bc7d743ab1afd9890d",
+      "status": "unchanged"
+    },
+    ".pi/extensions/architect-lib/generators.ts": {
+      "category": "framework",
+      "originalHash": "sha256:ad7e14d8548103fd193b9b566872bc9d4e754d7301ed253910ac34d690c23462",
+      "status": "unchanged"
+    },
+    ".pi/extensions/architect-lib/types.ts": {
+      "category": "framework",
+      "originalHash": "sha256:f7d25e49d928093d479709a656da15341b64c9a0691229644328ced609311acb",
+      "status": "unchanged"
+    },
+    ".pi/extensions/ask-user-question.ts": {
+      "category": "framework",
+      "originalHash": "sha256:c770fa193453768ee33875ffd626311e52f061af2856acc3fde014db3ec4fe64",
+      "status": "unchanged"
+    },
+    ".pi/extensions/filechanges.ts": {
+      "category": "framework",
+      "originalHash": "sha256:b04dfde9d19dcf1d0c6197bb36b153cc200befea7cb459a545afeec5b0f5c22c",
+      "status": "unchanged"
+    },
+    ".pi/extensions/hooks.ts": {
+      "category": "framework",
+      "originalHash": "sha256:2a953dde5b843d05818cadbe82876a6d362113e6d4932f0571b4c35935cdb405",
+      "status": "unchanged"
+    },
+    ".pi/extensions/coordinator.ts": {
+      "category": "framework",
+      "originalHash": "sha256:f25eb28fb9e2d5b4542f27252c427e044b5ded0169fa467e2b77174669747367",
+      "status": "unchanged"
+    },
+    ".pi/extensions/goal-loop.ts": {
+      "category": "framework",
+      "originalHash": "sha256:c65806990e28fd1b635c926d511e0fcbab98a95174a74f4cddb01c90b5ff29be",
+      "status": "unchanged"
+    },
+    ".pi/extensions/redaction.ts": {
+      "category": "framework",
+      "originalHash": "sha256:8fd16eba73b995d7e8f20f03a7c495c1ea26fb5032610e27cf239eb64299ba13",
+      "status": "unchanged"
+    },
+    ".pi/extensions/plan-mode.ts": {
+      "category": "framework",
+      "originalHash": "sha256:34efd4378ecb3431d77cf7e60c589ddb9aa7bf56c578d2f3fde52cfc6deee3cf",
+      "status": "unchanged"
+    },
+    ".pi/types.ts": {
+      "category": "framework",
+      "originalHash": "sha256:017a07fae90a46fca800dcb6b3ef19050570677c8a4a9672f85b238183f72ee4",
+      "status": "unchanged"
+    },
+    ".pi/architecture/CHANGELOG.md": {
+      "category": "user",
+      "originalHash": "sha256:653bed6d8499cbf4b96598d1c3c6e0537989018b08654fc9422d50c85a8f20d6",
+      "status": "modified"
+    },
+    ".pi/architecture/diagrams/system-overview.md": {
+      "category": "framework",
+      "originalHash": "sha256:162cb1fa10bc933370390c9b37d64dcb4dad333e4ecef4e73c3d48e9d8ae91d3",
+      "status": "unchanged"
+    },
+    ".pi/architecture/decisions/ADR-template.md": {
+      "category": "framework",
+      "originalHash": "sha256:18e171fa061c7f8abd07b3b90a7d02f619bf1545124969203225f4bdd4b41531",
+      "status": "unchanged"
+    },
+    ".pi/architecture/modules/module-template.md": {
+      "category": "framework",
+      "originalHash": "sha256:699b7812db449bf3de6885e3d56d03cc62f8a0f82352d1328c50c412b7073be0",
+      "status": "unchanged"
+    },
+    ".pi/github/instructions/architecture.instructions.md": {
+      "category": "framework",
+      "originalHash": "sha256:9f26ff4819db738887c1cdb9745537dadc43fc05ad788684b38dbc7a6dad17d5",
+      "status": "unchanged"
+    },
+    ".pi/github/instructions/validation.instructions.md": {
+      "category": "framework",
+      "originalHash": "sha256:934d64609f1275887a5c2795ce41d7d31fa5e8cf77cac35612d1b8685a44d28b",
+      "status": "unchanged"
+    },
+    ".pi/github/copilot/settings.json": {
+      "category": "framework",
+      "originalHash": "sha256:9e21c730edefe4080fee1014a02fbb96118aa300ea0f93563a53f9c6d9c4f2a1",
+      "status": "unchanged"
+    },
+    ".pi/github/workflows/01-planning-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:b7c13edf0d75fe2cc2a8784461637ec91a2bc894682768b6b208795f60a5d404",
+      "status": "unchanged"
+    },
+    ".pi/github/workflows/03-implementation-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:3b067bd1df93bb8de1eb26873825f2d5a330c46c619cb3209db127d33fde3ebb",
+      "status": "unchanged"
+    },
+    ".pi/github/workflows/04-validation-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:513bb31dd54f5961e221f71e5216fd1acde8ad0158f5523985bdad97a2bff8c8",
+      "status": "unchanged"
+    },
+    ".pi/github/workflows/02-issue-generation-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:41205400814e6d4b77ddbcf351d8e1f0701d11c618225eabf6ed3d3b630d56dd",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/architecture-validator.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:04e7cb86758e135b55abc556b9d043d6f68cd5566dd5b0a882cedc615fbde065",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/issue-factory.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:ef97de04d6f99a3b2edd04182ab8cf73a7da564b99d091f5c3d2056175fd686b",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/architecture-coordinator.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:9e376f5ba69f3fc30672b83e9792bb2cb961abc61d6fddda057a5df2ce398e0e",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/epic-planner.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:859599d908d8d1a5bc41d82eaea9414f147a1a16b8d37a99630f3d700f37c0ca",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/bootstrap-implementer.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:2a0b8f2d37ab6c9112d0fa0101429ad5afe3d2c39328b3d132eee1eeb454a3ee",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/security-validator.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:e9081be418d7f432fbd9b4a63d8181b44e797c93a8b6065ec330e2a5fa4b6109",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/operations-validator.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:464860fa7eabcad393471c8dc434268d2f55e72eda0889386abee02f88315ec3",
+      "status": "unchanged"
+    },
+    ".pi/github/copilot-instructions.md": {
+      "category": "framework",
+      "originalHash": "sha256:f82b95c50d87175e42851487b9c9f8891cfc1b5d74d784fdcbc2c4a221ddd19f",
+      "status": "unchanged"
+    },
+    ".pi/INDEX.md": {
+      "category": "framework",
+      "originalHash": "sha256:e61e5215c25ec05ff53bfb72309dde3f7c781c2ddc79c8af9cf6fa987cd4136e",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-operations.sh": {
+      "category": "generated",
+      "originalHash": "sha256:4fb994c9056b90f565fe536633795586da3197a2a2b8f745baea9af8db4440d5",
+      "status": "unchanged"
+    },
+    ".pi/scripts/create-feature-branch.sh": {
+      "category": "framework",
+      "originalHash": "sha256:33ff4c76faba418025dbe88a998f2a04a6cafd282d11fc644a50de014cc580d0",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-architecture.sh": {
+      "category": "generated",
+      "originalHash": "sha256:241df1a4517e0a04aff9cfc4efddbdcb4b3859e65bd35cb8c558a172dfe7cf4d",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-ubiquitous-language.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d9886f03dcc186d367c92dcd8f0547768534413c50f32d396d3d55ea3d016fb0",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:1ebac9c09ebfebc1e9cffdfa474c792f28bbe386a923ca49a0695bddee93df40",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/run_hardening_stages.sh": {
+      "category": "framework",
+      "originalHash": "sha256:8a67c21f7154e1cd4987f6e5e56dbbd476f3bf6d7846d4c167289008979d4a65",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_remaining.sh": {
+      "category": "framework",
+      "originalHash": "sha256:396b75ec9fb00224781e9eca66ac51a9ec7f05876d5175f80070560fdf629fe5",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/check_planning_packet.py": {
+      "category": "framework",
+      "originalHash": "sha256:214e1ce18ed2226f344f25687fde9dd586b061f1af8efd6f54c27bd09dabae67",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_package_build.sh": {
+      "category": "framework",
+      "originalHash": "sha256:67b0f705398369fb171c993c1e673f8cce16e4016cd6c1ca72c8996ce3bda7c4",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/validate_agent_output.py": {
+      "category": "framework",
+      "originalHash": "sha256:51cbdbed1921620608a25c2f4db67dbfd088a3d43cb96a03ec425c181d6ce4c9",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/run_preflight.sh": {
+      "category": "framework",
+      "originalHash": "sha256:137294de31aebfa339ae28ba878cb85720bdbe1b4298a2dd19ca184754bd67c4",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_migration_verify.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d25a4de5ddcb3946fca19e82828dd03f726d2084c71dbe4ecf0e222d1da1b67b",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_unit.sh": {
+      "category": "framework",
+      "originalHash": "sha256:64c8b8a4c6266725962b238a1c9814ea110c0f067e90ca9d38287a40074a5f19",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_release_readiness.sh": {
+      "category": "framework",
+      "originalHash": "sha256:0d62822ea089f0469e66561d501bf03cd5e9bb0dbedb199e0ca39286c3ffaa7c",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_docs_policy.sh": {
+      "category": "framework",
+      "originalHash": "sha256:8b13849d612e4dde20a43e3e2ef23c9279869c14683e29506213749e4f2e29ec",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/validate_agent_output.sh": {
+      "category": "framework",
+      "originalHash": "sha256:26816f935433df71266651dfe393c9ff3b7c3975426e05a93b7308c6fc3b80bf",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:a9617cd791ef4ebc72a519ca5169c287f94ba128e14c19f75a6db24267cf42ec",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/run_stage.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ade2b65032142b6f03fc08ed99828964c0bf6a7121d82969871ac963dac14fe1",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_lint.sh": {
+      "category": "framework",
+      "originalHash": "sha256:b5ce9794af4d271f7e04a82f6a35fe7e254d64ff4e71518cf201e4210c1b6560",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/check_architecture_conformance.sh": {
+      "category": "framework",
+      "originalHash": "sha256:811af3f104c77a13c076ddd3b876392e64c84c4f63ff8bc925f5441ef08c7d82",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_static_analysis.sh": {
+      "category": "framework",
+      "originalHash": "sha256:5d40980d65b39245bb3db064f0ae60b977b33cb0e7f86b0d211020cb894bafa7",
+      "status": "unchanged"
+    },
+    ".pi/scripts/merge-mr.sh": {
+      "category": "framework",
+      "originalHash": "sha256:204694650a7467f7bff61d77a73020b0c46e7699ba70fe92afe68470611ce006",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-architecture-readiness.sh": {
+      "category": "framework",
+      "originalHash": "sha256:2d7d786c72399e2ad2aa1db15a0d016faad1b303bb6b0b2bec3212ce16531ae4",
+      "status": "unchanged"
+    },
+    ".pi/scripts/fetch-issues.sh": {
+      "category": "framework",
+      "originalHash": "sha256:e9b6c563b9d242e925de55bb120e667e69ed2e6d544a248828b6cc2d0cf514fe",
+      "status": "unchanged"
+    },
+    ".pi/scripts/categorize-issues.sh": {
+      "category": "framework",
+      "originalHash": "sha256:172e09a69b56e3b502d184f740c447f570647893f4658e2dd91451595f77dc93",
+      "status": "unchanged"
+    },
+    ".pi/scripts/create-mr.sh": {
+      "category": "framework",
+      "originalHash": "sha256:c12ede5af3f0840e5042aee0bada314909843aa63d14f8cad40b993b66feb12b",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validation-cache.sh": {
+      "category": "generated",
+      "originalHash": "sha256:5fea93087bcd9852532ce8119f47ecdb61a46fd857b336e2955b087ed61aa3bd",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-operations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ab89729ca059bf5c51693c30dc088ea396c9e3cec282926eb20e0927d7c01c42",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:bde99e5c9735c306c6fa9b5286f56ff695f164608e559f08c95578fdc4f630b5",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:4aae6dc07ce65b800685600603af9e8bb9078fb8c543455b9d2aaefbc984f9e0",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-canonical.sh": {
+      "category": "framework",
+      "originalHash": "sha256:57aa990956727168405190ae951940081d48241de825acdfe18583a7ca711ffc",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:190560cc2814c33f598bb2a53a4363789d22ad9ea6001323aa5ce38cc9909690",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:1c1fd623c2de1b9e7c5e305ef4a208630bdf2445782c71fc82215c18a7d3f0ee",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-tests.sh": {
+      "category": "framework",
+      "originalHash": "sha256:e325f270d711dfd73a141c2dce39bd6e7511ce28d3f15dc1d0584a52c11930b1",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-security.sh": {
+      "category": "generated",
+      "originalHash": "sha256:0a9453d133e9b8e86cd767cec2f130bd6dc74db93d2169d2e43858af81438630",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-canonical.sh": {
+      "category": "generated",
+      "originalHash": "sha256:66d2e6887f040d7179e811f79f8c9f367066c6fd6a100c462ddb330556d54228",
+      "status": "unchanged"
+    },
+    ".pi/scripts/generate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d4e48b44eacf98df17eab6ad97fb67c58f2569a2200481632ca4cf348ec1daf7",
+      "status": "unchanged"
+    },
+    ".pi/scripts/mr-validation.sh": {
+      "category": "framework",
+      "originalHash": "sha256:4ff040e1c2cda028d317740d0c6f0dc5b8536a3986dcd79b7f90c70e1f16a0d3",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-ci.sh": {
+      "category": "generated",
+      "originalHash": "sha256:d5ae9a470c0e738063a103f8cedd9bb08ebc38dabd35883c6d16874228d08c45",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-integration.sh": {
+      "category": "generated",
+      "originalHash": "sha256:01c0dc34f6a94dcb46428049e4a090c89756c67755f0f16068dcfcb0b4df2ea0",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-tests.sh": {
+      "category": "generated",
+      "originalHash": "sha256:ff7840a569b1571782ae8c4174a6b871345c6a354c65ff4ca5784b898ba15466",
+      "status": "unchanged"
+    },
+    ".pi/scripts/git/close-epic.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d395291ad32ba27fff27f0826876762490adf2ce724b19d57ed6a442eaafaef4",
+      "status": "unchanged"
+    },
+    ".pi/scripts/git/close-issue.sh": {
+      "category": "framework",
+      "originalHash": "sha256:03e023bde33ac7303f291ba8ddc0420545a37cd3b43476ae1d742c3cc875d261",
+      "status": "unchanged"
+    },
+    ".pi/scripts/git/update-tracking-issue.sh": {
+      "category": "framework",
+      "originalHash": "sha256:564fb3b8e420f69ece40152cbeeb82fd1d5c4dadb1f1bcfa696bba7d88d0b337",
+      "status": "unchanged"
+    },
+    ".pi/scripts/git/link-issue-to-epic.sh": {
+      "category": "framework",
+      "originalHash": "sha256:527408594f868eec8727bf54365742716fbe584ad649031783980f6d7e778ff9",
+      "status": "unchanged"
+    },
+    ".pi/scripts/git/create-tracking-issue.sh": {
+      "category": "framework",
+      "originalHash": "sha256:76c3b50ef2f404043778fb7f2cd33168836767aff69332df1298670683baaece",
+      "status": "unchanged"
+    },
+    ".pi/prompts/blueprint-validate.md": {
+      "category": "framework",
+      "originalHash": "sha256:b73c83cb10e9afbb6b462063cd0a1ad588f301ade22735c2fb03272696d396e6",
+      "status": "unchanged"
+    },
+    ".pi/prompts/bug-fix.md": {
+      "category": "framework",
+      "originalHash": "sha256:9d88f8d9766a66f348a78d137e5c7e186dee834c448f5e21ad284559b27e3422",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-implementation-series.md": {
+      "category": "framework",
+      "originalHash": "sha256:af7eb7eadeb1c8929fae9c15a86ac627140a123a03f52c4ef5246c60543d539e",
+      "status": "unchanged"
+    },
+    ".pi/prompts/pattern-extract.md": {
+      "category": "framework",
+      "originalHash": "sha256:3433fa6188bf8717c4aa8a052c4f3b9c6aaa7ed3e01dc8b816ffc1e0cb7f475a",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-draft.md": {
+      "category": "framework",
+      "originalHash": "sha256:e50f0fb5a7d49d0316259e05e798ac44797b156394c8f7e22407907941309c14",
+      "status": "unchanged"
+    },
+    ".pi/prompts/epic-plan.md": {
+      "category": "framework",
+      "originalHash": "sha256:3633e445bb94ecdd41567490c3c31086784d6597e99ef3e86677628e00feb4b6",
+      "status": "unchanged"
+    },
+    ".pi/prompts/sync-check.md": {
+      "category": "framework",
+      "originalHash": "sha256:06c09fefa4521254c0c0e43b587985d809749a4fa0f9e462fc85f33e8182b382",
+      "status": "unchanged"
+    },
+    ".pi/prompts/blueprint-update.md": {
+      "category": "framework",
+      "originalHash": "sha256:e56adc41911876bbca89fa2d5947c7a76e5ebb4af423f8749d61e700fe4a95f4",
+      "status": "unchanged"
+    },
+    ".pi/prompts/hotfix.md": {
+      "category": "framework",
+      "originalHash": "sha256:65cc83277bbf83931e1941fb6059bfd1ae41ae5fe11a6f3124ce1f356fd3e1ec",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-template.md": {
+      "category": "framework",
+      "originalHash": "sha256:082223c4d14099fa85cf960b06b909baf0701f7ed4e450621e1e930593c6128c",
+      "status": "unchanged"
+    },
+    ".pi/prompts/epic-template.md": {
+      "category": "framework",
+      "originalHash": "sha256:cdc5b784ed287871d651ebcedeacddd74091b4c1ac3b7e696890d78353b94afc",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-closeout.md": {
+      "category": "framework",
+      "originalHash": "sha256:a2c88df36dd87fec9e87f2efcc0ff0ab694b75b5952090763c7081f9bcde5681",
+      "status": "unchanged"
+    },
+    ".pi/prompts/scope-analyzer.md": {
+      "category": "framework",
+      "originalHash": "sha256:be1d74366bbe8e5f7dd5949d45e9adb89b17b6015dc471921e32b6fc2e110633",
+      "status": "unchanged"
+    },
+    ".pi/prompts/ci-blueprint.md": {
+      "category": "framework",
+      "originalHash": "sha256:b2847a4ec3b26f3a77e6c06d8ebe2595032703ec2d8c1529a8f76204bc03c58f",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-template-set.md": {
+      "category": "framework",
+      "originalHash": "sha256:1f0d117b87a4823ba75024f094e2fde585a70dae3bfb7e25accd82662733b9a0",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-merge.md": {
+      "category": "framework",
+      "originalHash": "sha256:adfc1e0dd785efe556945f74e4f84c1a8f1efbd33d6ad68e50514cacf0b5511c",
+      "status": "unchanged"
+    },
+    ".pi/prompts/context-refresh.md": {
+      "category": "framework",
+      "originalHash": "sha256:09fdc06700827a1aec1906c6710c6c9b2a7419cc984359edcae9339c53114e47",
+      "status": "unchanged"
+    },
+    ".pi/prompts/git-issues.md": {
+      "category": "framework",
+      "originalHash": "sha256:000effa78e9a2bdbe06307eb4de3c879051e59ec728687b20df39db21a69f34c",
+      "status": "unchanged"
+    },
+    ".pi/prompts/feature-development.md": {
+      "category": "framework",
+      "originalHash": "sha256:4161e4ba61d4f00d75f0c616513ffb1f4a628292ad091ab33b0063d5e0ebeed9",
+      "status": "unchanged"
+    },
+    ".pi/prompts/plan-to-issues.md": {
+      "category": "framework",
+      "originalHash": "sha256:1cc665bad7a5aa45a8b769d22a8dbc5c7288ccaa2e8e017935b9ce7f6fd13fe8",
+      "status": "unchanged"
+    },
+    ".pi/prompts/refactoring.md": {
+      "category": "framework",
+      "originalHash": "sha256:b1fafce9705a0ac15ce975d5ab9747ed8685b37f05d7266ed5915b95582d2b2f",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/slash-commands.md": {
+      "category": "framework",
+      "originalHash": "sha256:d9783d8d481ae7a02c2c91db52f8600c7fb6821418dcbd5f589ca37f314b6a1b",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/pipeline.md": {
+      "category": "framework",
+      "originalHash": "sha256:e44a23d8ff5d49b6a1ae08b6b50f5ecbf09f774be2944dc3e60d98f57f7a6ca3",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/debug.md": {
+      "category": "framework",
+      "originalHash": "sha256:65368b250d343f208d3ad07d63b23fee8a178f3e9a3a65079d1b05ccb954b7ed",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/issue-factory.md": {
+      "category": "framework",
+      "originalHash": "sha256:078e16f2b69c44ea7bc3d356dc3b8a3bf861b220a3ce3fc4c2a0dd2e949848ac",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/architecture-coordinator.md": {
+      "category": "framework",
+      "originalHash": "sha256:87877ea4cc689c98f6ab8d661d85b0d0af8debe06f6840ab62c891370ba112f7",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/snippets.md": {
+      "category": "framework",
+      "originalHash": "sha256:4bf69877925a542de4d6f84f0205654ae2c53ac56ba740674eb849f1a7d1ce95",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/architecture-generator.md": {
+      "category": "framework",
+      "originalHash": "sha256:6b2763ece59b22d86a95e1d1712b118cbb700e0cce5d941435604b4acca3fd4b",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/land.md": {
+      "category": "framework",
+      "originalHash": "sha256:099bedd22bfd99ac6d061d376f0c5d0314bd7ddd351166d2816122d9ae210207",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/push.md": {
+      "category": "framework",
+      "originalHash": "sha256:93a9a3f3e154743e342ccc75f3780cca9efd2738d90545bd43bdc5518a2b310d",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/curator.md": {
+      "category": "framework",
+      "originalHash": "sha256:3a6ef64758000d80c5a126356afb1b7539e76b83f9a2dd6a42da2f99ebb435d3",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/kanban.md": {
+      "category": "framework",
+      "originalHash": "sha256:e82cc278ab29c86e93a0bdb222717f36088a3c0c02f5fa4e86b2fe28be723dab",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/ci-mr-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:ad5ae29d0043ac16c3a082488932e79f9f21132142616977d00aaf1f8bf26767",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/session-persistence.md": {
+      "category": "framework",
+      "originalHash": "sha256:3bdcb4d1008894d807773b28cc8a2c4ff3c933a5ecd296930a2bb1559b867d73",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/subagent-registry.md": {
+      "category": "framework",
+      "originalHash": "sha256:4b89ea68c8fca289a90a232ef86ff0b1b37c096482cbeb2a8450d28f2fb68a86",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/pull.md": {
+      "category": "framework",
+      "originalHash": "sha256:4d837457b90163de6b0a59ab425855f23e8efd0bf5cd7e945fa7ba4adead65d4",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/operations-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:86ee49c63e881afc18c5a0438d614d3918cb18c468720c9bb4d1f7ab5f37c298",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/issue-creator.md": {
+      "category": "framework",
+      "originalHash": "sha256:78e72f5e3ecb7e8737449c96ae17ac4b5c48bb31ed2a1e2fc929277462a02648",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/plan-mode.md": {
+      "category": "framework",
+      "originalHash": "sha256:7a37581c5005995fc0afa0fb77c1991de3384fa0dd2326610207927d28a6032c",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/hooks.md": {
+      "category": "framework",
+      "originalHash": "sha256:5ffafef4d3861be81760dd5bc7792ec865de37d6e668cde9636e607fd851c95b",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/security-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:1f5ab8b7f01f5dc0342c5c90dcf745f81b8f00858fd0d8283a979ee22e91581b",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/integration-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:c3894b281c5d79473002a9d8d5f81fbfe2909705c65e756415175972a6ebb62d",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/goal-loop.md": {
+      "category": "framework",
+      "originalHash": "sha256:5aacf58ec91fa18ec7b2a19dc511607a57c8a89974fdc864fa13f1e85bc53bca",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/documentation-maintainer.md": {
+      "category": "framework",
+      "originalHash": "sha256:dea9a6b86b2de03a78f1e042649f6a54a1729286ffbea8fb943a9ec61baa281a",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/commit.md": {
+      "category": "framework",
+      "originalHash": "sha256:e137745830577995cfc2a8ff26ed4ffcbd6da49e56065a755b06ce8725765916",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/architecture-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:fc468492fe93b5b4c2d460195a9b379f79b58913db59443ff1c25f54ae1b1310",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/code-developer.md": {
+      "category": "framework",
+      "originalHash": "sha256:a1497671fe07dde01d159919c12f7cdcaaf2a37df5b1ba38ca7736ef5c77180b",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/test-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:37557feb88715946a1d3e11cdaa67ab2395e785b0c13866f7038cc97c798f825",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/security-guards.md": {
+      "category": "framework",
+      "originalHash": "sha256:df4d2135c38aeea2cc781e6acd3fad5caac5ceb226c58dd14a7a0dfae51402b9",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/context-compaction.md": {
+      "category": "framework",
+      "originalHash": "sha256:2f238359167f08f4acee8cc76945a572e1203fb61027b93bcdc722e079591445",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/operations-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:363b53637cf49af6268f59bf53e70bec2e0f81366c9db192e771a1c2fb2bf7cc",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/model-registry.md": {
+      "category": "framework",
+      "originalHash": "sha256:82b1604c59f2b38e7ecb3b9a99ddca40ff2a886f559af2f8b8b2f1d6fa1262c2",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/security-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:34a70bb93cb256f30463519967601ce2f4e44c7dc0284d5f034a7120a79ef4ec",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/integration-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:10d21f097ff8e86312318538cf342ad56a0de18a56ddbeb80c44c98cd1ee00c0",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/system-prompt-tiers.md": {
+      "category": "framework",
+      "originalHash": "sha256:e4977fe1ad0c2ce8248deb136031a3aba59f6fed75f52850fc5e306027277aeb",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/architecture-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:7ef93c32dfffb458b6c1301ebf621bada00f4cf5573f5d030c552327579551bd",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/test-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:3709ea4476727c6e7db56a40dd3be5902140cfaf76ab990cb94b52847d4a92bb",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/ci-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:9abee72b24b7322a0130bb91da5ff20d39064cb75abddd25d2c589f442a22839",
+      "status": "unchanged"
+    },
+    ".pi/validators/default.toml": {
+      "category": "framework",
+      "originalHash": "sha256:860fbc421f5761cccb280f8eb657bc7e8bf14131220362631c87d5821d7cfb3f",
+      "status": "unchanged"
+    },
+    ".pi/validators/README.md": {
+      "category": "framework",
+      "originalHash": "sha256:ae67775d2cd23d35a28f8850161f88666fbf5a9bc2b62e91bf3de31d5c3a0ace",
+      "status": "unchanged"
+    },
+    ".pi/validators/spring.toml": {
+      "category": "framework",
+      "originalHash": "sha256:afc0f8b49b5228869f296a7683b1d8a5f6ffc72f366f889a4ab7f5a8a4cc2b1e",
+      "status": "unchanged"
+    },
+    ".pi/preflight_report.json": {
+      "category": "framework",
+      "originalHash": "sha256:7e42a99e6f4df0c913f79ffa733847ef8e010a459953cae893930e1e31a05b1b",
+      "status": "unchanged"
+    },
+    ".pi/domain/ubiquitous-language.md": {
+      "category": "user",
+      "originalHash": "sha256:b047dbd6d32bfcf6c220c3319642c79b4f97787c67e58ac03c5fc18f57ba62cb",
+      "status": "modified"
+    },
+    ".pi/domain/exploration.md": {
+      "category": "user",
+      "originalHash": "sha256:1c60d932c58be0ce9488bdf9891c991e6c0ca5b0ccc87361bdb11d8c8e8f7005",
+      "status": "modified"
+    },
+    ".pi/skills/architecture-coordinator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:98a2fdd6e6588fb6b0cc4f1cd13ce954ade4280b5db170f2967e7b3333cecc22",
+      "status": "unchanged"
+    },
+    ".pi/skills/architecture-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:12aedbe88bcbf3576378e47a4b6e3cbd2908675d6083e55807e36da86daf02fc",
+      "status": "unchanged"
+    },
+    ".pi/skills/security-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:0a20c5c2d7178008060a051d925c552fe993e6baa9a4e47eb50c9348b876756a",
+      "status": "unchanged"
+    },
+    ".pi/skills/operations-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:f292f919da546d46a13b99fedc11fb57a75516b597ae053e5492d512e5738cbc",
+      "status": "unchanged"
+    },
+    ".pi/skills/test-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:989c4b8d638b7c498a5d2e1f9ece1c748a325d0dacbb42d0efa081303a131798",
+      "status": "unchanged"
+    },
+    ".pi/skills/integration-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:ce4b4c95976acc8cc8ea81f3fdec452458242faea65fb3122f286aa0734eed69",
+      "status": "unchanged"
+    },
+    ".pi/skills/ci-mr-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:d37d67939d4b097daff2a51d50caa84144b31bf73296e623258a826ece8f1253",
+      "status": "unchanged"
+    },
+    ".pi/skills/code-developer/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:847fb9679ebc65c116614fcb0770659146a9392927bbb40626dc242285e82c42",
+      "status": "unchanged"
+    },
+    ".pi/skills/issue-creator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:fb7d392fd8f8b18624b033de00c698933729d88bdace5bff044aace063930557",
+      "status": "unchanged"
+    },
+    ".pi/skills/documentation-maintainer/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:82dcfa15c741e4c3ae02a1f9577af7ac575742ea3ca1c668a86cfef44d579b41",
+      "status": "unchanged"
+    },
+    ".pi/README.md": {
+      "category": "generated",
+      "originalHash": "sha256:46adb3cb48b79ee5e26595b06cdd22992cb3252f643ded3ec7a6f7f8677b0ca1",
+      "status": "unchanged"
+    },
+    ".gitignore": {
+      "category": "framework",
+      "originalHash": "sha256:b071663b414d6bf1004373057662f2b2809fd42367e53d2484c27e54c1ab5fb7",
+      "status": "unchanged"
+    },
+    "WORKFLOW.md": {
+      "category": "framework",
+      "originalHash": "sha256:9808142326406a2f271bb22491fe4f1355dda06c59c2f5267012b75bbde62d57",
+      "status": "unchanged"
+    },
+    ".pi/extensions/architect-lib/forge-adapter.ts": {
+      "category": "framework",
+      "originalHash": "sha256:c93c6f998544d5b3d148663d2c4a09a95b8bbae2d0fba93c845ff1f51678d3a6",
+      "status": "unchanged"
+    },
+    ".pi/extensions/architect-lib/tdd-generator.ts": {
+      "category": "framework",
+      "originalHash": "sha256:160bd6297c85403f99496fbf7809bcc1c29635cd057a4f76ebbd28b0ff18754d",
+      "status": "unchanged"
+    },
+    ".pi/extensions/tsconfig.json": {
+      "category": "framework",
+      "originalHash": "sha256:d00580bfe8a5492c24b0eb13bce2ee699d56b98ce5ef4f71af2918b1ddc0b309",
+      "status": "unchanged"
+    },
+    ".pi/architecture/implementation-roadmap.md": {
+      "category": "user",
+      "originalHash": "sha256:277e4ba1207cb122d73eccc09dba04d76fba0d8e3e5004dd348e1ee34aaa10ba",
+      "status": "modified"
+    },
+    ".pi/scripts/ci/local-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:98d8181260d31fd3303eebf92bc70412590131a75385fefb679e038574b2d54e",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/check_ddd_structure.sh": {
+      "category": "framework",
+      "originalHash": "sha256:f2fb90658b34c25f4c85a083ffc35c8e6b388459fbd0ac1b475c0624472cbec3",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/go/validate-operations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:3ba4b6711f8515f37a478f7a06823c4650b61be7da778a095b2f7860442bcfb7",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/go/validate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:20312e4ae7b5b354f49dd31e4e997f16b3ae8ab7818f26704f35dcf118af31e9",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/go/validate-security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:3d66400fc310fb7432ff9434d28bbaf705b4d3ddf10266cf9fa350ad940a8692",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/go/validate-canonical.sh": {
+      "category": "framework",
+      "originalHash": "sha256:b819783a2d29184a66b3ac0ae71b6a8f3989c5a798977d1b147c3a60df326457",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/go/validate-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:043448c4de25e226e96709b94c3c1a7670cd0a6f47ab307fa4ed826d07deebc4",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/go/validate-integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:dcbdc609280db0ac5a7f40820d5cc3b951df7f1dcb36aa2ec255741a265e1e7a",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/go/validate-tests.sh": {
+      "category": "framework",
+      "originalHash": "sha256:7e3285166dcbbabf89d4ded78ef336767c3dd03befc25dc6f1ca50513edc2451",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/python/validate-operations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:7050c2345b7ba2bd34cba6f101f4f2c46412155b70e0c461285240c55c71d10b",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/python/validate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:34fd11fbd19cee0856f8c1c1f99becb7154646886d26ccd239673de863919265",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/python/validate-security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:a8453e22fb1b1cfdd62a79dd200e35144a13478bc5c2db856b62c4a4c910ac65",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/python/validate-canonical.sh": {
+      "category": "framework",
+      "originalHash": "sha256:c1595344580d5eb2399e2dec95e2393b9f772770514da2f81415152c49c9ee78",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/python/validate-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:2c8c941fa81256d542fb3e900c81134d52d727f6314f759eff6c62d46be58bbf",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/python/validate-integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:a1e8b48da8e448ec54a3c8ab86567669d536a29ba9920abad23bffea2b55cf1e",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/python/validate-tests.sh": {
+      "category": "framework",
+      "originalHash": "sha256:0fc7350224acdea5566f5387e007cdd5d619364ad72ac4df82813273fd57fc0b",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/typescript/validate-operations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:a6f54c7526002cb928b2d9b272c26dfc38151a6bcf9b16e88d363eaa9c0cda4f",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/typescript/validate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d81953aaad55f085aad5c822106ada41efdb96d98cffe75af9fdf3b5fb645455",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/typescript/validate-security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:6efaacb0d964ac4802af1b6e64febcea5381dd7a0532078473a6db4c4d662506",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/typescript/validate-canonical.sh": {
+      "category": "framework",
+      "originalHash": "sha256:fda459070dc7382aa21a18ef35bcef6690785cc2893dc0a21cb7163d65afde7d",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/typescript/validate-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ac623eb9b00815e309d2406f354ffeaabd3eea75082e494ec01fdf8f47dc5114",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/typescript/validate-integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:fff4fa86138b9a665530802f27164289030ff9a310e9b83bcfa0aa6d21fadec6",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/typescript/validate-tests.sh": {
+      "category": "framework",
+      "originalHash": "sha256:0766f2a81e347933eb5165a52f85c6ef187f295a870bb62b14de23d928757a3c",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-operations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d9311bb85d151a87de536d59ca5ecedb64f8e706dc567676f319e29cd219e86e",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:865075e55eac4ddc376801126790a22243cc3afe040ba9ea87ed48e75d7b6100",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-spring-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:7cfba1009c4d01389d8483f08e4707f2e04bfd39d92ee88306052c9199cd2bfa",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-annotations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:f203261df873cd3fe3802841b17776c0fae1dc99a03aa214dd16cd4bfa4725dc",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:096d0110bb1e6a41270b6a1b6fbab4754d5545ee399b0c0dc2ceda8e36556883",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-canonical.sh": {
+      "category": "framework",
+      "originalHash": "sha256:a14ab70ba53946757a9c3692b9e31291d90fb43df6f6130b20b272a5c379c686",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:fae27bc8b709c88e3d64b6367f9e4604334770d59b4b9e741e06608d08891b12",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:7d918adf8f28b4f91af68bc0f3da661195d6eb922a452e86852fd39b6821b91b",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-tests.sh": {
+      "category": "framework",
+      "originalHash": "sha256:e98017ceb722bd3aa6a283000af07d30ed074051e96dbaa76e1081f69274244b",
+      "status": "unchanged"
+    },
+    ".pi/skills/tdd-practice.md": {
+      "category": "framework",
+      "originalHash": "sha256:c4e2f05e88abaa31f48376eb127e769b56694866a73769f36c0960573d5f2585",
+      "status": "unchanged"
+    },
+    ".pi/skills/go-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:5ee2969b7d30428a862240cb1b17b5a19554da2c146912e53557756f0c58c1c0",
+      "status": "unchanged"
+    },
+    ".pi/skills/angular-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:b8143821f913809df3303f9c20c858ca5aa161eccc7bbc8b69b75050a13088d7",
+      "status": "unchanged"
+    },
+    ".pi/skills/typescript-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:c4b25b5f5e76e84e2a7ab8af0043993bfb5d47d1c689f6f5377645cca7378ae6",
+      "status": "unchanged"
+    },
+    ".pi/skills/design-system-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:14e0a6726d32cbb83663f4a181788512e54759662567360624aed4dcb371d7d1",
+      "status": "unchanged"
+    },
+    ".pi/skills/rust-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:278e23e4be7752607f94f390f6770d2ac5837e28f06ad347bb706d726bc87dba",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/rust-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:28a65bf73032376577341d8b75b8d9f9788cd6058ae388e1cf1c7c7473e3a835",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/typescript-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:09e2ff0b0dea87356ce03347bb7119d2fc669755d25793dd96291b86c55e54b5",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/nextjs-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:80900886ae62aa59a1b6e47430849fe1372649244f9814d3d8be00820942c61a",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/design-system-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:562a9bc395096fef10911c22ff9480824c0aed48cea7e000e9c1db588c5dfb14",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/python-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:a7f573566bd0d90b4d2d4262c43e3de9c0a0379f07f59f185b73730915c14563",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/angular-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:ede820cc2fc4f86f11bd2a97e8c03f8a8832944d6e2e33819091f4cb7b5290e9",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/java-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:8fe7500823e7b41ee04cc4f0fcb9386aabec2c1b9003e8ce39de09b7cf78fdd3",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/go-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:7453a53e9ae8d5b91825aab32ed29c8cc6d16bb07610724a5cfd10a3106db745",
+      "status": "unchanged"
+    },
+    ".pi/skills/java-spring-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:5d68093293c887875634b9f567c6c886373ebfcf7cf248f4156da42e6c19b490",
+      "status": "unchanged"
+    },
+    ".pi/skills/python-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:89a1bdfbc5d3a1eedb5bf2f4260890321cc892e0893121e48d4b3f91d6e978c2",
+      "status": "unchanged"
+    },
+    ".pi/skills/nextjs-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:f1041e806a170fdbc391f6543033322cbe4b9baab82ee19b68b53751652a54cc",
+      "status": "unchanged"
+    }
+  },
+  "exports": {},
+  "templateContext": {
+    "projectName": "rigorix-oss",
+    "projectVersion": "0.1.0",
+    "language": "rust",
+    "repository": "arman-jalili/rigorix-oss",
+    "repoTool": "gh",
+    "groupId": "com.rigorix-oss",
+    "buildCommand": "cargo build",
+    "testCommand": "cargo test --all",
+    "lintCommand": "cargo clippy -- -D warnings",
+    "formatCommand": "cargo fmt",
+    "formatCheckCommand": "cargo fmt --check",
+    "securityAuditCommand": "cargo audit",
+    "errorHandlingPattern": "Result<T, E> pattern",
+    "tracingPattern": "tracing crate with structured spans",
+    "cancellationPattern": "CancellationToken pattern",
+    "atomicWritePattern": "tempfile + rename pattern",
+    "keyFile1": "src/index.ts",
+    "keyFile1Purpose": "Main entry point",
+    "keyFile2": "src/lib/core.ts",
+    "keyFile2Purpose": "Core library functions",
+    "domainDescription": "main rigorix project, parent for engine, cli and github actions"
+  },
+  "scaffoldedAt": "2026-06-21T19:05:41.403Z",
+  "lastUpdatedAt": "2026-07-20T16:07:23.151Z"
+}

--- a/mcp/guardian-manifest.json
+++ b/mcp/guardian-manifest.json
@@ -1,0 +1,1228 @@
+{
+  "schemaVersion": "0.1",
+  "frameworkVersion": "0.1.97",
+  "source": "pi",
+  "tools": [
+    "pi"
+  ],
+  "language": "rust",
+  "repoTool": "gh",
+  "archMode": "strict",
+  "groupId": "com.rigorix-oss",
+  "validators": [
+    "ci",
+    "tests",
+    "security",
+    "operations",
+    "integration",
+    "architecture",
+    "canonical"
+  ],
+  "workflows": [
+    "feature-development",
+    "bug-fix",
+    "hotfix",
+    "refactoring",
+    "issue-implementation-series",
+    "epic-plan",
+    "issue-draft",
+    "git-issues",
+    "issue-closeout",
+    "issue-merge",
+    "plan-to-issues",
+    "blueprint-validate",
+    "sync-check",
+    "context-refresh",
+    "scope-analyzer",
+    "pattern-extract",
+    "blueprint-update"
+  ],
+  "files": {
+    ".pi/context/checklists.md": {
+      "category": "framework",
+      "originalHash": "sha256:8f3e52628b0d1abe439d84f3b29848c4141110c485e2d42dd7ae0fb0fd234806",
+      "status": "unchanged"
+    },
+    ".pi/context/domain-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:f92b43bdc715fd5cd8d3ab292c236e705e1ad155e58cb343efe4c6605eacd717",
+      "status": "unchanged"
+    },
+    ".pi/context/project.md": {
+      "category": "user",
+      "originalHash": "sha256:2dd4ff55bd49f0524108fbcbb344acfce74eb7d66772a212261b505880b1b019",
+      "status": "modified"
+    },
+    ".pi/context/patterns.md": {
+      "category": "user",
+      "originalHash": "sha256:f236410e550929feab59092b3b3ba9bf36ccebeea7171ebd7f60346fe3b31289",
+      "status": "modified"
+    },
+    ".pi/context/output-formats.md": {
+      "category": "framework",
+      "originalHash": "sha256:57700883af3a4bac040a49c7a00e34040ef64fe66fe45502fa44dd6a49dada1f",
+      "status": "unchanged"
+    },
+    ".pi/context/patterns-base.md": {
+      "category": "framework",
+      "originalHash": "sha256:8d9bf4d5c7ab81f060b0fadf8138cbb615b26119860988215f2ebd405c42bd1e",
+      "status": "unchanged"
+    },
+    ".pi/workpad.md": {
+      "category": "framework",
+      "originalHash": "sha256:c15373fbf3ad0317a1281066c7605a9f2c0823c1a3c5e946e0620b808c6bf67b",
+      "status": "unchanged"
+    },
+    ".pi/agents/issue-factory.md": {
+      "category": "framework",
+      "originalHash": "sha256:8e1d2a8211e7634736c51f6fe5af2ae48d3263a39d54ddc7cb23c9183537ae06",
+      "status": "unchanged"
+    },
+    ".pi/agents/architecture-coordinator.md": {
+      "category": "framework",
+      "originalHash": "sha256:0449f8b3d33b1d479e0699303eea0e6c6d512f38972e99cb1b8c0da0f7b37f8c",
+      "status": "unchanged"
+    },
+    ".pi/agents/bootstrap-implementer.md": {
+      "category": "framework",
+      "originalHash": "sha256:77662fa88c70fe139f7ff526c8763a3226d7dff6c249081a7a63d02e1ac72041",
+      "status": "unchanged"
+    },
+    ".pi/agents/operations-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:e64c119a9f0fc7c9fcebf813f47bd43b091c8049a6fd32a2789da69ec1c1fbde",
+      "status": "unchanged"
+    },
+    ".pi/agents/security-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:6cd0cd853582cb8f60d27c7bb9e339977928a07f3b4fb8fb66bf894bd6fad728",
+      "status": "unchanged"
+    },
+    ".pi/agents/architecture-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:3fbae65130cbb256e5be0c0e3b784de9fd681a9a54629bb270617e29886fcc9c",
+      "status": "unchanged"
+    },
+    ".pi/agent/AGENTS.md": {
+      "category": "user",
+      "originalHash": "sha256:006f740d01f7dbf192eb78b4cc652c4593150f62d90265db8fdbdd17388de35a",
+      "status": "modified"
+    },
+    ".pi/extensions/curator.ts": {
+      "category": "framework",
+      "originalHash": "sha256:73e4167139e574df37fefa89271bd3ff2941f6d6f6e1abb8accfd0059a240c83",
+      "status": "unchanged"
+    },
+    ".pi/extensions/session-persistence.ts": {
+      "category": "framework",
+      "originalHash": "sha256:57ffec30b56753fd5cb676577f4a72c2feaf967470611316716825f3f50135fd",
+      "status": "unchanged"
+    },
+    ".pi/extensions/domain-explorer.ts": {
+      "category": "framework",
+      "originalHash": "sha256:181df5a732046e2ecb104eba8f78a919982d39ea7afde0332f040e4d7fec5e3a",
+      "status": "unchanged"
+    },
+    ".pi/extensions/kanban.ts": {
+      "category": "framework",
+      "originalHash": "sha256:c6cb9c7876986c155a784cac3919a094f0c0510413e955fd0d3986b27071a7e3",
+      "status": "unchanged"
+    },
+    ".pi/extensions/project-scaffolder.ts": {
+      "category": "framework",
+      "originalHash": "sha256:d0dd4ddeb736cb45a785b92b8c912e5dfd54254756f1e67202e56934c8b1a751",
+      "status": "unchanged"
+    },
+    ".pi/extensions/snippets.ts": {
+      "category": "framework",
+      "originalHash": "sha256:700a8426ac78d7a8d3a887ad2cba8078a603a427e8afef484e65ca09da21ce89",
+      "status": "unchanged"
+    },
+    ".pi/extensions/read-only-mode.ts": {
+      "category": "framework",
+      "originalHash": "sha256:97ba2d0956971f86e9301498a1065c8f3f0400d4631e9ef16961e7f00f94778e",
+      "status": "unchanged"
+    },
+    ".pi/extensions/slash-commands.ts": {
+      "category": "framework",
+      "originalHash": "sha256:57403f17cfe8a8d68d573cf213e96d5be7928102c7565b05e18297f4d2f92c2d",
+      "status": "unchanged"
+    },
+    ".pi/extensions/config-reload.ts": {
+      "category": "framework",
+      "originalHash": "sha256:1c3bf2e7dc67f61f14ca6bd7c768aa47ed99e4477721e562467d27e8072fc57a",
+      "status": "unchanged"
+    },
+    ".pi/extensions/pipeline.ts": {
+      "category": "framework",
+      "originalHash": "sha256:8904ceed21f5c5168399a60df3cd28f87b6ca1fb5334d9e32cc13e861acd8a38",
+      "status": "unchanged"
+    },
+    ".pi/extensions/bash-guard.ts": {
+      "category": "framework",
+      "originalHash": "sha256:faac81ad49dc7585f34db4be51d609349cfddb1685ae39047f6bcba305c6ba04",
+      "status": "unchanged"
+    },
+    ".pi/extensions/validation-runner.ts": {
+      "category": "framework",
+      "originalHash": "sha256:c00de33ce0f3b28da4fe486c503542311fc55888cd06b056aa25d1242030fc5c",
+      "status": "unchanged"
+    },
+    ".pi/extensions/architect.ts": {
+      "category": "framework",
+      "originalHash": "sha256:07694d021e5d0fa9def78445a9b178e7c13a00c8c4d0019e5af06faeb488b0dc",
+      "status": "modified"
+    },
+    ".pi/extensions/architect-lib/helpers.ts": {
+      "category": "framework",
+      "originalHash": "sha256:08ca9517e28570b7cd82b18d506b5b90d6995869ac418b5287cc9ff29ccf28a3",
+      "status": "modified"
+    },
+    ".pi/extensions/architect-lib/generators.ts": {
+      "category": "framework",
+      "originalHash": "sha256:d1f92110fe8b979911e095ce6b80cec74f1a18c31d3ea8749ff7c1fa8c8a28d7",
+      "status": "unchanged"
+    },
+    ".pi/extensions/architect-lib/forge-adapter.ts": {
+      "category": "framework",
+      "originalHash": "sha256:e85a34bb1af7564e617b76bcf2cc051c2370f7f640a8018f61ae352eb9cd7c60",
+      "status": "modified"
+    },
+    ".pi/extensions/architect-lib/types.ts": {
+      "category": "framework",
+      "originalHash": "sha256:45eb3594fdc2f65e1f3ab7ced668104aa19170bfd566b66ad3466d4b74727a18",
+      "status": "unchanged"
+    },
+    ".pi/extensions/ask-user-question.ts": {
+      "category": "framework",
+      "originalHash": "sha256:c770fa193453768ee33875ffd626311e52f061af2856acc3fde014db3ec4fe64",
+      "status": "unchanged"
+    },
+    ".pi/extensions/filechanges.ts": {
+      "category": "framework",
+      "originalHash": "sha256:b04dfde9d19dcf1d0c6197bb36b153cc200befea7cb459a545afeec5b0f5c22c",
+      "status": "unchanged"
+    },
+    ".pi/extensions/hooks.ts": {
+      "category": "framework",
+      "originalHash": "sha256:2a953dde5b843d05818cadbe82876a6d362113e6d4932f0571b4c35935cdb405",
+      "status": "unchanged"
+    },
+    ".pi/extensions/coordinator.ts": {
+      "category": "framework",
+      "originalHash": "sha256:0c676778ff4edad8f4c15db658d151e115666c9607aa80b3ed4ba5f08c83a26e",
+      "status": "unchanged"
+    },
+    ".pi/extensions/goal-loop.ts": {
+      "category": "framework",
+      "originalHash": "sha256:72d0e45d4afe6beabd5e8ed9a8e04c260ebb67c744633e5079c0a764eeecc82e",
+      "status": "unchanged"
+    },
+    ".pi/extensions/redaction.ts": {
+      "category": "framework",
+      "originalHash": "sha256:8fd16eba73b995d7e8f20f03a7c495c1ea26fb5032610e27cf239eb64299ba13",
+      "status": "unchanged"
+    },
+    ".pi/extensions/plan-mode.ts": {
+      "category": "framework",
+      "originalHash": "sha256:34efd4378ecb3431d77cf7e60c589ddb9aa7bf56c578d2f3fde52cfc6deee3cf",
+      "status": "unchanged"
+    },
+    ".pi/types.ts": {
+      "category": "framework",
+      "originalHash": "sha256:017a07fae90a46fca800dcb6b3ef19050570677c8a4a9672f85b238183f72ee4",
+      "status": "unchanged"
+    },
+    ".pi/architecture/CHANGELOG.md": {
+      "category": "framework",
+      "originalHash": "sha256:653bed6d8499cbf4b96598d1c3c6e0537989018b08654fc9422d50c85a8f20d6",
+      "status": "modified"
+    },
+    ".pi/architecture/diagrams/system-overview.md": {
+      "category": "framework",
+      "originalHash": "sha256:162cb1fa10bc933370390c9b37d64dcb4dad333e4ecef4e73c3d48e9d8ae91d3",
+      "status": "unchanged"
+    },
+    ".pi/architecture/decisions/ADR-template.md": {
+      "category": "framework",
+      "originalHash": "sha256:18e171fa061c7f8abd07b3b90a7d02f619bf1545124969203225f4bdd4b41531",
+      "status": "unchanged"
+    },
+    ".pi/architecture/implementation-roadmap.md": {
+      "category": "framework",
+      "originalHash": "sha256:277e4ba1207cb122d73eccc09dba04d76fba0d8e3e5004dd348e1ee34aaa10ba",
+      "status": "modified"
+    },
+    ".pi/architecture/modules/module-template.md": {
+      "category": "framework",
+      "originalHash": "sha256:1b72bef9fbcc5b99229ca641b114cff02e66e044bdf891ede880976d0ff43025",
+      "status": "unchanged"
+    },
+    ".pi/github/instructions/architecture.instructions.md": {
+      "category": "framework",
+      "originalHash": "sha256:9f26ff4819db738887c1cdb9745537dadc43fc05ad788684b38dbc7a6dad17d5",
+      "status": "unchanged"
+    },
+    ".pi/github/instructions/validation.instructions.md": {
+      "category": "framework",
+      "originalHash": "sha256:934d64609f1275887a5c2795ce41d7d31fa5e8cf77cac35612d1b8685a44d28b",
+      "status": "unchanged"
+    },
+    ".pi/github/copilot/settings.json": {
+      "category": "framework",
+      "originalHash": "sha256:9e21c730edefe4080fee1014a02fbb96118aa300ea0f93563a53f9c6d9c4f2a1",
+      "status": "unchanged"
+    },
+    ".pi/github/workflows/01-planning-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:b7c13edf0d75fe2cc2a8784461637ec91a2bc894682768b6b208795f60a5d404",
+      "status": "unchanged"
+    },
+    ".pi/github/workflows/03-implementation-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:3b067bd1df93bb8de1eb26873825f2d5a330c46c619cb3209db127d33fde3ebb",
+      "status": "unchanged"
+    },
+    ".pi/github/workflows/04-validation-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:513bb31dd54f5961e221f71e5216fd1acde8ad0158f5523985bdad97a2bff8c8",
+      "status": "unchanged"
+    },
+    ".pi/github/workflows/02-issue-generation-workflow.md": {
+      "category": "framework",
+      "originalHash": "sha256:41205400814e6d4b77ddbcf351d8e1f0701d11c618225eabf6ed3d3b630d56dd",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/architecture-validator.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:04e7cb86758e135b55abc556b9d043d6f68cd5566dd5b0a882cedc615fbde065",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/issue-factory.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:ef97de04d6f99a3b2edd04182ab8cf73a7da564b99d091f5c3d2056175fd686b",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/architecture-coordinator.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:9e376f5ba69f3fc30672b83e9792bb2cb961abc61d6fddda057a5df2ce398e0e",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/epic-planner.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:859599d908d8d1a5bc41d82eaea9414f147a1a16b8d37a99630f3d700f37c0ca",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/bootstrap-implementer.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:2a0b8f2d37ab6c9112d0fa0101429ad5afe3d2c39328b3d132eee1eeb454a3ee",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/security-validator.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:e9081be418d7f432fbd9b4a63d8181b44e797c93a8b6065ec330e2a5fa4b6109",
+      "status": "unchanged"
+    },
+    ".pi/github/agents/operations-validator.agent.md": {
+      "category": "framework",
+      "originalHash": "sha256:464860fa7eabcad393471c8dc434268d2f55e72eda0889386abee02f88315ec3",
+      "status": "unchanged"
+    },
+    ".pi/github/copilot-instructions.md": {
+      "category": "framework",
+      "originalHash": "sha256:f82b95c50d87175e42851487b9c9f8891cfc1b5d74d784fdcbc2c4a221ddd19f",
+      "status": "unchanged"
+    },
+    ".pi/INDEX.md": {
+      "category": "framework",
+      "originalHash": "sha256:e61e5215c25ec05ff53bfb72309dde3f7c781c2ddc79c8af9cf6fa987cd4136e",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-operations.sh": {
+      "category": "generated",
+      "originalHash": "sha256:4fb994c9056b90f565fe536633795586da3197a2a2b8f745baea9af8db4440d5",
+      "status": "unchanged"
+    },
+    ".pi/scripts/create-feature-branch.sh": {
+      "category": "framework",
+      "originalHash": "sha256:33ff4c76faba418025dbe88a998f2a04a6cafd282d11fc644a50de014cc580d0",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-architecture.sh": {
+      "category": "generated",
+      "originalHash": "sha256:241df1a4517e0a04aff9cfc4efddbdcb4b3859e65bd35cb8c558a172dfe7cf4d",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-ubiquitous-language.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d9886f03dcc186d367c92dcd8f0547768534413c50f32d396d3d55ea3d016fb0",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:1ebac9c09ebfebc1e9cffdfa474c792f28bbe386a923ca49a0695bddee93df40",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/local-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:98d8181260d31fd3303eebf92bc70412590131a75385fefb679e038574b2d54e",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/run_hardening_stages.sh": {
+      "category": "framework",
+      "originalHash": "sha256:8a67c21f7154e1cd4987f6e5e56dbbd476f3bf6d7846d4c167289008979d4a65",
+      "status": "modified"
+    },
+    ".pi/scripts/ci/stage_remaining.sh": {
+      "category": "framework",
+      "originalHash": "sha256:396b75ec9fb00224781e9eca66ac51a9ec7f05876d5175f80070560fdf629fe5",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/check_planning_packet.py": {
+      "category": "framework",
+      "originalHash": "sha256:214e1ce18ed2226f344f25687fde9dd586b061f1af8efd6f54c27bd09dabae67",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_package_build.sh": {
+      "category": "framework",
+      "originalHash": "sha256:67b0f705398369fb171c993c1e673f8cce16e4016cd6c1ca72c8996ce3bda7c4",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/validate_agent_output.py": {
+      "category": "framework",
+      "originalHash": "sha256:51cbdbed1921620608a25c2f4db67dbfd088a3d43cb96a03ec425c181d6ce4c9",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/run_preflight.sh": {
+      "category": "framework",
+      "originalHash": "sha256:137294de31aebfa339ae28ba878cb85720bdbe1b4298a2dd19ca184754bd67c4",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_migration_verify.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d25a4de5ddcb3946fca19e82828dd03f726d2084c71dbe4ecf0e222d1da1b67b",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/check_ddd_structure.sh": {
+      "category": "framework",
+      "originalHash": "sha256:f2fb90658b34c25f4c85a083ffc35c8e6b388459fbd0ac1b475c0624472cbec3",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_unit.sh": {
+      "category": "framework",
+      "originalHash": "sha256:64c8b8a4c6266725962b238a1c9814ea110c0f067e90ca9d38287a40074a5f19",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_release_readiness.sh": {
+      "category": "framework",
+      "originalHash": "sha256:0d62822ea089f0469e66561d501bf03cd5e9bb0dbedb199e0ca39286c3ffaa7c",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_docs_policy.sh": {
+      "category": "framework",
+      "originalHash": "sha256:8b13849d612e4dde20a43e3e2ef23c9279869c14683e29506213749e4f2e29ec",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/validate_agent_output.sh": {
+      "category": "framework",
+      "originalHash": "sha256:26816f935433df71266651dfe393c9ff3b7c3975426e05a93b7308c6fc3b80bf",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:a9617cd791ef4ebc72a519ca5169c287f94ba128e14c19f75a6db24267cf42ec",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/run_stage.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ade2b65032142b6f03fc08ed99828964c0bf6a7121d82969871ac963dac14fe1",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_lint.sh": {
+      "category": "framework",
+      "originalHash": "sha256:b5ce9794af4d271f7e04a82f6a35fe7e254d64ff4e71518cf201e4210c1b6560",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/check_architecture_conformance.sh": {
+      "category": "framework",
+      "originalHash": "sha256:481753c035c9383bf341e6b4c6e1eaae337975bdc3281becd0e9992a8a076bfc",
+      "status": "unchanged"
+    },
+    ".pi/scripts/ci/stage_static_analysis.sh": {
+      "category": "framework",
+      "originalHash": "sha256:5d40980d65b39245bb3db064f0ae60b977b33cb0e7f86b0d211020cb894bafa7",
+      "status": "unchanged"
+    },
+    ".pi/scripts/merge-mr.sh": {
+      "category": "framework",
+      "originalHash": "sha256:726ff4212cf5097de646668bb2a48c0ff63de02cb0132686474f6dc91e047afb",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-architecture-readiness.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d460c6ccd94a3382d3fde7fff1e9d9f7c10abba76a3f6a3e41238283e81354d5",
+      "status": "unchanged"
+    },
+    ".pi/scripts/fetch-issues.sh": {
+      "category": "framework",
+      "originalHash": "sha256:e9b6c563b9d242e925de55bb120e667e69ed2e6d544a248828b6cc2d0cf514fe",
+      "status": "unchanged"
+    },
+    ".pi/scripts/categorize-issues.sh": {
+      "category": "framework",
+      "originalHash": "sha256:172e09a69b56e3b502d184f740c447f570647893f4658e2dd91451595f77dc93",
+      "status": "unchanged"
+    },
+    ".pi/scripts/create-mr.sh": {
+      "category": "framework",
+      "originalHash": "sha256:6670010595a85cbf518fb02d760c417922e480b27979351e418ec4bcd0571b29",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validation-cache.sh": {
+      "category": "generated",
+      "originalHash": "sha256:5fea93087bcd9852532ce8119f47ecdb61a46fd857b336e2955b087ed61aa3bd",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-operations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ab89729ca059bf5c51693c30dc088ea396c9e3cec282926eb20e0927d7c01c42",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:250210026e0e228def1481a26f9bfc85c032734edc867d1aa153ee5ea4b09e6d",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ce3a057d27fbdcffb0e8043aece29acceea9e9eb69e61dae276f6a7205bdbb8e",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-canonical.sh": {
+      "category": "framework",
+      "originalHash": "sha256:c0e145a8e1c16024062bf928945c2cd45c4d1c0a78c942e547a7f3f4ededc80b",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d27898b08963a4ddfa0a62227ded3e91e61e81ecd4859c1549c3660abc09ec51",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:11a8b41544e1bd36379f724cd4fefc6ef4c608aca5f093d1db22b840d04d133f",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/rust/validate-tests.sh": {
+      "category": "framework",
+      "originalHash": "sha256:7538f07f8a432ba2c25ca1f53fc2778a3cbe1f811d77f26eff7015915b3471c9",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-security.sh": {
+      "category": "generated",
+      "originalHash": "sha256:0a9453d133e9b8e86cd767cec2f130bd6dc74db93d2169d2e43858af81438630",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-canonical.sh": {
+      "category": "generated",
+      "originalHash": "sha256:66d2e6887f040d7179e811f79f8c9f367066c6fd6a100c462ddb330556d54228",
+      "status": "unchanged"
+    },
+    ".pi/scripts/generate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d4e48b44eacf98df17eab6ad97fb67c58f2569a2200481632ca4cf348ec1daf7",
+      "status": "unchanged"
+    },
+    ".pi/scripts/mr-validation.sh": {
+      "category": "framework",
+      "originalHash": "sha256:4ff040e1c2cda028d317740d0c6f0dc5b8536a3986dcd79b7f90c70e1f16a0d3",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-ci.sh": {
+      "category": "generated",
+      "originalHash": "sha256:d5ae9a470c0e738063a103f8cedd9bb08ebc38dabd35883c6d16874228d08c45",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-integration.sh": {
+      "category": "generated",
+      "originalHash": "sha256:01c0dc34f6a94dcb46428049e4a090c89756c67755f0f16068dcfcb0b4df2ea0",
+      "status": "unchanged"
+    },
+    ".pi/scripts/validate-tests.sh": {
+      "category": "generated",
+      "originalHash": "sha256:ff7840a569b1571782ae8c4174a6b871345c6a354c65ff4ca5784b898ba15466",
+      "status": "unchanged"
+    },
+    ".pi/scripts/git/close-epic.sh": {
+      "category": "framework",
+      "originalHash": "sha256:fade48608d4bfc267ec7bae6b374c6fb2a40b709a2d226ec06c36ede853f5c2a",
+      "status": "unchanged"
+    },
+    ".pi/scripts/git/close-issue.sh": {
+      "category": "framework",
+      "originalHash": "sha256:8984749dc0957659553108265bb16463166ade0f6e7acd8742be003bf92f990e",
+      "status": "unchanged"
+    },
+    ".pi/scripts/git/update-tracking-issue.sh": {
+      "category": "framework",
+      "originalHash": "sha256:4701dc3b3afca2884071db20a4b4a2665d12e6af5498b349a75b598da0fe7cbe",
+      "status": "unchanged"
+    },
+    ".pi/scripts/git/link-issue-to-epic.sh": {
+      "category": "framework",
+      "originalHash": "sha256:626c4eb5935ebdcec66b51128ef29f11b797a959b1ceadfb6a886e5b9b0c37a5",
+      "status": "unchanged"
+    },
+    ".pi/scripts/git/create-tracking-issue.sh": {
+      "category": "framework",
+      "originalHash": "sha256:b5cb2ed891b0de4cfb8434f55ef5053ea49d02708e00ef68db3f5ae02a99a0c6",
+      "status": "unchanged"
+    },
+    ".pi/prompts/blueprint-validate.md": {
+      "category": "framework",
+      "originalHash": "sha256:b73c83cb10e9afbb6b462063cd0a1ad588f301ade22735c2fb03272696d396e6",
+      "status": "unchanged"
+    },
+    ".pi/prompts/bug-fix.md": {
+      "category": "framework",
+      "originalHash": "sha256:9d88f8d9766a66f348a78d137e5c7e186dee834c448f5e21ad284559b27e3422",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-implementation-series.md": {
+      "category": "framework",
+      "originalHash": "sha256:af7eb7eadeb1c8929fae9c15a86ac627140a123a03f52c4ef5246c60543d539e",
+      "status": "unchanged"
+    },
+    ".pi/prompts/pattern-extract.md": {
+      "category": "framework",
+      "originalHash": "sha256:3433fa6188bf8717c4aa8a052c4f3b9c6aaa7ed3e01dc8b816ffc1e0cb7f475a",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-draft.md": {
+      "category": "framework",
+      "originalHash": "sha256:e50f0fb5a7d49d0316259e05e798ac44797b156394c8f7e22407907941309c14",
+      "status": "unchanged"
+    },
+    ".pi/prompts/epic-plan.md": {
+      "category": "framework",
+      "originalHash": "sha256:3633e445bb94ecdd41567490c3c31086784d6597e99ef3e86677628e00feb4b6",
+      "status": "unchanged"
+    },
+    ".pi/prompts/sync-check.md": {
+      "category": "framework",
+      "originalHash": "sha256:06c09fefa4521254c0c0e43b587985d809749a4fa0f9e462fc85f33e8182b382",
+      "status": "unchanged"
+    },
+    ".pi/prompts/blueprint-update.md": {
+      "category": "framework",
+      "originalHash": "sha256:e56adc41911876bbca89fa2d5947c7a76e5ebb4af423f8749d61e700fe4a95f4",
+      "status": "unchanged"
+    },
+    ".pi/prompts/hotfix.md": {
+      "category": "framework",
+      "originalHash": "sha256:65cc83277bbf83931e1941fb6059bfd1ae41ae5fe11a6f3124ce1f356fd3e1ec",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-template.md": {
+      "category": "framework",
+      "originalHash": "sha256:082223c4d14099fa85cf960b06b909baf0701f7ed4e450621e1e930593c6128c",
+      "status": "unchanged"
+    },
+    ".pi/prompts/epic-template.md": {
+      "category": "framework",
+      "originalHash": "sha256:cdc5b784ed287871d651ebcedeacddd74091b4c1ac3b7e696890d78353b94afc",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-closeout.md": {
+      "category": "framework",
+      "originalHash": "sha256:a2c88df36dd87fec9e87f2efcc0ff0ab694b75b5952090763c7081f9bcde5681",
+      "status": "unchanged"
+    },
+    ".pi/prompts/scope-analyzer.md": {
+      "category": "framework",
+      "originalHash": "sha256:be1d74366bbe8e5f7dd5949d45e9adb89b17b6015dc471921e32b6fc2e110633",
+      "status": "unchanged"
+    },
+    ".pi/prompts/ci-blueprint.md": {
+      "category": "framework",
+      "originalHash": "sha256:b2847a4ec3b26f3a77e6c06d8ebe2595032703ec2d8c1529a8f76204bc03c58f",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-template-set.md": {
+      "category": "framework",
+      "originalHash": "sha256:e39a39d393eccf5accef33afbab39c11315d58dd56cc96447fd9bef4746a5ddd",
+      "status": "unchanged"
+    },
+    ".pi/prompts/issue-merge.md": {
+      "category": "framework",
+      "originalHash": "sha256:adfc1e0dd785efe556945f74e4f84c1a8f1efbd33d6ad68e50514cacf0b5511c",
+      "status": "unchanged"
+    },
+    ".pi/prompts/context-refresh.md": {
+      "category": "framework",
+      "originalHash": "sha256:09fdc06700827a1aec1906c6710c6c9b2a7419cc984359edcae9339c53114e47",
+      "status": "unchanged"
+    },
+    ".pi/prompts/git-issues.md": {
+      "category": "framework",
+      "originalHash": "sha256:000effa78e9a2bdbe06307eb4de3c879051e59ec728687b20df39db21a69f34c",
+      "status": "unchanged"
+    },
+    ".pi/prompts/feature-development.md": {
+      "category": "framework",
+      "originalHash": "sha256:4161e4ba61d4f00d75f0c616513ffb1f4a628292ad091ab33b0063d5e0ebeed9",
+      "status": "unchanged"
+    },
+    ".pi/prompts/plan-to-issues.md": {
+      "category": "framework",
+      "originalHash": "sha256:1cc665bad7a5aa45a8b769d22a8dbc5c7288ccaa2e8e017935b9ce7f6fd13fe8",
+      "status": "unchanged"
+    },
+    ".pi/prompts/refactoring.md": {
+      "category": "framework",
+      "originalHash": "sha256:b1fafce9705a0ac15ce975d5ab9747ed8685b37f05d7266ed5915b95582d2b2f",
+      "status": "unchanged"
+    },
+    ".pi/skills/tdd-practice.md": {
+      "category": "framework",
+      "originalHash": "sha256:8c2a7fbb809dda355bae934cc725b09f5198e4e730a5951819306db76eb2403f",
+      "status": "unchanged"
+    },
+    ".pi/skills/go-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:cd255d81913e4f288d1875bb3cce49dcbe53232db254deecc328ec83bbf18b71",
+      "status": "unchanged"
+    },
+    ".pi/skills/angular-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:b8143821f913809df3303f9c20c858ca5aa161eccc7bbc8b69b75050a13088d7",
+      "status": "unchanged"
+    },
+    ".pi/skills/typescript-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:dbf9ac9ebf9fd26d5c6b6bb5c17f55ecd83ae6b2be5faca8017f88dcd3c99d89",
+      "status": "unchanged"
+    },
+    ".pi/skills/design-system-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:14e0a6726d32cbb83663f4a181788512e54759662567360624aed4dcb371d7d1",
+      "status": "unchanged"
+    },
+    ".pi/skills/rust-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:08fde54fe7481b8c997c092344bec1d96db05f6a0a5c038ecd5ba58484a8d9b0",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/rust-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:28a65bf73032376577341d8b75b8d9f9788cd6058ae388e1cf1c7c7473e3a835",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/slash-commands.md": {
+      "category": "framework",
+      "originalHash": "sha256:d9783d8d481ae7a02c2c91db52f8600c7fb6821418dcbd5f589ca37f314b6a1b",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/pipeline.md": {
+      "category": "framework",
+      "originalHash": "sha256:e44a23d8ff5d49b6a1ae08b6b50f5ecbf09f774be2944dc3e60d98f57f7a6ca3",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/debug.md": {
+      "category": "framework",
+      "originalHash": "sha256:65368b250d343f208d3ad07d63b23fee8a178f3e9a3a65079d1b05ccb954b7ed",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/issue-factory.md": {
+      "category": "framework",
+      "originalHash": "sha256:078e16f2b69c44ea7bc3d356dc3b8a3bf861b220a3ce3fc4c2a0dd2e949848ac",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/typescript-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:09e2ff0b0dea87356ce03347bb7119d2fc669755d25793dd96291b86c55e54b5",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/architecture-coordinator.md": {
+      "category": "framework",
+      "originalHash": "sha256:87877ea4cc689c98f6ab8d661d85b0d0af8debe06f6840ab62c891370ba112f7",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/snippets.md": {
+      "category": "framework",
+      "originalHash": "sha256:4bf69877925a542de4d6f84f0205654ae2c53ac56ba740674eb849f1a7d1ce95",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/architecture-generator.md": {
+      "category": "framework",
+      "originalHash": "sha256:6b2763ece59b22d86a95e1d1712b118cbb700e0cce5d941435604b4acca3fd4b",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/land.md": {
+      "category": "framework",
+      "originalHash": "sha256:099bedd22bfd99ac6d061d376f0c5d0314bd7ddd351166d2816122d9ae210207",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/nextjs-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:80900886ae62aa59a1b6e47430849fe1372649244f9814d3d8be00820942c61a",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/push.md": {
+      "category": "framework",
+      "originalHash": "sha256:93a9a3f3e154743e342ccc75f3780cca9efd2738d90545bd43bdc5518a2b310d",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/curator.md": {
+      "category": "framework",
+      "originalHash": "sha256:3a6ef64758000d80c5a126356afb1b7539e76b83f9a2dd6a42da2f99ebb435d3",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/kanban.md": {
+      "category": "framework",
+      "originalHash": "sha256:e82cc278ab29c86e93a0bdb222717f36088a3c0c02f5fa4e86b2fe28be723dab",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/ci-mr-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:ad5ae29d0043ac16c3a082488932e79f9f21132142616977d00aaf1f8bf26767",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/session-persistence.md": {
+      "category": "framework",
+      "originalHash": "sha256:3bdcb4d1008894d807773b28cc8a2c4ff3c933a5ecd296930a2bb1559b867d73",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/subagent-registry.md": {
+      "category": "framework",
+      "originalHash": "sha256:4b89ea68c8fca289a90a232ef86ff0b1b37c096482cbeb2a8450d28f2fb68a86",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/design-system-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:562a9bc395096fef10911c22ff9480824c0aed48cea7e000e9c1db588c5dfb14",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/pull.md": {
+      "category": "framework",
+      "originalHash": "sha256:4d837457b90163de6b0a59ab425855f23e8efd0bf5cd7e945fa7ba4adead65d4",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/python-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:a7f573566bd0d90b4d2d4262c43e3de9c0a0379f07f59f185b73730915c14563",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/operations-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:86ee49c63e881afc18c5a0438d614d3918cb18c468720c9bb4d1f7ab5f37c298",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/issue-creator.md": {
+      "category": "framework",
+      "originalHash": "sha256:78e72f5e3ecb7e8737449c96ae17ac4b5c48bb31ed2a1e2fc929277462a02648",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/plan-mode.md": {
+      "category": "framework",
+      "originalHash": "sha256:7a37581c5005995fc0afa0fb77c1991de3384fa0dd2326610207927d28a6032c",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/hooks.md": {
+      "category": "framework",
+      "originalHash": "sha256:5ffafef4d3861be81760dd5bc7792ec865de37d6e668cde9636e607fd851c95b",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/security-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:1f5ab8b7f01f5dc0342c5c90dcf745f81b8f00858fd0d8283a979ee22e91581b",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/angular-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:ede820cc2fc4f86f11bd2a97e8c03f8a8832944d6e2e33819091f4cb7b5290e9",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/integration-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:c3894b281c5d79473002a9d8d5f81fbfe2909705c65e756415175972a6ebb62d",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/goal-loop.md": {
+      "category": "framework",
+      "originalHash": "sha256:5aacf58ec91fa18ec7b2a19dc511607a57c8a89974fdc864fa13f1e85bc53bca",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/documentation-maintainer.md": {
+      "category": "framework",
+      "originalHash": "sha256:dea9a6b86b2de03a78f1e042649f6a54a1729286ffbea8fb943a9ec61baa281a",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/commit.md": {
+      "category": "framework",
+      "originalHash": "sha256:e137745830577995cfc2a8ff26ed4ffcbd6da49e56065a755b06ce8725765916",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/architecture-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:fc468492fe93b5b4c2d460195a9b379f79b58913db59443ff1c25f54ae1b1310",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/code-developer.md": {
+      "category": "framework",
+      "originalHash": "sha256:a1497671fe07dde01d159919c12f7cdcaaf2a37df5b1ba38ca7736ef5c77180b",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/test-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:37557feb88715946a1d3e11cdaa67ab2395e785b0c13866f7038cc97c798f825",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/java-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:8fe7500823e7b41ee04cc4f0fcb9386aabec2c1b9003e8ce39de09b7cf78fdd3",
+      "status": "unchanged"
+    },
+    ".pi/skills/agents/go-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:7453a53e9ae8d5b91825aab32ed29c8cc6d16bb07610724a5cfd10a3106db745",
+      "status": "unchanged"
+    },
+    ".pi/skills/java-spring-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:9888654973d606ab685ff30a4c29be399c0f3184cd04c1155e0081b5bcf805bf",
+      "status": "unchanged"
+    },
+    ".pi/skills/python-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:cea6f47eb09823f8f4b4c1f6397baa5fadddb3365ff7b1108bd8b59a5eec9e5f",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/security-guards.md": {
+      "category": "framework",
+      "originalHash": "sha256:df4d2135c38aeea2cc781e6acd3fad5caac5ceb226c58dd14a7a0dfae51402b9",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/context-compaction.md": {
+      "category": "framework",
+      "originalHash": "sha256:2f238359167f08f4acee8cc76945a572e1203fb61027b93bcdc722e079591445",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/operations-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:363b53637cf49af6268f59bf53e70bec2e0f81366c9db192e771a1c2fb2bf7cc",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/model-registry.md": {
+      "category": "framework",
+      "originalHash": "sha256:82b1604c59f2b38e7ecb3b9a99ddca40ff2a886f559af2f8b8b2f1d6fa1262c2",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/security-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:34a70bb93cb256f30463519967601ce2f4e44c7dc0284d5f034a7120a79ef4ec",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/integration-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:10d21f097ff8e86312318538cf342ad56a0de18a56ddbeb80c44c98cd1ee00c0",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/system-prompt-tiers.md": {
+      "category": "framework",
+      "originalHash": "sha256:e4977fe1ad0c2ce8248deb136031a3aba59f6fed75f52850fc5e306027277aeb",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/architecture-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:7ef93c32dfffb458b6c1301ebf621bada00f4cf5573f5d030c552327579551bd",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/test-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:3709ea4476727c6e7db56a40dd3be5902140cfaf76ab990cb94b52847d4a92bb",
+      "status": "unchanged"
+    },
+    ".pi/skills/validators/ci-validator.md": {
+      "category": "framework",
+      "originalHash": "sha256:9abee72b24b7322a0130bb91da5ff20d39064cb75abddd25d2c589f442a22839",
+      "status": "unchanged"
+    },
+    ".pi/skills/nextjs-enterprise-codegen.md": {
+      "category": "framework",
+      "originalHash": "sha256:f1041e806a170fdbc391f6543033322cbe4b9baab82ee19b68b53751652a54cc",
+      "status": "unchanged"
+    },
+    ".pi/validators/default.toml": {
+      "category": "framework",
+      "originalHash": "sha256:860fbc421f5761cccb280f8eb657bc7e8bf14131220362631c87d5821d7cfb3f",
+      "status": "unchanged"
+    },
+    ".pi/validators/README.md": {
+      "category": "framework",
+      "originalHash": "sha256:ae67775d2cd23d35a28f8850161f88666fbf5a9bc2b62e91bf3de31d5c3a0ace",
+      "status": "unchanged"
+    },
+    ".pi/validators/spring.toml": {
+      "category": "framework",
+      "originalHash": "sha256:afc0f8b49b5228869f296a7683b1d8a5f6ffc72f366f889a4ab7f5a8a4cc2b1e",
+      "status": "unchanged"
+    },
+    ".pi/preflight_report.json": {
+      "category": "framework",
+      "originalHash": "sha256:caea8f7070c6f3eb9ae81c84881fd3035a8e71ef5c3743a17674b77752c9c7bd",
+      "status": "unchanged"
+    },
+    ".pi/domain/ubiquitous-language.md": {
+      "category": "user",
+      "originalHash": "sha256:b047dbd6d32bfcf6c220c3319642c79b4f97787c67e58ac03c5fc18f57ba62cb",
+      "status": "modified"
+    },
+    ".pi/domain/exploration.md": {
+      "category": "user",
+      "originalHash": "sha256:5b5903b776f7b8b925fb5dd369c4d907da4ed9fbdad14dafbdd7160ead963434",
+      "status": "modified"
+    },
+    ".pi/skills/architecture-coordinator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:9b51f013c381b86743f21a8a77912a41b63b08f514ac54dffd5db7155df398ee",
+      "status": "unchanged"
+    },
+    ".pi/skills/architecture-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:d7146f1905c8aad55991c38a6db836b768c2873f02c50adc165ea768ca5ecaa4",
+      "status": "unchanged"
+    },
+    ".pi/skills/security-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:66786957c9a7bb71053d1feccd8f40a204d95f8e5880d9c0558502d8eb9db218",
+      "status": "unchanged"
+    },
+    ".pi/skills/operations-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:97bc848787b511d9520af53bda47c94e8f372e92d1c8f1ba98c9ccc5598f8b8f",
+      "status": "unchanged"
+    },
+    ".pi/skills/test-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:6b27bb80f518206e9babfabea1f3e521e7f7b4d2fe8e80911c136ade55d7bd18",
+      "status": "unchanged"
+    },
+    ".pi/skills/integration-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:4c91ba7081920d18fab50a9622f73d8f924a96cfe1dd7aeaaf6ff3907953be64",
+      "status": "unchanged"
+    },
+    ".pi/skills/ci-mr-validator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:f69d2745c477c71cca5b45aeeea364ab31c4254972f971d438e8a6690218f216",
+      "status": "unchanged"
+    },
+    ".pi/skills/code-developer/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:f1f8b05e5e86a5c28eb4f7ed5f1d2a0881a5c7c07c3e732745b79cc0b2d308ac",
+      "status": "unchanged"
+    },
+    ".pi/skills/issue-creator/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:b2ced8bf47b2eebbf9d1598f69a119c9cda78bf6001c6aa0bbe341c529a5456d",
+      "status": "unchanged"
+    },
+    ".pi/skills/documentation-maintainer/SKILL.md": {
+      "category": "generated",
+      "originalHash": "sha256:6a27eaf6be7fd2a861857cd6e4ddff20481fbc6ef023a1802c09c5f34ddf67ce",
+      "status": "unchanged"
+    },
+    ".pi/README.md": {
+      "category": "generated",
+      "originalHash": "sha256:46adb3cb48b79ee5e26595b06cdd22992cb3252f643ded3ec7a6f7f8677b0ca1",
+      "status": "unchanged"
+    },
+    "WORKFLOW.md": {
+      "category": "framework",
+      "originalHash": "sha256:9808142326406a2f271bb22491fe4f1355dda06c59c2f5267012b75bbde62d57",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/go/validate-operations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:2b6745a33274d3a271a00e8329988f6a40e736ba7e74d0174d2d176b07872e82",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/go/validate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:b6015897f70de7b5edbe1e153655f4b982704586d4d8fac03927d41ad640967f",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/go/validate-security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:bf5377f544e859f1ad99fc3ee0a5e2c8bdb19dcee611e858b0f6ccac4a6516ec",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/go/validate-canonical.sh": {
+      "category": "framework",
+      "originalHash": "sha256:36c34500a75c020cee85b73fea050d1f0c70353248c24fe2572a3f9cd282f9b7",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/go/validate-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:3614692f8dc60c3a29f03673691a663f6c68e3963a84b963db82c1e114581102",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/go/validate-integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:fe3616e2a6db18b783813c5cb22a021daded3c8fc87a6a3c0d4e030a61a18078",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/go/validate-tests.sh": {
+      "category": "framework",
+      "originalHash": "sha256:7e3285166dcbbabf89d4ded78ef336767c3dd03befc25dc6f1ca50513edc2451",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/python/validate-operations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:7050c2345b7ba2bd34cba6f101f4f2c46412155b70e0c461285240c55c71d10b",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/python/validate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:b6f1c2112ffdaf7a0dc835f105ec27c7aa1cd5abfe646725591bc6e0549f31d4",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/python/validate-security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:74a2f1efa0437de97c8403bfb0e23b12e06f3d2f07d33d59649ce4ec10a6667e",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/python/validate-canonical.sh": {
+      "category": "framework",
+      "originalHash": "sha256:a103e9eabe98aed37b8e52531163212e7dfc15dc554a2be303c4f454d2430b79",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/python/validate-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:8f7c962a462fb26bf1b129caff4135a98e2321d9c7adbf2ff7a5e56aeec2044f",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/python/validate-integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:065c60cfe9aba2d4f5e52bf752f0e1db97e48ffd093758b1a00ebc0958047e7f",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/python/validate-tests.sh": {
+      "category": "framework",
+      "originalHash": "sha256:0fc7350224acdea5566f5387e007cdd5d619364ad72ac4df82813273fd57fc0b",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/typescript/validate-operations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:61c6c9f26dc06e7027685807c3eba18c0ee6527e69a070fd1ef8cc08f1ca0c92",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/typescript/validate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:27fda438aea3c16685e5630ab8fcbefe9f35a2c41ab010ef9ec26769c46f572f",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/typescript/validate-security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:c2cf065a5e0e9b21b75ada456ddc18c4906cffe821b45259c0ec1f9db12e09c0",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/typescript/validate-canonical.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ead8ae65e342b653fb52197af44cc22a14cf96b355213da31a8606ba186505c6",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/typescript/validate-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ec99934d26634007bedc917c4653cdcbc7091f24d45cb8eb634252ff92e3aa68",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/typescript/validate-integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ea04b21a89fa59c3b15a3e1988a8341a5cb2b965d0ebf11fe6afd19cc5818676",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/typescript/validate-tests.sh": {
+      "category": "framework",
+      "originalHash": "sha256:0766f2a81e347933eb5165a52f85c6ef187f295a870bb62b14de23d928757a3c",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-operations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:85ba34bd70b8bb363f434ff8135bd88eebfa09860f90fd6e98faa2bcacd99d16",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:860df0ab3d3405c665775ff330d3ccc42b04532d9e3e52e8381f6a251ef0d043",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-spring-architecture.sh": {
+      "category": "framework",
+      "originalHash": "sha256:69e356050605afb3462b0c06062a343febad22f1cd8d9d00f08690b6622ad66d",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-annotations.sh": {
+      "category": "framework",
+      "originalHash": "sha256:d41f71ecd7bc7bedb32cbc2710b7404d4cdc34d049953a48a2cba293a58fed74",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-security.sh": {
+      "category": "framework",
+      "originalHash": "sha256:096d0110bb1e6a41270b6a1b6fbab4754d5545ee399b0c0dc2ceda8e36556883",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-canonical.sh": {
+      "category": "framework",
+      "originalHash": "sha256:2305270475030599a2b8e27166f0e6c0f5025b396bf237afcaa3175ad5ec1bcc",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-ci.sh": {
+      "category": "framework",
+      "originalHash": "sha256:fae27bc8b709c88e3d64b6367f9e4604334770d59b4b9e741e06608d08891b12",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-integration.sh": {
+      "category": "framework",
+      "originalHash": "sha256:ff677d9afbc2ba1503d5bbf935a5a96d77930b8ea85e463e175d46680e188ba3",
+      "status": "unchanged"
+    },
+    ".pi/scripts/languages/java/validate-tests.sh": {
+      "category": "framework",
+      "originalHash": "sha256:e98017ceb722bd3aa6a283000af07d30ed074051e96dbaa76e1081f69274244b",
+      "status": "unchanged"
+    },
+    ".pi/extensions/architect-lib/tdd-generator.ts": {
+      "category": "framework",
+      "originalHash": "sha256:c61cd989f5b4ed7db8405917819b8e40503612c619a9de4c38f17eb592754044",
+      "status": "unchanged"
+    }
+  },
+  "exports": {},
+  "templateContext": {
+    "projectName": "rigorix-oss",
+    "projectVersion": "0.1.0",
+    "language": "rust",
+    "repository": "arman-jalili/rigorix-oss",
+    "repoTool": "gh",
+    "groupId": "com.rigorix-oss",
+    "buildCommand": "cargo build",
+    "testCommand": "cargo test --all",
+    "lintCommand": "cargo clippy -- -D warnings",
+    "formatCommand": "cargo fmt",
+    "formatCheckCommand": "cargo fmt --check",
+    "securityAuditCommand": "cargo audit",
+    "errorHandlingPattern": "Result<T, E> pattern",
+    "tracingPattern": "tracing crate with structured spans",
+    "cancellationPattern": "CancellationToken pattern",
+    "atomicWritePattern": "tempfile + rename pattern",
+    "keyFile1": "src/index.ts",
+    "keyFile1Purpose": "Main entry point",
+    "keyFile2": "src/lib/core.ts",
+    "keyFile2Purpose": "Core library functions",
+    "domainDescription": "mcp server for rigorix cli"
+  },
+  "scaffoldedAt": "2026-07-12T07:44:41.001Z",
+  "lastUpdatedAt": "2026-07-17T21:12:00.501Z"
+}


### PR DESCRIPTION
Reversal of an over-broad catch in #774.

guardian-manifest.json (root + engine/mcp/cli/actions) is a **declarative
scaffold manifest** — framework config (source, tools, language, validators,
workflows, groupId) plus a per-file originalHash ledger tracking drift of
scaffolded `.pi/context/*.md`. It is a scaffold lockfile (reproducibility +
drift audit), NOT runtime state like `.guardian-pipeline-state.json`.

- Re-tracks the 5 manifest files (restored from the pre-#774 commit)
- Removes `guardian-manifest.json` + `**/guardian-manifest.json` from
  .gitignore
- Keeps `.guardian-*.json` pipeline/epic state ignored (genuine runtime
  state — current pipeline position, rewritten per run)