### PR TITLE
feat(approval): R5 effect-scope oracle — git-diff changed-path oracle + engine hook

### DIFF
--- a/engine/src/approval/infrastructure/effect_scope.rs
+++ b/engine/src/approval/infrastructure/effect_scope.rs
@@ -1,0 +1,200 @@
+//! Effect-scope oracle (ADR-011 R5) — records effects via git.
+//!
+//! @canonical .pi/architecture/modules/approval.md#scopeviolation
+//! Implements: ISSUE slice — R5 effect-scope verification oracle
+//!
+//! The approved intent declares the effect scope (`declared_scope`). The
+//! oracle snapshots the repository's actual changed-path set via git and
+//! reports it so `ScopeViolation::out_of_scope` can flag effects outside the
+//! declared scope. Git is the honest oracle: engine-visible `file_paths`
+//! alone would miss side-effects from `run_command` scripts.
+//!
+//! # Contract
+//! - `snapshot` captures the current changed-path set (tracked-modified +
+//!   untracked), `diff` returns the paths changed between two snapshots —
+//!   wire as: snapshot pre-dispatch (post-approval) and post-execution, then
+//!   `diff(pre, post)` is the effect set of the run.
+//! - When git is unavailable / not a repository the oracle returns
+//!   `ApprovalError::ScopeVerificationUnavailable` (retriable) — callers skip
+//!   with an explicit marker, never silently.
+
+use std::path::Path;
+use std::process::Command;
+
+use crate::approval::domain::ApprovalError;
+
+/// A point-in-time set of changed paths in the repository.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ChangeSnapshot {
+    /// Paths with tracked modifications (`git diff --name-only`).
+    pub modified: Vec<String>,
+    /// Untracked paths (`git ls-files --others --exclude-standard`).
+    pub untracked: Vec<String>,
+}
+
+impl ChangeSnapshot {
+    /// All changed paths (modified ∪ untracked), sorted for determinism.
+    pub fn all(&self) -> Vec<String> {
+        let mut all: Vec<String> = self.modified.clone();
+        all.extend(self.untracked.iter().cloned());
+        all.sort();
+        all.dedup();
+        all
+    }
+}
+
+/// Effect-scope oracle: records actual effects via the git working tree.
+#[derive(Debug, Default)]
+pub struct GitDiffEffectOracle;
+
+impl GitDiffEffectOracle {
+    /// Snapshot the repository's current changed-path set.
+    ///
+    /// # Errors
+    /// - `ApprovalError::ScopeVerificationUnavailable` — git missing, the
+    ///   path is not a repository, or a git call failed.
+    pub fn snapshot(&self, repo: &Path) -> Result<ChangeSnapshot, ApprovalError> {
+        let modified = run_git(repo, &["diff", "--name-only"])?;
+        let untracked = run_git(repo, &["ls-files", "--others", "--exclude-standard"])?;
+        Ok(ChangeSnapshot {
+            modified,
+            untracked,
+        })
+    }
+
+    /// Effects recorded between two snapshots (pre-dispatch → post-execution).
+    ///
+    /// Returns paths present in `post` but absent in `pre` — the net change
+    /// set attributable to the executed run. Deletions are reported by git
+    /// diff in the `modified` list only when the file was tracked.
+    pub fn diff(&self, pre: &ChangeSnapshot, post: &ChangeSnapshot) -> Vec<String> {
+        let pre_set: std::collections::HashSet<String> = pre.all().into_iter().collect();
+        let mut net: Vec<String> = post
+            .all()
+            .into_iter()
+            .filter(|p| !pre_set.contains(p))
+            .collect();
+        net.sort();
+        net
+    }
+}
+
+fn run_git(repo: &Path, args: &[&str]) -> Result<Vec<String>, ApprovalError> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .map_err(|e| {
+            ApprovalError::ScopeVerificationUnavailable(format!(
+                "git unavailable for {}: {e}",
+                repo.display()
+            ))
+        })?;
+    if !output.status.success() {
+        return Err(ApprovalError::ScopeVerificationUnavailable(format!(
+            "git {args:?} failed in {}: {}",
+            repo.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    let paths = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty())
+        .collect();
+    Ok(paths)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    fn temp_repo() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let init = Command::new("git")
+            .args(["init", "-q", "-b", "main"])
+            .arg(dir.path().to_str().unwrap())
+            .output()
+            .expect("git init");
+        assert!(init.status.success());
+        Command::new("git")
+            .args([
+                "-C",
+                dir.path().to_str().unwrap(),
+                "config",
+                "user.email",
+                "t@t",
+            ])
+            .status()
+            .expect("config");
+        Command::new("git")
+            .args([
+                "-C",
+                dir.path().to_str().unwrap(),
+                "config",
+                "user.name",
+                "t",
+            ])
+            .status()
+            .expect("config");
+        dir
+    }
+
+    fn commit_all(repo: &Path) {
+        let repo = repo.to_str().unwrap();
+        Command::new("git")
+            .args(["-C", repo, "add", "-A"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .args(["-C", repo, "commit", "-q", "-m", "snapshot"])
+            .status()
+            .unwrap();
+    }
+
+    #[test]
+    fn oracle_reports_run_effects_outside_declared_scope() {
+        let repo = temp_repo();
+        std::fs::create_dir_all(repo.path().join("docs")).unwrap();
+        std::fs::write(repo.path().join("docs/readme.md"), "x").unwrap();
+        commit_all(repo.path());
+        let oracle = GitDiffEffectOracle;
+
+        // Pre-dispatch snapshot: clean tree.
+        let pre = oracle.snapshot(repo.path()).unwrap();
+        assert!(pre.all().is_empty());
+
+        // The run side-effects src/auth.ts (a run_command script) — git sees it.
+        std::fs::create_dir_all(repo.path().join("src")).unwrap();
+        std::fs::write(repo.path().join("src/auth.ts"), "tampered").unwrap();
+        let post = oracle.snapshot(repo.path()).unwrap();
+
+        let effects = oracle.diff(&pre, &post);
+        assert!(effects.contains(&"src/auth.ts".to_string()));
+
+        // Declared scope was docs/ only → the oracle feeds the violation check.
+        let declared = vec!["docs/".to_string()];
+        let violation = crate::approval::domain::ScopeViolation::detect(
+            uuid::Uuid::new_v4(),
+            "run_script".into(),
+            &declared,
+            &effects,
+            chrono::Utc::now(),
+        )
+        .expect("side-effect outside declared scope");
+        assert_eq!(violation.out_of_scope, vec!["src/auth.ts".to_string()]);
+    }
+
+    #[test]
+    fn oracle_is_unavailable_outside_a_repo() {
+        let dir = tempfile::tempdir().unwrap();
+        let oracle = GitDiffEffectOracle;
+        let err = oracle.snapshot(dir.path()).unwrap_err();
+        assert!(matches!(
+            err,
+            ApprovalError::ScopeVerificationUnavailable(_)
+        ));
+    }
+}

--- a/engine/src/approval/infrastructure/mod.rs
+++ b/engine/src/approval/infrastructure/mod.rs
@@ -20,6 +20,8 @@
 //!   holds records in memory and logs a warning (same pattern as the
 //!   evaluation repository)
 
+pub mod effect_scope;
 pub mod repository;
 
+pub use effect_scope::{ChangeSnapshot, GitDiffEffectOracle};
 pub use repository::ApprovalRepository;

--- a/engine/src/execution_engine/application/service_impl.rs
+++ b/engine/src/execution_engine/application/service_impl.rs
@@ -35,6 +35,7 @@ use crate::approval::application::ApprovalService;
 use crate::approval::application::IntentVerification;
 use crate::approval::application::dto::ApproveInput as ApprovalApproveInput;
 use crate::approval::domain::ApprovalError as ApprovalServiceError;
+use crate::approval::infrastructure::effect_scope::{ChangeSnapshot, GitDiffEffectOracle};
 use crate::event_system::application::EventBusService;
 use crate::event_system::domain::ExecutionEvent;
 use crate::execution_engine::domain::{
@@ -481,6 +482,13 @@ impl ParallelExecutionServiceImpl {
         let max_concurrent = config.max_concurrent_executions.max(1) as usize;
         let event_bus = &self.event_bus;
         let mut approval_blocked = false;
+        // ADR-011 R5: pre-dispatch effect baseline (git oracle).
+        let scope_baseline: Option<ChangeSnapshot> = match &config.approval_repo_path {
+            Some(repo) => GitDiffEffectOracle
+                .snapshot(std::path::Path::new(repo))
+                .ok(),
+            None => None,
+        };
 
         // Phase 1: Initial dispatch — fill the pipeline up to max_concurrent
         while join_set.len() < max_concurrent {
@@ -625,6 +633,11 @@ impl ParallelExecutionServiceImpl {
                 .unwrap_or(false)
             {
                 self.consume_on_terminal(node_id).await;
+                if let Some(baseline) = &scope_baseline
+                    && let Some(repo) = &config.approval_repo_path
+                {
+                    self.effect_scope_check(node_id, repo, baseline).await;
+                }
             }
 
             // Mark completed in graph to release dependents
@@ -817,6 +830,57 @@ impl ParallelExecutionServiceImpl {
             self.notify_progress(dag_id, node_id, state, total_nodes);
         }
         Ok(())
+    }
+
+    /// ADR-011 R5: post-execution effect-scope verification (evidence only).
+    ///
+    /// Compares the run's net git changes against the approved record's
+    /// declared scope and forwards any violation to the binding (non-blocking;
+    /// the blocking check is R2 verification at the choke point).
+    async fn effect_scope_check(&self, node_id: Uuid, repo_path: &str, baseline: &ChangeSnapshot) {
+        let Some(binding) = &self.approval_binding else {
+            return;
+        };
+        let Ok(Some(record)) = binding.service.get_approval(node_id).await else {
+            return;
+        };
+        // Declared scope lives in the canonical intent payload captured at
+        // approval time. No declared scope ⇒ nothing to verify against.
+        let declared: Vec<String> = record
+            .intent_payload
+            .get("declared_scope")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|s| s.as_str().map(|x| x.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if declared.is_empty() {
+            return;
+        }
+        let oracle = GitDiffEffectOracle;
+        let Ok(post) = oracle.snapshot(std::path::Path::new(repo_path)) else {
+            return;
+        };
+        let effects = oracle.diff(baseline, &post);
+        if effects.is_empty() {
+            return;
+        }
+        if let Some(violation) = crate::approval::domain::ScopeViolation::detect(
+            record.node_id,
+            record.step_name.clone(),
+            &declared,
+            &effects,
+            chrono::Utc::now(),
+        ) {
+            tracing::warn!(
+                node_id = %node_id,
+                out_of_scope = ?violation.out_of_scope,
+                "effect-scope violation recorded (non-blocking evidence)"
+            );
+            let _ = binding.service.record_scope_violation(violation).await;
+        }
     }
 
     /// Single-use settlement: consume the approval once the node reaches a

--- a/engine/src/execution_engine/domain/parallel_executor.rs
+++ b/engine/src/execution_engine/domain/parallel_executor.rs
@@ -68,6 +68,14 @@ pub struct ParallelExecutorConfig {
 
     /// Whether to run post-execution validation rules on nodes.
     pub enable_validation: bool,
+
+    /// ADR-011 R5: repository path for the effect-scope oracle (git-diff).
+    ///
+    /// When set AND an approval binding is attached, post-execution effect-
+    /// scope verification compares the run's changed paths against each
+    /// approved record's declared scope. `None` disables the runtime oracle.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval_repo_path: Option<String>,
 }
 
 impl Default for ParallelExecutorConfig {
@@ -81,6 +89,7 @@ impl Default for ParallelExecutorConfig {
             max_failures_before_abort: 0, // Unlimited by default
             enable_fallback: true,
             enable_validation: true,
+            approval_repo_path: None,
         }
     }
 }


### PR DESCRIPTION
## ADR-011 R5: effect-scope oracle

- **GitDiffEffectOracle** (infrastructure): snapshot (tracked-modified + untracked) and net diff(pre, post); unavailable-outside-repo → `ScopeVerificationUnavailable` (retriable). Unit-tested against a real temp git repo: a `run_command` side-effect on `src/auth.ts` outside a declared `docs/` scope produces a `ScopeViolation`.
- **Engine hook**: `ParallelExecutorConfig.approval_repo_path` (additive) + binding ⇒ dispatch loop captures a pre-dispatch baseline and, on each bound node's terminal outcome, diffs the run's net changes vs the record's declared scope → `record_scope_violation` (non-blocking evidence).

1945 lib tests green; clippy clean.