### PR TITLE
[Issue #794] Implement ApprovalError — approval

### DIFF
--- a/engine/tests/unit/approval/approvalerror/approvalerror_test.rs
+++ b/engine/tests/unit/approval/approvalerror/approvalerror_test.rs
@@ -54,3 +54,32 @@ fn test_approvalerror_implements_std_error() {
     fn assert_error<E: std::error::Error>() {}
     assert_error::<ApprovalError>();
 }
+
+#[test]
+fn test_approvalerror_source_is_none() {
+    // ApprovalError is a leaf error type — every variant has no source chain.
+    use std::error::Error;
+    let err: Box<dyn Error> = Box::new(ApprovalError::NotFound(Uuid::nil()));
+    assert!(err.source().is_none());
+    let err: Box<dyn Error> = Box::new(ApprovalError::IntentMismatch {
+        node_id: Uuid::nil(),
+        expected: "e".into(),
+        actual: "a".into(),
+    });
+    assert!(err.source().is_none());
+}
+
+#[test]
+fn test_approvalerror_mismatch_message_is_frozen_contract() {
+    // The Display message is part of the frozen error contract (ADR-011 /
+    // audit trails) — it must not drift.
+    let err = ApprovalError::IntentMismatch {
+        node_id: Uuid::nil(),
+        expected: "abc".into(),
+        actual: "def".into(),
+    };
+    assert_eq!(
+        err.to_string(),
+        "Intent verification failed for node 00000000-0000-0000-0000-000000000000: expected abc, got def"
+    );
+}


### PR DESCRIPTION
## Issue Closeout

Closes #794

### Summary
Close the `ApprovalError` acceptance item (#794). The full error contract —
all 7 variants, `thiserror` Display messages, and `is_retriable()` with
`IntentMismatch` non-retriable — was implemented and tested at contract freeze
(#798). This issue adds frozen-message and leaf-error (`source() == None`)
assertions to lock AC #15 against drift.

### Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| All variants, Display, is_retriable() (IntentMismatch → non-retriable) (AC #15) | ✅ | inline + unit tests: all variants Display non-empty; classification (IntentMismatch/NotFound/AlreadyConsumed/Expired/InvalidState non-retriable, ScopeVerificationUnavailable/Internal retriable); frozen mismatch message; std::error::Error + source()==None |

### Validator Results

| Validator | Status | Details |
|-----------|--------|---------|
| CI | ✅ PASSED | cargo check + clippy -D warnings (0) + fmt |
| Test | ✅ PASSED | 5 approvalerror unit tests pass |
| Canonical | ✅ PASSED | @canonical refs retained |
| Architecture | ✅ PASSED | validate-architecture.sh 6/0 |

### Files Changed
- `engine/tests/unit/approval/approvalerror/approvalerror_test.rs`

Refs: #785 (epic), canonical `.pi/architecture/modules/approval.md#error-handling`
