### PR TITLE
feat(execution-engine): production approval binding flip — factory attach + env-driven (ADR-011)

### DIFF
--- a/actions/src/main.rs
+++ b/actions/src/main.rs
@@ -381,6 +381,7 @@ async fn build_action_orchestrator(
         }
     };
     let hook_runner = load_hook_runner(repo_root);
+    let approval_binding = rigorix_engine::execution_engine::application::factory::ApprovalBindingSetup::from_env(std::path::Path::new(repo_root));
     let execution = ParallelExecutionFactoryImpl
         .create(ParallelExecutionFactoryConfig {
             executor_config: ParallelExecutorConfig {
@@ -392,6 +393,7 @@ async fn build_action_orchestrator(
                 max_failures_before_abort: 0,
                 enable_fallback: true,
                 enable_validation: true,
+                approval_repo_path: None,
             },
             register_event_handlers: true,
             enable_progress_callbacks: true,
@@ -399,6 +401,7 @@ async fn build_action_orchestrator(
             event_bus: Some(Arc::clone(&event_bus)),
             permission_enforcer,
             hook_runner,
+            approval_binding,
         })
         .await
         .map_err(|e| format!("execution: {e}"))?;

--- a/cli/src/cli_boundary/orchestrator.rs
+++ b/cli/src/cli_boundary/orchestrator.rs
@@ -303,6 +303,7 @@ pub async fn build_orchestrator_with_budget(
         }
     };
     let hook_runner = load_hook_runner(repo_root.as_str());
+    let approval_binding = rigorix_engine::execution_engine::application::factory::ApprovalBindingSetup::from_env(std::path::Path::new(&repo_root));
     let execution = ParallelExecutionFactoryImpl
         .create(ParallelExecutionFactoryConfig {
             executor_config: ParallelExecutorConfig {
@@ -314,6 +315,7 @@ pub async fn build_orchestrator_with_budget(
                 max_failures_before_abort: 0,
                 enable_fallback: true,
                 enable_validation: true,
+                approval_repo_path: None,
             },
             register_event_handlers: true,
             enable_progress_callbacks: true,
@@ -321,6 +323,7 @@ pub async fn build_orchestrator_with_budget(
             event_bus: Some(Arc::clone(&event_bus)),
             permission_enforcer,
             hook_runner,
+            approval_binding,
         })
         .await
         .map_err(|e| CliError::General(format!("execution: {e}")))?;

--- a/cli/src/tui/event_bridge.rs
+++ b/cli/src/tui/event_bridge.rs
@@ -382,11 +382,16 @@ pub(crate) fn event_to_vm_command(event: &ExecutionEvent) -> Option<VmCommand> {
             None
         }
         // Audit lifecycle events have no TUI rendering — informational.
+        // ADR-011 approval/scope events are likewise informational for the
+        // TUI (rendered in audit + progress views instead).
         ExecutionEvent::AuditEnvelopeDelivered { .. }
         | ExecutionEvent::AuditEnvelopeQueued { .. }
         | ExecutionEvent::AuditEnvelopeDropped { .. }
         | ExecutionEvent::CircuitBreakerStateChanged { .. }
-        | ExecutionEvent::AuditEnvelopeCreated { .. } => None,
+        | ExecutionEvent::AuditEnvelopeCreated { .. }
+        | ExecutionEvent::ApprovalRecorded { .. }
+        | ExecutionEvent::IntentMismatchDetected { .. }
+        | ExecutionEvent::ScopeViolationRecorded { .. } => None,
     }
 }
 

--- a/engine/.pi/architecture/CHANGELOG.md
+++ b/engine/.pi/architecture/CHANGELOG.md
@@ -1,3 +1,24 @@
+## [2026-09-02] — Approval binding production flip (ADR-011, env-driven)
+
+### Added
+- `ParallelExecutionFactoryConfig.approval_binding` (`ApprovalBindingSetup`) —
+  the engine factory attaches an `ApprovalServiceImpl` (repository + run key +
+  TTL) with a **live session-graph resolver** (`SessionGraphResolver` reads the
+  executor's shared session map — no Arc cycle), turning approve/verify/consume
+  on at the runtime choke point for factory-built engines
+- `ApprovalBindingSetup::from_env` + wiring in CLI / action / MCP entry points:
+  `RIGORIX_APPROVAL_BINDING=1` (+ `RIGORIX_HMAC_KEY` = envelope key,
+  `RIGORIX_APPROVAL_TTL_SECONDS`, store `.rigorix/approvals.json`) flips the
+  binding on; default off ⇒ legacy gate unchanged
+- Sessions map shared as `Arc<Mutex<..>>` (non-cyclic resolver); executor
+  sessions now pub(crate) handle for the factory
+- Factory-path integration test: approve captures → choke point verifies →
+  tool runs → record consumed
+- Remaining (boundary identity): MCP/CLI approve surfaces must pass
+  `approver_id` when binding is on (engine denies without it by design);
+  ADR-011 still Proposed until envelope build path populates refs + boundary
+  identity land
+
 # Architecture Change Log
 
 ---

--- a/engine/src/execution_engine/application/factory.rs
+++ b/engine/src/execution_engine/application/factory.rs
@@ -45,6 +45,22 @@ pub trait ParallelExecutionFactory: Send + Sync {
 
 /// Configuration for creating a `ParallelExecutionService` instance.
 #[derive(Clone)]
+/// ADR-011 production approval binding setup.
+///
+/// When present, the engine factory attaches an `ApprovalServiceImpl`
+/// (repository + run key + TTL) with a session-graph intent resolver to the
+/// executor, turning on approval capture/verification/consume at the runtime
+/// choke point. `None` keeps the legacy `session.approved` gate.
+pub struct ApprovalBindingSetup {
+    /// Durable approval-record repository (node-scoped).
+    pub repository:
+        std::sync::Arc<dyn crate::approval::infrastructure::repository::ApprovalRepository>,
+    /// Run key — must equal the envelope HMAC key (ADR-011 §key).
+    pub run_key: Vec<u8>,
+    /// Approval lifetime (expires_at = decided_at + ttl).
+    pub ttl_seconds: u64,
+}
+
 pub struct ParallelExecutionFactoryConfig {
     /// The parallel executor configuration.
     pub executor_config: crate::execution_engine::domain::ParallelExecutorConfig,
@@ -73,6 +89,9 @@ pub struct ParallelExecutionFactoryConfig {
     /// When set, every tool execution runs the configured shell hooks
     /// (which can block, override permissions, or enrich audit context).
     pub hook_runner: Option<Arc<dyn HookRunnerService>>,
+
+    /// ADR-011: optional approval binding (see [`ApprovalBindingSetup`]).
+    pub approval_binding: Option<ApprovalBindingSetup>,
 }
 
 impl Default for ParallelExecutionFactoryConfig {
@@ -85,6 +104,7 @@ impl Default for ParallelExecutionFactoryConfig {
             event_bus: None,
             permission_enforcer: None,
             hook_runner: None,
+            approval_binding: None,
         }
     }
 }
@@ -136,4 +156,59 @@ pub struct FailureStrategyOverride {
     pub failure_type: String,
     /// The preferred retry strategy for this failure type.
     pub preferred_strategy: crate::execution_engine::domain::RetryStrategy,
+}
+
+impl ApprovalBindingSetup {
+    /// Build an approval binding setup from environment configuration.
+    ///
+    /// Enabled by `RIGORIX_APPROVAL_BINDING=1|true`. The run key defaults to
+    /// `RIGORIX_HMAC_KEY` (must equal the envelope HMAC key — ADR-011 §key);
+    /// TTL via `RIGORIX_APPROVAL_TTL_SECONDS` (default 3600). Records are
+    /// persisted to `<repo_root>/.rigorix/approvals.json` (atomic writes,
+    /// cross-process resume).
+    ///
+    /// Returns `None` when disabled — the executor keeps the legacy
+    /// `session.approved` gate (zero behavior change).
+    pub fn from_env(repo_root: &std::path::Path) -> Option<Self> {
+        let enabled = std::env::var("RIGORIX_APPROVAL_BINDING").ok();
+        let on = matches!(
+            enabled.as_deref(),
+            Some("1") | Some("true") | Some("TRUE") | Some("yes")
+        );
+        if !on {
+            return None;
+        }
+        let run_key = std::env::var("RIGORIX_HMAC_KEY")
+            .ok()
+            .filter(|k| !k.is_empty())
+            .map(|k| k.into_bytes());
+        let Some(run_key) = run_key else {
+            tracing::warn!(
+                "RIGORIX_APPROVAL_BINDING=1 but RIGORIX_HMAC_KEY is unset — approval binding disabled"
+            );
+            return None;
+        };
+        let ttl_seconds = std::env::var("RIGORIX_APPROVAL_TTL_SECONDS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(3600);
+        let store_dir = repo_root.join(".rigorix");
+        let _ = std::fs::create_dir_all(&store_dir);
+        let repository = std::sync::Arc::new(
+            crate::approval::infrastructure::repository::FileBackedApprovalRepository::open(
+                store_dir.join("approvals.json"),
+            )
+            .expect("approval store must open"),
+        );
+        tracing::info!(
+            ttl_seconds,
+            "approval binding ENABLED (ADR-011) — records at {}",
+            store_dir.join("approvals.json").display()
+        );
+        Some(Self {
+            repository,
+            run_key,
+            ttl_seconds,
+        })
+    }
 }

--- a/engine/src/execution_engine/application/factory_impl.rs
+++ b/engine/src/execution_engine/application/factory_impl.rs
@@ -65,6 +65,24 @@ impl ParallelExecutionFactory for ParallelExecutionFactoryImpl {
         if let Some(runner) = config.hook_runner {
             executor = executor.with_hook_runner(runner);
         }
+        if let Some(binding) = config.approval_binding {
+            // ADR-011: attach the approval binding with a live session-graph
+            // intent resolver — approve/verify/consume now run at the runtime
+            // choke point (records persist through the supplied repository).
+            let sessions = executor.sessions_handle();
+            let resolver = std::sync::Arc::new(
+                crate::execution_engine::application::service_impl::SessionGraphResolver::new(
+                    sessions,
+                ),
+            );
+            let service = crate::approval::application::ApprovalServiceImpl::new(
+                binding.repository,
+                resolver,
+                binding.run_key,
+                std::time::Duration::from_secs(binding.ttl_seconds),
+            );
+            executor = executor.with_approval_service(std::sync::Arc::new(service));
+        }
         Ok(Box::new(executor))
     }
 }

--- a/engine/src/execution_engine/application/service_impl.rs
+++ b/engine/src/execution_engine/application/service_impl.rs
@@ -31,9 +31,8 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use uuid::Uuid;
 
-use crate::approval::application::ApprovalService;
-use crate::approval::application::IntentVerification;
 use crate::approval::application::dto::ApproveInput as ApprovalApproveInput;
+use crate::approval::application::{ApprovalService, IntentVerification, ResolvedNode};
 use crate::approval::domain::ApprovalError as ApprovalServiceError;
 use crate::approval::infrastructure::effect_scope::{ChangeSnapshot, GitDiffEffectOracle};
 use crate::event_system::application::EventBusService;
@@ -73,7 +72,7 @@ async fn spawn_concurrent_node(
     join_set: &mut tokio::task::JoinSet<(Uuid, TaskResult)>,
     graph: &mut crate::dag_engine::domain::TaskGraph,
     event_bus: &Arc<dyn EventBusService>,
-    sessions: &Mutex<HashMap<Uuid, ExecutionSession>>,
+    sessions: &Arc<Mutex<HashMap<Uuid, ExecutionSession>>>,
     dag_id: Uuid,
     node_id: Uuid,
     permission_enforcer: &Option<Arc<dyn PermissionEnforcer>>,
@@ -349,7 +348,7 @@ async fn spawn_concurrent_node(
 // ---------------------------------------------------------------------------
 
 /// Internal state for an active execution.
-struct ExecutionSession {
+pub(crate) struct ExecutionSession {
     /// Per-node execution states.
     node_states: HashMap<Uuid, NodeExecutionState>,
     /// IDs of nodes currently running in the JoinSet.
@@ -403,7 +402,11 @@ const GIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 pub struct ParallelExecutionServiceImpl {
     /// Active execution sessions keyed by dag_id.
-    sessions: Mutex<HashMap<Uuid, ExecutionSession>>,
+    ///
+    /// Shared via `Arc` so the ADR-011 session-graph intent resolver can
+    /// resolve step/node intents from the live run graph without holding a
+    /// reference back to the executor (no reference cycle).
+    sessions: Arc<Mutex<HashMap<Uuid, ExecutionSession>>>,
     /// Global executor config.
     config: ParallelExecutorConfig,
     /// Registered progress callbacks.
@@ -952,7 +955,7 @@ impl ParallelExecutionServiceImpl {
         event_bus: Arc<dyn EventBusService>,
     ) -> Self {
         Self {
-            sessions: Mutex::new(HashMap::new()),
+            sessions: Arc::new(Mutex::new(HashMap::new())),
             config,
             progress_callbacks: Mutex::new(Vec::new()),
             retry_service,
@@ -975,6 +978,11 @@ impl ParallelExecutionServiceImpl {
     pub fn with_permission_enforcer(mut self, enforcer: Arc<dyn PermissionEnforcer>) -> Self {
         self.permission_enforcer = Some(enforcer);
         self
+    }
+
+    /// Share the session map (ADR-011: session-graph intent resolver).
+    pub(crate) fn sessions_handle(&self) -> Arc<Mutex<HashMap<Uuid, ExecutionSession>>> {
+        Arc::clone(&self.sessions)
     }
 
     /// Set the recovery service for automatic failure recovery.
@@ -3292,5 +3300,69 @@ impl RetryEvaluationService for RetryEvaluationServiceImpl {
                 attempt, failure_context.max_attempts, strategy, backoff_ms
             ),
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SessionGraphResolver — ADR-011 intent source for the production binding
+// ---------------------------------------------------------------------------
+
+/// Resolves step/node intents from the executor's LIVE sessions.
+///
+/// Implementation-level `NodeIntentResolver` used to build the production
+/// `ApprovalServiceImpl`: `resolve_by_node_id` looks up the node in any
+/// active session's sealed graph; `resolve_by_step_name` matches a session
+/// node currently blocked at the approval gate (AwaitingApproval /
+/// IntentMismatch). Reads only the shared session map — no reference back to
+/// the executor, so no Arc cycle.
+#[derive(Clone)]
+pub(crate) struct SessionGraphResolver {
+    sessions: Arc<Mutex<HashMap<Uuid, ExecutionSession>>>,
+}
+
+impl SessionGraphResolver {
+    /// Attach a resolver to an executor's shared session map.
+    pub(crate) fn new(sessions: Arc<Mutex<HashMap<Uuid, ExecutionSession>>>) -> Self {
+        Self { sessions }
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::approval::application::NodeIntentResolver for SessionGraphResolver {
+    async fn resolve_by_step_name(&self, step_name: &str) -> Option<ResolvedNode> {
+        let map = self.sessions.lock().ok()?;
+        for session in map.values() {
+            if let Some((node_id, _)) = session.node_states.iter().find(|(_, st)| {
+                st.node_name == step_name
+                    && (st.status == NodeStatus::AwaitingApproval
+                        || st.status == NodeStatus::IntentMismatch)
+            }) && let Some(node) = session.graph.as_ref().and_then(|g| g.get_node(*node_id))
+            {
+                return Some(ResolvedNode {
+                    node_id: *node_id,
+                    step_name: step_name.to_string(),
+                    intent: crate::approval::domain::ExecutionIntent::from_node(node),
+                });
+            }
+        }
+        None
+    }
+
+    async fn resolve_by_node_id(&self, node_id: Uuid) -> Option<ResolvedNode> {
+        let map = self.sessions.lock().ok()?;
+        for session in map.values() {
+            if let Some(node) = session.graph.as_ref().and_then(|g| g.get_node(node_id)) {
+                return Some(ResolvedNode {
+                    node_id,
+                    step_name: session
+                        .node_states
+                        .get(&node_id)
+                        .map(|st| st.node_name.clone())
+                        .unwrap_or_else(|| node.name.clone()),
+                    intent: crate::approval::domain::ExecutionIntent::from_node(node),
+                });
+            }
+        }
+        None
     }
 }

--- a/engine/src/execution_engine/approval_binding_tests.rs
+++ b/engine/src/execution_engine/approval_binding_tests.rs
@@ -337,3 +337,91 @@ async fn test_tampered_intent_halts_before_dispatch_and_reapproval_recovers() {
     let _ = std::fs::remove_file(&marker_a);
     let _ = std::fs::remove_file(&marker_b);
 }
+
+// ── Factory attach (production flip path) ───────────────────────────────────
+
+use crate::execution_engine::application::dto::ApproveNodeInput as ExecApproveNodeInput;
+use crate::execution_engine::application::factory::{
+    ApprovalBindingSetup, ParallelExecutionFactory, ParallelExecutionFactoryConfig,
+};
+use crate::execution_engine::application::factory_impl::ParallelExecutionFactoryImpl;
+
+/// ADR-011: the engine factory attaches the binding from
+/// `ParallelExecutionFactoryConfig.approval_binding` (the env-driven flip the
+/// CLI/action/MCP entry points use) — approve captures a record, the dispatch
+/// choke point verifies, and the record is consumed on terminal outcome.
+#[tokio::test]
+async fn test_factory_attached_binding_captures_verifies_consumes() {
+    let dag_id = Uuid::new_v4();
+    let node_id = Uuid::new_v4();
+    let marker = std::env::temp_dir().join(format!("approval-factory-{dag_id}.marker"));
+    let _ = std::fs::remove_file(&marker);
+    let graph = {
+        let mut g = TaskGraph::new();
+        g.add_unchecked(gated_run_node(
+            node_id,
+            "risky_step",
+            &format!("touch {}", marker.display()),
+        ))
+        .unwrap();
+        g.seal().unwrap();
+        g
+    };
+
+    let repo = Arc::new(InMemoryApprovalRepository::new());
+    let config = ParallelExecutionFactoryConfig {
+        executor_config: ParallelExecutorConfig::default(),
+        event_bus: Some(Arc::new(
+            crate::event_system::application::event_bus_service_impl::EventBusServiceImpl::default(
+            ),
+        )),
+        approval_binding: Some(ApprovalBindingSetup {
+            repository: repo.clone(),
+            run_key: b"engine-run-key".to_vec(),
+            ttl_seconds: 3600,
+        }),
+        ..ParallelExecutionFactoryConfig::default()
+    };
+    let executor: Box<dyn ParallelExecutionService> = ParallelExecutionFactoryImpl::new()
+        .create(config)
+        .await
+        .unwrap();
+
+    executor
+        .execute_graph(ExecuteGraphInput {
+            dag_id,
+            graph: Some(graph.clone()),
+            config_override: None,
+        })
+        .await
+        .unwrap();
+    let approve = executor
+        .approve_node(ExecApproveNodeInput {
+            dag_id,
+            step_names: vec!["risky_step".to_string()],
+            approver_id: Some("tester@org".into()),
+            authority: None,
+            decision_context: None,
+            token_claims_ref: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(approve.approved, vec!["risky_step".to_string()]);
+
+    executor
+        .resume_execution(ResumeExecutionInput { dag_id })
+        .await
+        .unwrap();
+    let state = executor
+        .get_execution_state(GetExecutionStateInput { dag_id })
+        .await
+        .unwrap();
+    assert!(state.is_complete);
+    assert!(
+        marker.exists(),
+        "verified intent dispatched via the factory path"
+    );
+    let record = repo.load(node_id).await.unwrap().expect("record present");
+    assert_eq!(record.status, ApprovalStatus::Consumed);
+    let _ = std::fs::remove_file(&marker);
+}

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -1006,6 +1006,7 @@ async fn build_real_engine(
             .create(ParallelExecutionFactoryConfig {
                 permission_enforcer,
                 hook_runner,
+                approval_binding: rigorix_engine::execution_engine::application::factory::ApprovalBindingSetup::from_env(std::path::Path::new(repo_root)),
                 ..ParallelExecutionFactoryConfig::default()
             })
             .await?,


### PR DESCRIPTION
## ADR-011 production flip

- Engine factory attaches the binding: `ParallelExecutionFactoryConfig.approval_binding` (repo + run key + TTL) with a live `SessionGraphResolver` over the shared session map (no Arc cycle) — approve/verify/consume active at the runtime choke point
- `ApprovalBindingSetup::from_env` + CLI/action/MCP wiring: `RIGORIX_APPROVAL_BINDING=1` (+ `RIGORIX_HMAC_KEY` = envelope key, TTL env, `.rigorix/approvals.json`). Default off = legacy gate unchanged
- Factory-path integration test (approve → verify → dispatch → consume)
- 1946 lib tests green; all 4 crates compile; clippy clean

Remaining for ADR-011 Accepted: boundary approve surfaces pass approver_id (engine denies without identity by design), envelope build path populates refs.