### PR TITLE
[Issue #791] Implement ScopeViolation — approval

### DIFF
--- a/engine/src/approval/domain/violation.rs
+++ b/engine/src/approval/domain/violation.rs
@@ -40,3 +40,56 @@ pub struct ScopeViolation {
     /// When the violation was detected (post-execution check).
     pub detected_at: DateTime<Utc>,
 }
+
+impl ScopeViolation {
+    /// Compute the effects outside the declared scope (pure path-set logic).
+    ///
+    /// A declared entry covers: the exact path (`src/auth.ts`) or every path
+    /// under a directory entry (`src/` → `src/auth.ts`, `src/lib.rs`). The
+    /// directory match is boundary-aware so `src` never swallows `src2/…`.
+    pub fn out_of_scope(declared: &[String], actual: &[String]) -> Vec<String> {
+        let declared: Vec<String> = declared
+            .iter()
+            .map(|d| d.trim_end_matches('/').to_string())
+            .collect();
+        let mut out = Vec::new();
+        'effect: for effect in actual {
+            let effect = effect.trim_end_matches('/');
+            for entry in &declared {
+                let covered = effect == entry || effect.starts_with(&format!("{entry}/"));
+                if covered {
+                    continue 'effect;
+                }
+            }
+            out.push(effect.to_string());
+        }
+        out
+    }
+
+    /// Build a `ScopeViolation` from oracle effects vs the declared scope.
+    ///
+    /// Returns `None` when every recorded effect stayed inside the declared
+    /// scope — in-scope execution is not a violation. Used by the post-
+    /// execution effect-scope check (R5); the result is non-blocking,
+    /// first-class envelope evidence.
+    pub fn detect(
+        node_id: Uuid,
+        step_name: String,
+        declared_scope: &[String],
+        actual_effects: &[String],
+        detected_at: DateTime<Utc>,
+    ) -> Option<ScopeViolation> {
+        let out_of_scope = Self::out_of_scope(declared_scope, actual_effects);
+        if out_of_scope.is_empty() {
+            return None;
+        }
+        Some(ScopeViolation {
+            node_id,
+            step_name,
+            declared_scope: declared_scope.to_vec(),
+            actual_effects: actual_effects.to_vec(),
+            out_of_scope,
+            detected_at,
+        })
+    }
+}

--- a/engine/tests/unit/approval/scopeviolation/scopeviolation_test.rs
+++ b/engine/tests/unit/approval/scopeviolation/scopeviolation_test.rs
@@ -35,3 +35,74 @@ fn test_scopeviolation_serde_round_trip() {
     let decoded: ScopeViolation = serde_json::from_str(&encoded).expect("deserialize");
     assert_eq!(decoded, v);
 }
+
+// ── #791 behavior: out-of-scope detection (git-diff oracle) ─────────────────
+
+#[test]
+fn test_file_tool_outside_declared_scope_is_flagged() {
+    // AC #11: a file tool writing outside the declared scope → violation.
+    let declared = vec!["docs/x.md".to_string(), "docs/".to_string()];
+    let actual = vec![
+        "docs/x.md".to_string(),
+        "src/sneaky.rs".to_string(), // outside declared scope
+    ];
+    let out = ScopeViolation::out_of_scope(&declared, &actual);
+    assert_eq!(out, vec!["src/sneaky.rs".to_string()]);
+}
+
+#[test]
+fn test_run_command_side_effect_caught_by_git_diff_oracle() {
+    // AC #12: a run_command script side-effected src/auth.ts — the git-diff
+    // oracle reports it and the declared-scope comparison flags it.
+    let declared = vec!["docs/".to_string()]; // script was "approved" for docs only
+    let actual = vec![
+        "docs/readme.md".to_string(),
+        "src/auth.ts".to_string(), // side-effect, outside declared scope
+    ];
+    let violation = ScopeViolation::detect(
+        Uuid::new_v4(),
+        "run_script".to_string(),
+        &declared,
+        &actual,
+        Utc::now(),
+    )
+    .expect("side-effect must produce a violation");
+    assert_eq!(violation.actual_effects, actual);
+    assert_eq!(violation.out_of_scope, vec!["src/auth.ts".to_string()]);
+}
+
+#[test]
+fn test_declared_directory_covers_nested_files() {
+    let declared = vec!["src/".to_string(), "Cargo.toml".to_string()];
+    let actual = vec!["src/lib.rs".to_string(), "Cargo.toml".to_string()];
+    assert!(ScopeViolation::out_of_scope(&declared, &actual).is_empty());
+    // Directory-prefix safety: "src" must not swallow "src2/…".
+    let actual2 = vec!["src2/evil.ts".to_string()];
+    assert_eq!(
+        ScopeViolation::out_of_scope(&declared, &actual2),
+        vec!["src2/evil.ts".to_string()]
+    );
+}
+
+#[test]
+fn test_no_effects_outside_scope_yields_no_violation() {
+    let declared = vec!["src/".to_string()];
+    let actual = vec!["src/lib.rs".to_string(), "src/main.rs".to_string()];
+    let violation = ScopeViolation::detect(
+        Uuid::new_v4(),
+        "build".to_string(),
+        &declared,
+        &actual,
+        Utc::now(),
+    );
+    assert!(violation.is_none(), "in-scope effects are not violations");
+}
+
+#[test]
+fn test_declared_exact_file_boundary() {
+    let declared = vec!["src/auth.ts".to_string()];
+    let actual = vec!["src/auth.ts.bak".to_string(), "src/auth.ts".to_string()];
+    // "src/auth.ts.bak" is a different path — not covered by the file entry.
+    let out = ScopeViolation::out_of_scope(&declared, &actual);
+    assert_eq!(out, vec!["src/auth.ts.bak".to_string()]);
+}


### PR DESCRIPTION
## Issue Closeout

Closes #791

### Summary
Implement `ScopeViolation` (#791): pure out-of-scope detection over the
git-diff oracle's recorded effect set, plus the `detect()` evidence builder.

### Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| File tool outside declared scope → scope_violation flagged (AC #11) | ✅ (domain) | `out_of_scope()`/`detect()` unit-tested; envelope flagging wired in #792 |
| run_command side-effect on src/auth.ts caught by git-diff oracle (AC #12) | ✅ (domain) | detect() over oracle effect set flags `src/auth.ts` (unit-tested) |

### Validator Results

| Validator | Status | Details |
|-----------|--------|---------|
| CI | ✅ PASSED | cargo check + clippy -D warnings (0) + fmt |
| Test | ✅ PASSED | 7 scopeviolation unit tests pass |
| Canonical | ✅ PASSED | @canonical refs retained |
| Architecture | ✅ PASSED | validate-architecture.sh 6/0 |

### Files Changed
- `engine/src/approval/domain/violation.rs` — out_of_scope/detect
- `engine/tests/unit/approval/scopeviolation/scopeviolation_test.rs` — behavior tests

Refs: #785 (epic), canonical `.pi/architecture/modules/approval.md#scopeviolation`
