### PR TITLE
[Issue #789] Implement ApprovalRecord — approval

### DIFF
--- a/engine/src/approval/domain/record.rs
+++ b/engine/src/approval/domain/record.rs
@@ -29,6 +29,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use super::error::ApprovalError;
 use super::hash::IntentHash;
 
 /// Lifecycle of a single-use approval record.
@@ -101,4 +102,96 @@ pub struct ApprovalRecord {
     pub status: ApprovalStatus,
     /// What the human was shown (R4).
     pub decision_context: DecisionContext,
+}
+
+impl ApprovalRecord {
+    /// Whether the approval is still pending (may be verified and dispatched).
+    pub fn is_pending(&self) -> bool {
+        matches!(self.status, ApprovalStatus::Pending)
+    }
+
+    /// Whether the approval has lapsed at (or before) the given instant.
+    ///
+    /// TTL is enforced at verification time — an expired approval never
+    /// dispatches. Non-expiring decisions are expressed with a far-future
+    /// `expires_at`; the comparison is inclusive (`now >= expires_at`).
+    pub fn is_expired_at(&self, at: DateTime<Utc>) -> bool {
+        at >= self.expires_at
+    }
+
+    /// Enforce the TTL at verification time.
+    ///
+    /// When `now` is at/past `expires_at` the record is transitioned to
+    /// `Expired` and `ApprovalError::Expired` is returned — the caller must
+    /// not dispatch. No-op for records that already left `Pending`.
+    pub fn enforce_ttl(&mut self, now: DateTime<Utc>) -> Result<(), ApprovalError> {
+        if !matches!(self.status, ApprovalStatus::Pending) {
+            return Ok(());
+        }
+        if now >= self.expires_at {
+            self.status = ApprovalStatus::Expired;
+            return Err(ApprovalError::Expired(self.node_id));
+        }
+        Ok(())
+    }
+
+    /// R3 single-use — consume the approval on **terminal outcome** (success,
+    /// skipped, or exhausted failure after ≥1 dispatch).
+    ///
+    /// Failed attempts do NOT consume — a legitimate retry re-verifies the
+    /// same intent while the record stays `Pending`. A non-terminal
+    /// interruption keeps `Pending` so a resumed run can verify and continue.
+    ///
+    /// # Errors
+    /// - `ApprovalError::Expired` — the approval lapsed before dispatch
+    /// - `ApprovalError::AlreadyConsumed` — replay of a consumed approval
+    /// - `ApprovalError::InvalidState` — record was superseded
+    pub fn consume(&mut self) -> Result<(), ApprovalError> {
+        match self.status {
+            ApprovalStatus::Pending => {
+                self.status = ApprovalStatus::Consumed;
+                Ok(())
+            }
+            ApprovalStatus::Consumed => Err(ApprovalError::AlreadyConsumed(self.node_id)),
+            ApprovalStatus::Expired => Err(ApprovalError::Expired(self.node_id)),
+            ApprovalStatus::Superseded => Err(ApprovalError::InvalidState(
+                "cannot consume a superseded approval".into(),
+            )),
+        }
+    }
+
+    /// Transition a pending approval to `Expired` (e.g. TTL sweep).
+    pub fn expire(&mut self) -> Result<(), ApprovalError> {
+        match self.status {
+            ApprovalStatus::Pending => {
+                self.status = ApprovalStatus::Expired;
+                Ok(())
+            }
+            ApprovalStatus::Consumed => Err(ApprovalError::AlreadyConsumed(self.node_id)),
+            ApprovalStatus::Expired => Err(ApprovalError::InvalidState(
+                "approval already expired".into(),
+            )),
+            ApprovalStatus::Superseded => Err(ApprovalError::InvalidState(
+                "cannot expire a superseded approval".into(),
+            )),
+        }
+    }
+
+    /// Invalidate a pending approval because it no longer authorizes:
+    /// (a) a re-plan replaced the sealed graph for a paused run, (b) a newer
+    /// approval for the same node replaced this one, or (c) the run was
+    /// cancelled and re-executed with the same dag_id.
+    pub fn supersede(&mut self) -> Result<(), ApprovalError> {
+        match self.status {
+            ApprovalStatus::Pending => {
+                self.status = ApprovalStatus::Superseded;
+                Ok(())
+            }
+            ApprovalStatus::Consumed => Err(ApprovalError::AlreadyConsumed(self.node_id)),
+            ApprovalStatus::Expired => Err(ApprovalError::Expired(self.node_id)),
+            ApprovalStatus::Superseded => Err(ApprovalError::InvalidState(
+                "approval already superseded".into(),
+            )),
+        }
+    }
 }

--- a/engine/tests/unit/approval/approvalrecord/approvalrecord_test.rs
+++ b/engine/tests/unit/approval/approvalrecord/approvalrecord_test.rs
@@ -61,3 +61,71 @@ fn test_approval_status_variants_are_frozen() {
         ApprovalStatus::Superseded
     ));
 }
