### PR TITLE
feat(execution-engine): ADR-011 dispatch wiring — ApprovalService at the choke point (opt-in)

### DIFF
--- a/engine/.pi/architecture/CHANGELOG.md
+++ b/engine/.pi/architecture/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Architecture Change Log
 
+---
+
+## [2026-09-02] — Approval dispatch wiring (ADR-011 acceptance slice, opt-in)
+
+### Added
+- Execution engine now optionally carries an approval binding
+  (`ParallelExecutionServiceImpl::with_approval_service`):
+  - `approve_node` persists a single-use `ApprovalRecord` (identity captured
+    via new optional `ApproveNodeInput.approver_id` / `authority` /
+    `decision_context` / `token_claims_ref` fields) before releasing the node
+  - `run_dispatch_loop` (shared by execute + resume) verifies the recorded
+    intent at the dispatch choke point: `Matched` → dispatch;
+    `Mismatched` / `Invalid` / missing record → HALT into
+    `NodeStatus::IntentMismatch` (tool never called, re-approval required)
+  - single-use records are consumed once on terminal outcome
+- `NodeStatus::IntentMismatch` state + persistence mapping (coarse view:
+  InProgress); still_pending/pending-approval views include it
+- Integration tests: bound approve→verify→dispatch→consume; cross-process
+  tampered-intent resume halts before dispatch and re-approval recovers
+- Default-off: no binding ⇒ legacy `session.approved` gate unchanged
+  (1943 lib tests + 58 approval unit tests green; clippy clean)
+- Remaining ADR-011 surface (deferred): envelope `ApprovalRecorded` events,
+  git-diff effect-scope oracle, identity/token claims at the MCP layer —
+  ADR-011 stays Proposed until those land
+
+# Architecture Change Log
+
 <!--
 Canonical Reference: .pi/architecture/CHANGELOG.md
 Blueprint Source: Guardian Framework v1.2

--- a/engine/src/execution_engine/application/dto/mod.rs
+++ b/engine/src/execution_engine/application/dto/mod.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use uuid::Uuid;
 
