### PR TITLE
[Issue #790] Implement DecisionContext — approval

### DIFF
--- a/engine/src/approval/domain/record.rs
+++ b/engine/src/approval/domain/record.rs
@@ -75,6 +75,53 @@ pub struct DecisionContext {
     pub full_payload: Option<serde_json::Value>,
 }
 
+impl DecisionContext {
+    /// Recursively redact values under sensitive field names.
+    ///
+    /// Reuses the observability `span_privacy` classification (`api_key`,
+    /// `token`, `secret`, `password`, `authorization`, …) — one redaction
+    /// policy across traces and approval summaries. The value under a
+    /// sensitive key is replaced with `"<redacted>"` at any nesting depth.
+    pub fn redact_value(value: &serde_json::Value) -> serde_json::Value {
+        match value {
+            serde_json::Value::Object(map) => {
+                let mut out = serde_json::Map::with_capacity(map.len());
+                for (key, val) in map {
+                    if crate::observability::span_privacy::is_sensitive_field(key) {
+                        out.insert(key.clone(), serde_json::Value::String("<redacted>".into()));
+                    } else {
+                        out.insert(key.clone(), Self::redact_value(val));
+                    }
+                }
+                serde_json::Value::Object(out)
+            }
+            serde_json::Value::Array(items) => {
+                serde_json::Value::Array(items.iter().map(Self::redact_value).collect())
+            }
+            other => other.clone(),
+        }
+    }
+
+    /// Build the envelope-safe summary deterministically.
+    ///
+    /// The summary is `rendered_step` plus the compact, **redacted** evidence
+    /// and state snapshot (when present). The opt-in `full_payload` is never
+    /// included — what leaves the local store is safe by construction.
+    pub fn summarize(&self) -> String {
+        let mut parts = Vec::new();
+        parts.push(self.rendered_step.clone());
+        if let Some(evidence) = &self.upstream_evidence {
+            let redacted = Self::redact_value(evidence);
+            parts.push(serde_json::to_string(&redacted).unwrap_or_else(|_| "<evidence>".into()));
+        }
+        if let Some(snapshot) = &self.state_snapshot {
+            let redacted = Self::redact_value(snapshot);
+            parts.push(serde_json::to_string(&redacted).unwrap_or_else(|_| "<snapshot>".into()));
+        }
+        parts.join(" | ")
+    }
+}
+
 /// The durable record of a human decision, bound to an execution intent.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ApprovalRecord {

--- a/engine/tests/unit/approval/decisioncontext/decisioncontext_test.rs
+++ b/engine/tests/unit/approval/decisioncontext/decisioncontext_test.rs
@@ -48,3 +48,72 @@ fn test_decisioncontext_serde_round_trip() {
     let decoded: DecisionContext = serde_json::from_str(&encoded).expect("deserialize");
     assert_eq!(decoded, ctx);
 }
+
+// ── #790 behavior: envelope-safe summary + SpanPrivacy redaction ────────────
+
+#[test]
+fn test_summary_redacts_api_key_using_span_privacy() {
+    // AC #14: an api_key inside decision_context must be redacted in the summary.
+    let ctx = DecisionContext {
+        rendered_step: "call openai".to_string(),
+        upstream_evidence: Some(json!({
+            "api_key": "sk-0123456789abcdef",
+            "model": "gpt-4",
+            "nested": {"secret": "hunter2", "ok": "visible"}
+        })),
+        state_snapshot: Some(json!({"git": "abc123"})),
+        summary: String::new(), // will be derived
+        full_payload: None,
+    };
+    let summary = ctx.summarize();
+    assert!(
+        !summary.contains("sk-0123456789abcdef"),
+        "raw api_key leaked: {summary}"
+    );
+    assert!(!summary.contains("hunter2"), "raw secret leaked: {summary}");
+    assert!(
+        summary.contains("<redacted>"),
+        "summary must mark redaction"
+    );
+    assert!(summary.contains("visible"), "non-sensitive fields survive");
+    assert!(summary.contains("gpt-4"));
+}
+
+#[test]
+fn test_summarize_excludes_full_payload_by_default() {
+    // AC #13: full payload is opt-in — the summary never embeds it.
+    let ctx = DecisionContext {
+        rendered_step: "deploy".to_string(),
+        upstream_evidence: None,
+        state_snapshot: None,
+        summary: String::new(),
+        full_payload: Some(json!({"very": "long", "private": {"api_key": "x"}})),
+    };
+    let summary = ctx.summarize();
+    assert!(!summary.contains("very"));
+    assert!(!summary.contains("private"));
+    assert!(summary.contains("deploy"));
+}
+
+#[test]
+fn test_summarize_is_deterministic_and_redaction_util_reused() {
+    let ctx = DecisionContext {
+        rendered_step: "run tests".to_string(),
+        upstream_evidence: Some(json!({"results": {"passed": 3}, "api_token": "tok-1"})),
+        state_snapshot: Some(json!({"branch": "main"})),
+        summary: String::new(),
+        full_payload: None,
+    };
+    let s1 = ctx.summarize();
+    let s2 = ctx.summarize();
+    assert_eq!(s1, s2, "summarize must be deterministic");
+    assert!(!s1.contains("tok-1"));
+
+    // The redaction helper is the same span_privacy classification used by
+    // observability — reuse, not a parallel implementation.
+    let redacted =
+        DecisionContext::redact_value(&json!({"authorization": "Bearer x", "user": "u"}));
+    assert_eq!(redacted["authorization"], json!("<redacted>"));
+    assert_eq!(redacted["user"], json!("u"));
+    assert!(rigorix_engine::observability::span_privacy::is_sensitive_field("api_key"));
+}


### PR DESCRIPTION
## Issue Closeout

Closes #790

### Summary
Implement `DecisionContext` (#790): envelope-safe deterministic `summarize()`
and recursive `redact_value()` reusing the observability `span_privacy` field
classification.

### Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| approve with decision_context → envelope contains context ref + summary; full payload opt-in | ✅ (unit groundwork; service integration tracked in #792) | `summarize()` never embeds `full_payload`; summary deterministic (tested) |
| api_key inside decision_context → redacted in summary (SpanPrivacy reuse) | ✅ | `redact_value()` reuses `observability::span_privacy::is_sensitive_field` — api_key/secret/authorization redacted at any depth, non-sensitive fields preserved (unit tested) |

### Validator Results

| Validator | Status | Details |
|-----------|--------|---------|
| CI | ✅ PASSED | cargo check + clippy -D warnings (0) + fmt |
| Test | ✅ PASSED | 6 decisioncontext unit tests pass |
| Canonical | ✅ PASSED | @canonical refs retained |
| Architecture | ✅ PASSED | validate-architecture.sh 6/0 |

### Files Changed
- `engine/src/approval/domain/record.rs` — DecisionContext summarize/redact_value
- `engine/tests/unit/approval/decisioncontext/decisioncontext_test.rs` — behavior tests

Refs: #785 (epic), canonical `.pi/architecture/modules/approval.md#decisioncontext`