+
+// ── #789 behavior: status transitions ────────────────────────────────────────
+
+#[test]
+fn test_consume_transitions_pending_to_consumed() {
+    let mut record = sample_record();
+    assert!(record.consume().is_ok());
+    assert_eq!(record.status, ApprovalStatus::Consumed);
+}
+
+#[test]
+fn test_consumed_record_cannot_be_replayed() {
+    // Single-use semantics: a second consume is rejected (replay guard).
+    let mut record = sample_record();
+    record.consume().unwrap();
+    let err = record.consume().unwrap_err();
+    assert!(matches!(
+        err,
+        rigorix_engine::approval::domain::ApprovalError::AlreadyConsumed(_)
+    ));
+    // A consumed approval must never transition to another terminal state.
+    assert!(record.supersede().is_err());
+}
+
+#[test]
+fn test_expire_transitions_pending_to_expired() {
+    let mut record = sample_record();
+    assert!(record.expire().is_ok());
+    assert_eq!(record.status, ApprovalStatus::Expired);
+    // Expired approvals never dispatch — a consume attempt fails with Expired.
+    let err = record.consume().unwrap_err();
+    assert!(matches!(
+        err,
+        rigorix_engine::approval::domain::ApprovalError::Expired(_)
+    ));
+}
+
+#[test]
+fn test_supersede_transitions_pending_to_superseded() {
+    // Re-plan / newer approval / cancelled-and-re-executed run → superseded.
+    let mut record = sample_record();
+    assert!(record.supersede().is_ok());
+    assert_eq!(record.status, ApprovalStatus::Superseded);
+    assert!(record.consume().is_err());
+}
+
+#[test]
+fn test_expired_after_ttl_never_dispatches() {
+    let mut record = sample_record();
+    let past = record.expires_at + Duration::seconds(1);
+    assert!(record.is_expired_at(past));
+    // Enforced at verification: TTL lapse → Expired, no dispatch.
+    assert!(record.enforce_ttl(past).is_err());
+    assert_eq!(record.status, ApprovalStatus::Expired);
+    let before = record.decided_at + Duration::seconds(1);
+    let fresh = sample_record();
+    assert!(!fresh.is_expired_at(before));
+}
+
+#[test]
+fn test_non_terminal_interruption_keeps_pending() {
+    // Cross-process resume: a paused run never consumed the approval, so a
+    // resumed run can verify and continue.
+    let record = sample_record();
+    assert_eq!(record.status, ApprovalStatus::Pending);
+    // Pausing is not a terminal outcome — nothing to consume yet.
+    assert!(record.is_pending());
+}


### PR DESCRIPTION
## Issue Closeout

Closes #789

### Summary
Implement `ApprovalRecord` lifecycle behavior (#789): single-use status
transitions (`Pending → Consumed | Expired | Superseded`), replay rejection,
and TTL enforcement at verification time.

### Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Serde round-trip preserves all fields; status transitions valid (Pending → Consumed/Expired/Superseded) | ✅ | `cargo test --test unit -- approvalrecord` — 9/9 pass (round-trip, consume/expire/supersede transitions, replay guard, TTL, pending-preserved-on-interruption) |

### Validator Results

| Validator | Status | Details |
|-----------|--------|---------|
| CI | ✅ PASSED | cargo check + clippy -D warnings (0) + fmt |
| Test | ✅ PASSED | 9 approvalrecord unit tests pass |
| Canonical | ✅ PASSED | @canonical refs retained |
| Architecture | ✅ PASSED | validate-architecture.sh 6/0 |

### Files Changed
- `engine/src/approval/domain/record.rs` — consume/expire/supersede/enforce_ttl
- `engine/tests/unit/approval/approvalrecord/approvalrecord_test.rs` — behavior tests

Refs: #785 (epic), canonical `.pi/architecture/modules/approval.md#approvalrecord`