+use crate::approval::domain::DecisionContext;
 use crate::execution_engine::domain::{
     ExecutionResult, NodeExecutionState, NodeStatus, ParallelExecutorConfig, RetryDecision,
     RetryPolicy, TaskResult,
@@ -69,6 +70,26 @@ pub struct ApproveNodeInput {
     pub dag_id: Uuid,
     /// Step (node) names to approve.
     pub step_names: Vec<String>,
+
+    // ── ADR-011 approval binding (optional, engine-side) ───────────────────
+    // When the execution engine carries an approval binding, approving a step
+    // persists a single-use ApprovalRecord bound to the exact execution
+    // intent. Identity is a required captured fact (R3): absent `approver_id`
+    // with binding enabled denies the step.
+    /// Required for binding capture — human identity subject (see identity
+    /// module). `None` keeps the legacy approved-set path when no binding is
+    /// configured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approver_id: Option<String>,
+    /// Role / policy id (captured fact, not a judgment).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authority: Option<String>,
+    /// R4 — what the human was shown at approval time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decision_context: Option<DecisionContext>,
+    /// IdP token/claims presented at approval (credential-substitution check).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_claims_ref: Option<String>,
 }
 
 /// Output from approving steps of a paused execution.

--- a/engine/src/execution_engine/application/service_impl.rs
+++ b/engine/src/execution_engine/application/service_impl.rs
@@ -31,6 +31,10 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use uuid::Uuid;
 
+use crate::approval::application::ApprovalService;
+use crate::approval::application::IntentVerification;
+use crate::approval::application::dto::ApproveInput as ApprovalApproveInput;
+use crate::approval::domain::ApprovalError as ApprovalServiceError;
 use crate::event_system::application::EventBusService;
 use crate::event_system::domain::ExecutionEvent;
 use crate::execution_engine::domain::{
@@ -368,6 +372,21 @@ struct ExecutionSession {
 }
 
 // ---------------------------------------------------------------------------
+// ApprovalBinding
+// ---------------------------------------------------------------------------
+
+/// ADR-011 opt-in binding between the execution engine and the approval module.
+///
+/// The `service` captures approval records, verifies them at the dispatch
+/// choke point, and consumes them on terminal outcome. Callers construct the
+/// service with its own `NodeIntentResolver` (the sealed graph adapter) and
+/// inject it here per run scope.
+pub(crate) struct ApprovalBinding {
+    /// Approval lifecycle service (records, verify, consume).
+    pub(crate) service: Arc<dyn ApprovalService>,
+}
+
+// ---------------------------------------------------------------------------
 // ParallelExecutionServiceImpl
 // ---------------------------------------------------------------------------
 
@@ -400,6 +419,12 @@ pub struct ParallelExecutionServiceImpl {
     recovery_service: Option<Arc<dyn RecoveryService>>,
     /// Recovery context per execution session (dag_id keyed).
     recovery_contexts: Mutex<HashMap<Uuid, RecoveryContext>>,
+
+    /// ADR-011 approval binding (opt-in). When present, approval-gated nodes
+    /// are verified against the recorded intent at the dispatch choke point
+    /// (`verify_intent`), consume on terminal outcome, and approval capture
+    /// persists single-use records. `None` = legacy `session.approved` gate.
+    approval_binding: Option<Arc<ApprovalBinding>>,
 }
 
 impl ParallelExecutionServiceImpl {
@@ -469,6 +494,25 @@ impl ParallelExecutionServiceImpl {
             let Some(node_id) = node_id else {
                 break;
             };
+
+            // ADR-011 choke point: verify the approved intent before dispatch.
+            if graph
+                .get_node(node_id)
+                .map(|n| n.requires_approval)
+                .unwrap_or(false)
+            {
+                match self.verify_before_dispatch(node_id).await {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        self.halt_intent_mismatch(dag_id, graph, node_id, total_nodes)
+                            .await?;
+                        approval_blocked = true;
+                        break;
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+
             spawn_concurrent_node(
                 &mut join_set,
                 graph,
@@ -558,6 +602,16 @@ impl ParallelExecutionServiceImpl {
                 self.notify_progress(dag_id, node_id, state, total_nodes);
             }
 
+            // ADR-011 R3: consume the single-use approval on terminal outcome
+            // (success, skipped, or exhausted failure after ≥1 dispatch).
+            if graph
+                .get_node(node_id)
+                .map(|n| n.requires_approval)
+                .unwrap_or(false)
+            {
+                self.consume_on_terminal(node_id).await;
+            }
+
             // Mark completed in graph to release dependents
             let _ = graph.mark_completed(node_id);
 
@@ -573,6 +627,25 @@ impl ParallelExecutionServiceImpl {
                 let Some(next_id) = next_id else {
                     break;
                 };
+
+                // ADR-011 choke point: verify the approved intent before dispatch.
+                if graph
+                    .get_node(next_id)
+                    .map(|n| n.requires_approval)
+                    .unwrap_or(false)
+                {
+                    match self.verify_before_dispatch(next_id).await {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            self.halt_intent_mismatch(dag_id, graph, next_id, total_nodes)
+                                .await?;
+                            approval_blocked = true;
+                            break;
+                        }
+                        Err(e) => return Err(e),
+                    }
+                }
+
                 spawn_concurrent_node(
                     &mut join_set,
                     graph,
@@ -624,6 +697,92 @@ impl ParallelExecutionServiceImpl {
             node_results,
             approval_blocked,
         ))
+    }
+
+    /// ADR-011 choke point — verify a gated node's intent before dispatch.
+    ///
+    /// Returns `Ok(true)` to dispatch (`Matched`), `Ok(false)` to HALT
+    /// (`Mismatched` / `Invalid` / missing record — the tool is never called),
+    /// or an internal error when the approval service itself fails (fail-closed).
+    async fn verify_before_dispatch(&self, node_id: Uuid) -> Result<bool, ExecutionError> {
+        let Some(binding) = &self.approval_binding else {
+            return Ok(true); // legacy gate — no binding
+        };
+        match binding.service.verify_intent(node_id).await {
+            Ok(IntentVerification::Matched) => {
+                tracing::info!(node_id = %node_id, "dispatch: intent MATCHED — verified against approved record");
+                Ok(true)
+            }
+            Ok(verdict) => {
+                tracing::error!(
+                    node_id = %node_id,
+                    verdict = ?verdict,
+                    "dispatch HALT: approval invalid or intent mismatch — re-approval required"
+                );
+                Ok(false)
+            }
+            Err(ApprovalServiceError::NotFound(_)) => {
+                tracing::warn!(
+                    node_id = %node_id,
+                    "dispatch HALT: no approval record (legacy or invalidated) — re-approval required"
+                );
+                Ok(false)
+            }
+            Err(e) => Err(ExecutionError::InternalError {
+                detail: format!("Approval verification failed: {e}"),
+            }),
+        }
+    }
+
+    /// Halt a node on intent mismatch (R2): never dispatches; the node moves
+    /// to `IntentMismatch`, is requeued (so a later re-approval + resume can
+    /// pick it up), and is dropped from the session's approved set.
+    async fn halt_intent_mismatch(
+        &self,
+        dag_id: Uuid,
+        graph: &mut crate::dag_engine::domain::TaskGraph,
+        node_id: Uuid,
+        total_nodes: u32,
+    ) -> Result<(), ExecutionError> {
+        graph.requeue_ready_node(node_id);
+        let updated_state = {
+            let mut sessions = self
+                .sessions
+                .lock()
+                .map_err(|e| ExecutionError::InternalError {
+                    detail: format!("Lock error: {e}"),
+                })?;
+            if let Some(session) = sessions.get_mut(&dag_id) {
+                session.approved.remove(&node_id);
+                if let Some(state) = session.node_states.get_mut(&node_id) {
+                    state.mark_intent_mismatch();
+                    Some(state.clone())
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        };
+        if let Some(state) = updated_state {
+            self.notify_progress(dag_id, node_id, state, total_nodes);
+        }
+        Ok(())
+    }
+
+    /// Single-use settlement: consume the approval once the node reaches a
+    /// terminal outcome. Non-terminal failures never reach this point.
+    async fn consume_on_terminal(&self, node_id: Uuid) {
+        let Some(binding) = &self.approval_binding else {
+            return;
+        };
+        match binding.service.consume(node_id).await {
+            Ok(()) => tracing::info!(node_id = %node_id, "approval consumed (terminal outcome)"),
+            Err(ApprovalServiceError::NotFound(_) | ApprovalServiceError::AlreadyConsumed(_)) => {}
+            Err(e) => {
+                tracing::warn!(node_id = %node_id, error = %e, "consume failed (non-fatal)")
+            }
+        }
     }
 
     /// Mark the front ready node as awaiting human approval in the session.
@@ -678,6 +837,7 @@ impl ParallelExecutionServiceImpl {
             permission_enforcer: None,
             recovery_service: None,
             recovery_contexts: Mutex::new(HashMap::new()),
+            approval_binding: None,
         }
     }
 
@@ -696,6 +856,19 @@ impl ParallelExecutionServiceImpl {
     /// Set the recovery service for automatic failure recovery.
     pub fn with_recovery_service(mut self, recovery: Arc<dyn RecoveryService>) -> Self {
         self.recovery_service = Some(recovery);
+        self
+    }
+
+    /// Enable ADR-011 approval binding (opt-in).
+    ///
+    /// When set, approval-gated nodes are verified against the recorded
+    /// intent hash before dispatch (`Matched` → dispatch, else HALT into
+    /// `IntentMismatch` — the tool is never called) and single-use records are
+    /// consumed on terminal outcome. `approve_node` persists binding records
+    /// when the input carries an approver identity. Without a binding the
+    /// legacy `session.approved` gate is unchanged.
+    pub fn with_approval_service(mut self, service: Arc<dyn ApprovalService>) -> Self {
+        self.approval_binding = Some(Arc::new(ApprovalBinding { service }));
         self
     }
 
@@ -1758,7 +1931,10 @@ impl ParallelExecutionService for ParallelExecutionServiceImpl {
         let (approval_pending, pending_approval_steps) = if approval_blocked {
             let steps = live_states
                 .values()
-                .filter(|s| s.status == NodeStatus::AwaitingApproval)
+                .filter(|s| {
+                    s.status == NodeStatus::AwaitingApproval
+                        || s.status == NodeStatus::IntentMismatch
+                })
                 .map(|s| s.node_name.clone())
                 .collect::<Vec<_>>();
             (true, steps)
@@ -2440,72 +2616,163 @@ impl ParallelExecutionService for ParallelExecutionServiceImpl {
         &self,
         input: ApproveNodeInput,
     ) -> Result<ApproveNodeOutput, ExecutionError> {
-        let mut sessions = self
-            .sessions
-            .lock()
-            .map_err(|e| ExecutionError::InternalError {
-                detail: format!("Lock error: {}", e),
-            })?;
+        // Binding-aware approve: with ADR-011 approval binding the approval is
+        // captured as a single-use record bound to the canonical execution
+        // intent (R1+R3). The legacy `session.approved` set remains the gate
+        // in both modes — with binding, a node enters it only after its
+        // record was persisted.
+        struct Candidate {
+            name: String,
+            node_id: Uuid,
+        }
 
-        let session = sessions
-            .get_mut(&input.dag_id)
-            .ok_or(ExecutionError::NodeNotFound {
-                node_id: input.dag_id,
-            })?;
+        // (1) Resolve candidates under the sessions lock (no awaits held).
+        let (candidates, mut denied, not_found) = {
+            let mut sessions = self
+                .sessions
+                .lock()
+                .map_err(|e| ExecutionError::InternalError {
+                    detail: format!("Lock error: {e}"),
+                })?;
 
-        let mut approved: Vec<String> = Vec::new();
-        let mut not_found: Vec<String> = Vec::new();
-        let mut denied: Vec<String> = Vec::new();
+            let session = sessions
+                .get_mut(&input.dag_id)
+                .ok_or(ExecutionError::NodeNotFound {
+                    node_id: input.dag_id,
+                })?;
 
-        for name in &input.step_names {
-            // Resolve step name -> node id from the session's live states.
-            let node_id = session
-                .node_states
-                .iter()
-                .find(|(_, s)| &s.node_name == name)
-                .map(|(id, _)| *id);
+            let mut candidates: Vec<Candidate> = Vec::new();
+            let mut denied: Vec<String> = Vec::new();
+            let mut not_found: Vec<String> = Vec::new();
 
-            let Some(node_id) = node_id else {
-                not_found.push(name.clone());
-                continue;
-            };
+            for name in &input.step_names {
+                // Resolve step name -> node id from the session's live states.
+                let node_id = session
+                    .node_states
+                    .iter()
+                    .find(|(_, s)| &s.node_name == name)
+                    .map(|(id, _)| *id);
 
-            // GAP-H-07: only approval-gated nodes awaiting human sign-off may
-            // be approved. Resolve `requires_approval` from the session graph;
-            // a node not in `AwaitingApproval` (already approved/executed/
-            // completed) is rejected.
-            let gated = session
-                .graph
-                .as_ref()
-                .and_then(|g| g.get_node(node_id))
-                .map(|n| n.requires_approval)
-                .unwrap_or(false);
-            let awaiting = session
-                .node_states
-                .get(&node_id)
-                .map(|s| s.status == NodeStatus::AwaitingApproval)
-                .unwrap_or(false);
+                let Some(node_id) = node_id else {
+                    not_found.push(name.clone());
+                    continue;
+                };
 
-            if !gated || !awaiting {
-                denied.push(name.clone());
-                continue;
+                // GAP-H-07: only approval-gated nodes awaiting human sign-off
+                // may be approved. Resolve `requires_approval` from the session
+                // graph; a node not in `AwaitingApproval` (already approved/
+                // executed/completed) is rejected. A node halted on
+                // `IntentMismatch` is awaiting re-approval and may be approved
+                // again (fresh record + new hash).
+                let gated = session
+                    .graph
+                    .as_ref()
+                    .and_then(|g| g.get_node(node_id))
+                    .map(|n| n.requires_approval)
+                    .unwrap_or(false);
+                let awaiting = session
+                    .node_states
+                    .get(&node_id)
+                    .map(|s| {
+                        s.status == NodeStatus::AwaitingApproval
+                            || s.status == NodeStatus::IntentMismatch
+                    })
+                    .unwrap_or(false);
+
+                if !gated || !awaiting {
+                    denied.push(name.clone());
+                    continue;
+                }
+
+                candidates.push(Candidate {
+                    name: name.clone(),
+                    node_id,
+                });
             }
+            (candidates, denied, not_found)
+        };
 
-            session.approved.insert(node_id);
-            approved.push(name.clone());
+        let candidate_names: Vec<String> = candidates.iter().map(|c| c.name.clone()).collect();
 
-            // A node blocked on approval becomes dispatchable again.
-            if let Some(state) = session.node_states.get_mut(&node_id) {
-                state.mark_ready();
+        // (2) Capture the approval record when a binding is configured.
+        let mut approved: Vec<String> = Vec::new();
+        if let Some(binding) = &self.approval_binding {
+            // R3: identity is a required captured fact — fail closed without it.
+            let approver_id = input.approver_id.clone().filter(|s| !s.trim().is_empty());
+            match approver_id {
+                Some(approver_id) => {
+                    let approve_input = ApprovalApproveInput {
+                        dag_id: input.dag_id,
+                        step_names: candidate_names.clone(),
+                        approver_id,
+                        authority: input.authority.clone(),
+                        decision_context: input.decision_context.clone(),
+                        token_claims_ref: input.token_claims_ref.clone(),
+                    };
+                    let out = binding.service.approve(approve_input).await.map_err(|e| {
+                        ExecutionError::InternalError {
+                            detail: format!("Approval binding capture failed: {e}"),
+                        }
+                    })?;
+                    approved = out.approved;
+                    // Names that failed to bind are denied (never silently granted).
+                    for name in &candidate_names {
+                        if !approved.contains(name) {
+                            denied.push(name.clone());
+                        }
+                    }
+                }
+                None => {
+                    if !candidate_names.is_empty() {
+                        tracing::warn!(
+                            dag_id = %input.dag_id,
+                            candidates = candidate_names.len(),
+                            "approve denied: approval binding requires approver_id (identity is a captured fact)"
+                        );
+                        denied.extend(candidate_names.clone());
+                    }
+                }
+            }
+        } else {
+            approved = candidate_names;
+        }
+
+        // (3) Commit under the sessions lock: approved nodes become
+        // dispatchable; still_pending reflects the remaining approval gate.
+        let mut still_pending: Vec<String> = Vec::new();
+        {
+            let mut sessions = self
+                .sessions
+                .lock()
+                .map_err(|e| ExecutionError::InternalError {
+                    detail: format!("Lock error: {e}"),
+                })?;
+            if let Some(session) = sessions.get_mut(&input.dag_id) {
+                for cand in &candidates {
+                    if approved.contains(&cand.name) {
+                        session.approved.insert(cand.node_id);
+                        // A node blocked on approval becomes dispatchable again.
+                        if let Some(state) = session.node_states.get_mut(&cand.node_id) {
+                            state.mark_ready();
+                        }
+                    }
+                }
+                still_pending = session
+                    .node_states
+                    .values()
+                    .filter(|s| {
+                        s.status == NodeStatus::AwaitingApproval
+                            || s.status == NodeStatus::IntentMismatch
+                    })
+                    .map(|s| s.node_name.clone())
+                    .collect();
             }
         }
 
-        let still_pending: Vec<String> = session
-            .node_states
-            .values()
-            .filter(|s| s.status == NodeStatus::AwaitingApproval)
-            .map(|s| s.node_name.clone())
-            .collect();
+        // `denied` may contain duplicates if a name was both un-gated and
+        // binding-denied — de-dupe while preserving order.
+        let mut seen = HashSet::new();
+        denied.retain(|n| seen.insert(n.clone()));
 
         Ok(ApproveNodeOutput {
             dag_id: input.dag_id,

--- a/engine/src/execution_engine/approval_binding_tests.rs
+++ b/engine/src/execution_engine/approval_binding_tests.rs
@@ -1,0 +1,339 @@
+//! ADR-011 approval-binding wiring tests (opt-in dispatch choke point).
+//!
+//! @canonical .pi/architecture/modules/approval.md#approvalservice
+//! Implements: ISSUE slice — ApprovalService invoked by the runtime dispatch
+//!   path: approve captures a record, dispatch verifies the intent hash
+//!   (HALT on mismatch — tool never called), and the record is consumed once
+//!   on terminal outcome.
+//! Issue: #792 wiring (ADR-011 acceptance slice)
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use uuid::Uuid;
+
+use crate::approval::application::{ApprovalServiceImpl, NodeIntentResolver, ResolvedNode};
+use crate::approval::domain::{ApprovalStatus, ExecutionIntent};
+use crate::approval::infrastructure::repository::{
+    ApprovalRepository, FileBackedApprovalRepository, InMemoryApprovalRepository,
+};
+use crate::dag_engine::domain::{TaskGraph, TaskNode};
+use crate::event_system::application::event_bus_service_impl::EventBusServiceImpl;
+use crate::execution_engine::application::dto::{
+    ApproveNodeInput, ExecuteGraphInput, GetExecutionStateInput, HydrateExecutionInput,
+    ResumeExecutionInput,
+};
+use crate::execution_engine::application::service::ParallelExecutionService;
+use crate::execution_engine::application::service_impl::{
+    ParallelExecutionServiceImpl, RetryEvaluationServiceImpl,
+};
+use crate::execution_engine::domain::{NodeStatus, ParallelExecutorConfig};
+
+// ── Harness ─────────────────────────────────────────────────────────────────
+
+/// Resolver over a fixed (sealed) graph — mirrors what the orchestrator wires
+/// for a run: step name / node id → canonical `ExecutionIntent`.
+struct GraphResolver {
+    by_name: HashMap<String, (Uuid, ExecutionIntent)>,
+}
+
+impl GraphResolver {
+    fn from_graph(graph: &TaskGraph) -> Self {
+        let mut by_name = HashMap::new();
+        for node in graph.nodes() {
+            by_name.insert(
+                node.name.clone(),
+                (node.id, ExecutionIntent::from_node(node)),
+            );
+        }
+        Self { by_name }
+    }
+}
+
+#[async_trait::async_trait]
+impl NodeIntentResolver for GraphResolver {
+    async fn resolve_by_step_name(&self, step_name: &str) -> Option<ResolvedNode> {
+        self.by_name
+            .get(step_name)
+            .map(|(id, intent)| ResolvedNode {
+                node_id: *id,
+                step_name: step_name.to_string(),
+                intent: intent.clone(),
+            })
+    }
+    async fn resolve_by_node_id(&self, node_id: Uuid) -> Option<ResolvedNode> {
+        self.by_name
+            .iter()
+            .find(|(_, (id, _))| *id == node_id)
+            .map(|(name, (id, intent))| ResolvedNode {
+                node_id: *id,
+                step_name: name.clone(),
+                intent: intent.clone(),
+            })
+    }
+}
+
+fn executor_with_binding(
+    repo: Arc<dyn ApprovalRepository>,
+    resolver: Arc<dyn NodeIntentResolver>,
+) -> ParallelExecutionServiceImpl {
+    let service = ApprovalServiceImpl::new(
+        repo,
+        resolver,
+        b"engine-run-key".to_vec(),
+        Duration::from_secs(3600),
+    );
+    let executor = ParallelExecutionServiceImpl::new(
+        ParallelExecutorConfig::default(),
+        Box::new(RetryEvaluationServiceImpl::new()),
+        Arc::new(EventBusServiceImpl::default()),
+    );
+    executor.with_approval_service(Arc::new(service))
+}
+
+fn gated_run_node(id: Uuid, name: &str, command: &str) -> TaskNode {
+    let intent = serde_json::json!({ "command": command });
+    TaskNode::new(id, name, "run_command", vec![], intent.to_string()).with_requires_approval(true)
+}
+
+fn marker_path(tag: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("approval-bound-{tag}.marker"))
+}
+
+fn touch_cmd(path: &Path) -> String {
+    format!("touch {}", path.display())
+}
+
+/// ADR-011 AC #4: approve → identical intent → verified at the choke point →
+/// dispatches (tool runs) → single-use record consumed on terminal outcome.
+#[tokio::test]
+async fn test_bound_approval_dispatches_verified_intent_and_consumes() {
+    let dag_id = Uuid::new_v4();
+    let node_id = Uuid::new_v4();
+    let marker = marker_path("dispatch-a");
+    let _ = std::fs::remove_file(&marker);
+    let graph = {
+        let mut g = TaskGraph::new();
+        g.add_unchecked(gated_run_node(node_id, "risky_step", &touch_cmd(&marker)))
+            .unwrap();
+        g.seal().unwrap();
+        g
+    };
+
+    let repo = Arc::new(InMemoryApprovalRepository::new()) as Arc<dyn ApprovalRepository>;
+    let resolver = Arc::new(GraphResolver::from_graph(&graph)) as Arc<dyn NodeIntentResolver>;
+    let executor = executor_with_binding(repo.clone(), resolver);
+
+    // First execute pauses at the approval gate (legacy pause semantics).
+    let out = executor
+        .execute_graph(ExecuteGraphInput {
+            dag_id,
+            graph: Some(graph.clone()),
+            config_override: None,
+        })
+        .await
+        .unwrap();
+    assert!(out.approval_pending, "gated run pauses before dispatch");
+
+    // Human approves with captured identity → record persisted, node released.
+    let approve = executor
+        .approve_node(ApproveNodeInput {
+            dag_id,
+            step_names: vec!["risky_step".to_string()],
+            approver_id: Some("tester@org".into()),
+            authority: Some("role:operator".into()),
+            decision_context: None,
+            token_claims_ref: Some("tok-ref".into()),
+        })
+        .await
+        .unwrap();
+    assert_eq!(approve.approved, vec!["risky_step".to_string()]);
+    let record = repo
+        .load(node_id)
+        .await
+        .expect("repo")
+        .expect("record present");
+    assert_eq!(record.status, ApprovalStatus::Pending);
+
+    // Resume → dispatch choke point verifies (Matched) → tool runs → consume.
+    executor
+        .resume_execution(ResumeExecutionInput { dag_id })
+        .await
+        .unwrap();
+    let state = executor
+        .get_execution_state(GetExecutionStateInput { dag_id })
+        .await
+        .unwrap();
+    assert!(
+        state.is_complete,
+        "verified intent dispatches and completes"
+    );
+    assert!(
+        marker.exists(),
+        "tool must execute when the approved intent is verified"
+    );
+    let record = repo
+        .load(node_id)
+        .await
+        .expect("repo")
+        .expect("record present");
+    assert_eq!(
+        record.status,
+        ApprovalStatus::Consumed,
+        "single-use record consumed once on terminal outcome"
+    );
+    let _ = std::fs::remove_file(&marker);
+}
+
+/// ADR-011 AC #5: intent mutated between approve and dispatch (cross-process
+/// resume against a tampered persisted graph) → HALT before dispatch, node
+/// `IntentMismatch`, tool never called; re-approval recovers.
+#[tokio::test]
+async fn test_tampered_intent_halts_before_dispatch_and_reapproval_recovers() {
+    let dag_id = Uuid::new_v4();
+    let node_id = Uuid::new_v4();
+    let store = std::env::temp_dir().join(format!("approval-bound-store-{dag_id}.json"));
+    let _ = std::fs::remove_file(&store);
+
+    // ── Process A: original graph, approve, pause (never dispatched) ──
+    let marker_a = marker_path(&format!("tamper-{dag_id}-a"));
+    let _ = std::fs::remove_file(&marker_a);
+    let graph_a = {
+        let mut g = TaskGraph::new();
+        g.add_unchecked(gated_run_node(node_id, "deploy", &touch_cmd(&marker_a)))
+            .unwrap();
+        g.seal().unwrap();
+        g
+    };
+    let repo_a = Arc::new(FileBackedApprovalRepository::open(&store).unwrap())
+        as Arc<dyn ApprovalRepository>;
+    let executor_a = executor_with_binding(
+        repo_a,
+        Arc::new(GraphResolver::from_graph(&graph_a)) as Arc<dyn NodeIntentResolver>,
+    );
+    executor_a
+        .execute_graph(ExecuteGraphInput {
+            dag_id,
+            graph: Some(graph_a.clone()),
+            config_override: None,
+        })
+        .await
+        .unwrap();
+    let approve_a = executor_a
+        .approve_node(ApproveNodeInput {
+            dag_id,
+            step_names: vec!["deploy".to_string()],
+            approver_id: Some("tester@org".into()),
+            authority: None,
+            decision_context: None,
+            token_claims_ref: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(approve_a.approved, vec!["deploy".to_string()]);
+    let state_a = executor_a
+        .get_execution_state(GetExecutionStateInput { dag_id })
+        .await
+        .unwrap();
+    // A pauses with the approval granted but the node never dispatched.
+
+    // ── Process B: persisted store + a TAMPERED graph (upstream change) ──
+    let marker_b = marker_path(&format!("tamper-{dag_id}-b"));
+    let _ = std::fs::remove_file(&marker_b);
+    let graph_tampered = {
+        let mut g = TaskGraph::new();
+        g.add_unchecked(gated_run_node(
+            node_id,
+            "deploy",
+            &touch_cmd(&marker_b), // mutated intent
+        ))
+        .unwrap();
+        g.seal().unwrap();
+        g
+    };
+    let repo_b = Arc::new(FileBackedApprovalRepository::open(&store).unwrap())
+        as Arc<dyn ApprovalRepository>;
+    let executor_b = executor_with_binding(
+        repo_b.clone(),
+        Arc::new(GraphResolver::from_graph(&graph_tampered)) as Arc<dyn NodeIntentResolver>,
+    );
+    // Cross-process resume: B hydrates with the persisted approved set and the
+    // record file written by A — the OLD approval now must NOT authorize the
+    // tampered dispatch.
+    executor_b
+        .hydrate_execution(HydrateExecutionInput {
+            dag_id,
+            graph: graph_tampered.clone(),
+            node_states: state_a.node_states.clone(),
+            approved: HashSet::from([node_id]),
+            started_at: state_a.started_at.unwrap_or_else(chrono::Utc::now),
+        })
+        .await
+        .unwrap();
+
+    let resume = executor_b
+        .resume_execution(ResumeExecutionInput { dag_id })
+        .await
+        .unwrap();
+    assert_eq!(resume.dag_id, dag_id);
+
+    // HALT: node in IntentMismatch, nothing dispatched.
+    let state_b = executor_b
+        .get_execution_state(GetExecutionStateInput { dag_id })
+        .await
+        .unwrap();
+    let node_state = state_b.node_states.get(&node_id).expect("node present");
+    assert_eq!(
+        node_state.status,
+        NodeStatus::IntentMismatch,
+        "tampered intent must halt the node into IntentMismatch"
+    );
+    assert!(
+        !state_b.is_complete,
+        "mismatched intent must not complete the run"
+    );
+    assert!(
+        !marker_a.exists(),
+        "tool must never be called (marker A absent)"
+    );
+    assert!(
+        !marker_b.exists(),
+        "tool must never be called (marker B absent)"
+    );
+
+    // Re-approval (new record bound to the CURRENT graph) → dispatch proceeds.
+    let reapprove = executor_b
+        .approve_node(ApproveNodeInput {
+            dag_id,
+            step_names: vec!["deploy".to_string()],
+            approver_id: Some("tester@org".into()),
+            authority: None,
+            decision_context: None,
+            token_claims_ref: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(reapprove.approved, vec!["deploy".to_string()]);
+    executor_b
+        .resume_execution(ResumeExecutionInput { dag_id })
+        .await
+        .unwrap();
+    let state_c = executor_b
+        .get_execution_state(GetExecutionStateInput { dag_id })
+        .await
+        .unwrap();
+    assert!(
+        state_c.is_complete,
+        "re-approval against current intent completes"
+    );
+    assert!(
+        marker_b.exists(),
+        "re-approved intent dispatches (marker B present)"
+    );
+
+    let _ = std::fs::remove_file(&store);
+    let _ = std::fs::remove_file(&marker_a);
+    let _ = std::fs::remove_file(&marker_b);
+}

--- a/engine/src/execution_engine/domain/parallel_executor.rs
+++ b/engine/src/execution_engine/domain/parallel_executor.rs
@@ -115,6 +115,13 @@ pub enum NodeStatus {
     Skipped,
     /// Ready but paused awaiting human approval (sign-off required).
     AwaitingApproval,
+    /// Pre-dispatch verification failed — the executing intent no longer
+    /// matches what was approved (R2 HALT). Re-approval is the only recovery.
+    ///
+    /// ADR-011 acceptance: the node never dispatches in this state; a
+    /// legitimate re-approval transitions it back to `AwaitingApproval` →
+    /// `Ready`.
+    IntentMismatch,
 }
 
 impl NodeStatus {
@@ -141,6 +148,7 @@ impl NodeStatus {
             NodeStatus::Failed => "failed",
             NodeStatus::Skipped => "skipped",
             NodeStatus::AwaitingApproval => "awaiting_approval",
+            NodeStatus::IntentMismatch => "intent_mismatch",
         }
     }
 }
@@ -256,6 +264,17 @@ impl NodeExecutionState {
         if self.status == NodeStatus::Ready || self.status == NodeStatus::Pending {
             self.status = NodeStatus::AwaitingApproval;
         }
+    }
+
+    /// Transition the node to IntentMismatch (R2 HALT) and back to
+    /// `AwaitingApproval` on legitimate re-approval.
+    ///
+    /// - `mark_intent_mismatch`: pre-dispatch verification failed; the node is
+    ///   blocked and must be re-approved (never dispatches from this state).
+    /// - `mark_awaiting_approval` (called on re-approval) moves it back to the
+    ///   normal approval gate.
+    pub fn mark_intent_mismatch(&mut self) {
+        self.status = NodeStatus::IntentMismatch;
     }
 
     /// Record a retry (increments attempt counter, resets to Ready).

--- a/engine/src/execution_engine/mod.rs
+++ b/engine/src/execution_engine/mod.rs
@@ -46,6 +46,9 @@ pub mod domain;
 pub mod infrastructure;
 
 #[cfg(test)]
+pub mod approval_binding_tests;
+
+#[cfg(test)]
 pub mod concurrency_tests;
 
 #[cfg(test)]

--- a/engine/src/state_persistence/domain/state.rs
+++ b/engine/src/state_persistence/domain/state.rs
@@ -244,7 +244,9 @@ impl ExecutionState {
             let mut ns = NodeState::new(*node_id);
             ns.status = match exec.status {
                 ExecStatus::Pending | ExecStatus::Ready => NodeStatus::Pending,
-                ExecStatus::Running | ExecStatus::AwaitingApproval => NodeStatus::InProgress,
+                ExecStatus::Running | ExecStatus::AwaitingApproval | ExecStatus::IntentMismatch => {
+                    NodeStatus::InProgress
+                }
                 ExecStatus::Completed => NodeStatus::Completed,
                 ExecStatus::Failed => NodeStatus::Failed,
                 ExecStatus::Skipped => NodeStatus::Skipped,


### PR DESCRIPTION
## ADR-011 acceptance slice: ApprovalService at the dispatch choke point (opt-in)

### Summary
Closes the last open wiring gap from the approval epic's validation report:
the runtime now **invokes** `ApprovalService` — capture, verify, halt, consume —
instead of only the legacy `session.approved` gate. Default-off (no binding =
unchanged legacy behavior), so all pre-existing tests stay untouched.

### What changed
| Seam | Change |
|------|--------|
| Engine | `ParallelExecutionServiceImpl::with_approval_service()` (opt-in `ApprovalBinding`) |
| approve | bound `approve_node` persists a single-use `ApprovalRecord` bound to the canonical `ExecutionIntent` before releasing the node; new optional `ApproveNodeInput.{approver_id, authority, decision_context, token_claims_ref}` (identity is a required captured fact — denied without it) |
| Dispatch | `run_dispatch_loop` (shared by execute + resume) calls `verify_intent` before dispatching a gated node: `Matched` → dispatch; `Mismatched`/`Invalid`/missing record → **HALT** into new `NodeStatus::IntentMismatch` (tool never called, re-approval required) |
| Consume | single-use record consumed once on terminal outcome (failed attempts stay Pending) |
| State | `NodeStatus::IntentMismatch` + persistence mapping (coarse: InProgress); pending-approval views include it |

### Verification
- 1943 lib tests + 58 approval unit tests green; `clippy -D warnings` clean
- New integration tests:
  - bound approve → identical intent verified at choke point → tool runs → record `Consumed`
  - cross-process resume against a **tampered persisted graph** → HALT pre-dispatch (`IntentMismatch`), spy markers assert the tool is **never called**, re-approval recovers and completes

### Honest scope (still open — ADR-011 stays Proposed)
- Envelope `ApprovalRecorded` events + `scope_violations[]` wiring (audit)
- git-diff effect-scope oracle at runtime (R5)
- Identity/token claims surfaced through the MCP approve surface

Refs: #792 (ApprovalService), ADR-011, canonical `.pi/architecture/modules/approval.md#integration-with-existing-modules`
