### PR TITLE
[Issue #793] Implement ApproveInput / ApproveOutput — approval

### DIFF
--- a/engine/src/approval/application/dto/mod.rs
+++ b/engine/src/approval/application/dto/mod.rs
@@ -21,7 +21,7 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::approval::domain::{ApprovalRecord, DecisionContext};
+use crate::approval::domain::{ApprovalError, ApprovalRecord, DecisionContext};
 
 /// Input for approving a set of steps of a DAG.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -55,4 +55,58 @@ pub struct ApproveOutput {
     pub still_pending: Vec<String>,
     /// The persisted single-use records (one per approved node).
     pub approval_records: Vec<ApprovalRecord>,
+}
+
+impl ApproveInput {
+    /// Validate the boundary input.
+    ///
+    /// # Contract
+    /// - `approver_id` is required (identity is a captured fact, R3)
+    /// - at least one `step_name` must be present
+    ///
+    /// # Errors
+    /// - `ApprovalError::InvalidState` — missing approver or empty step set
+    pub fn validate(&self) -> Result<(), ApprovalError> {
+        if self.approver_id.trim().is_empty() {
+            return Err(ApprovalError::InvalidState(
+                "approve requires an approver_id (identity is a captured fact)".into(),
+            ));
+        }
+        if self.step_names.is_empty() {
+            return Err(ApprovalError::InvalidState(
+                "approve requires at least one step_name".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// De-duplicate step names preserving first-occurrence order.
+    pub fn dedup_step_names(&self) -> Vec<String> {
+        let mut seen = std::collections::HashSet::new();
+        let mut out = Vec::with_capacity(self.step_names.len());
+        for name in &self.step_names {
+            if seen.insert(name.clone()) {
+                out.push(name.clone());
+            }
+        }
+        out
+    }
+}
+
+impl ApproveOutput {
+    /// Whether every requested/known step was approved (nothing pending or
+    /// missing).
+    pub fn is_fully_approved(&self) -> bool {
+        self.not_found.is_empty() && self.still_pending.is_empty() && !self.approved.is_empty()
+    }
+
+    /// Number of approved steps.
+    pub fn approval_count(&self) -> usize {
+        self.approved.len()
+    }
+
+    /// Number of steps still awaiting approval.
+    pub fn pending_count(&self) -> usize {
+        self.still_pending.len()
+    }
 }

--- a/engine/tests/unit/approval/approveinput-approveoutput/approveinput-approveoutput_test.rs
+++ b/engine/tests/unit/approval/approveinput-approveoutput/approveinput-approveoutput_test.rs
@@ -81,3 +81,52 @@ fn test_approveoutput_serde_round_trip() {
     let decoded: ApproveOutput = serde_json::from_str(&encoded).expect("deserialize");
     assert_eq!(decoded, output);
 }
+
+// ── #793 behavior: boundary validation ───────────────────────────────────────
+
+#[test]
+fn test_approveinput_requires_approver_and_steps() {
+    use rigorix_engine::approval::domain::ApprovalError;
+
+    // Missing approver → rejected at the boundary.
+    let mut no_approver = sample_input();
+    no_approver.approver_id.clear();
+    assert!(matches!(
+        no_approver.validate(),
+        Err(ApprovalError::InvalidState(_))
+    ));
+
+    // No steps → rejected.
+    let mut no_steps = sample_input();
+    no_steps.step_names.clear();
+    assert!(matches!(
+        no_steps.validate(),
+        Err(ApprovalError::InvalidState(_))
+    ));
+
+    // Valid input passes.
+    assert!(sample_input().validate().is_ok());
+}
+
+#[test]
+fn test_approveinput_dedupes_and_preserves_order() {
+    let mut input = sample_input();
+    input.step_names = vec!["a".into(), "b".into(), "a".into(), "c".into()];
+    let deduped = input.dedup_step_names();
+    assert_eq!(
+        deduped,
+        vec!["a".to_string(), "b".to_string(), "c".to_string()]
+    );
+}
+
+#[test]
+fn test_approveoutput_aggregate_helpers() {
+    let mut out = sample_output();
+    assert!(out.is_fully_approved());
+    assert_eq!(out.approval_count(), 1);
+
+    out.approved.clear();
+    out.still_pending.push("deploy".into());
+    assert!(!out.is_fully_approved());
+    assert_eq!(out.pending_count(), 1);
+}


### PR DESCRIPTION
## Issue Closeout

Closes #793

### Summary
Implement `ApproveInput` / `ApproveOutput` boundary behavior (#793) on top of
the frozen DTO schemas: input validation (required approver + non-empty step
set), de-duplication, and output aggregate helpers for TUI/MCP surfaces.

### Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| DTO schemas defined with documented field names/types (contract freeze) | ✅ | frozen in #798; serde round-trips preserved |
| Boundary validation + aggregate behavior | ✅ | 6 unit tests pass (validate/dedupe/is_fully_approved/counts) |

### Validator Results

| Validator | Status | Details |
|-----------|--------|---------|
| CI | ✅ PASSED | cargo check + clippy -D warnings (0) + fmt |
| Test | ✅ PASSED | 6 dto unit tests pass |
| Canonical | ✅ PASSED | @canonical refs retained |
| Architecture | ✅ PASSED | validate-architecture.sh 6/0 |

### Files Changed
- `engine/src/approval/application/dto/mod.rs` — impl blocks
- `engine/tests/unit/approval/approveinput-approveoutput/approveinput-approveoutput_test.rs`

Refs: #785 (epic), canonical `.pi/architecture/modules/approval.md#approveinput-approveoutput`
