### PR TITLE
feat(mcp): rigorix_approve_execution surfaces approver identity (ADR-011 R3)

### DIFF
--- a/mcp/src/execution_tools/domain/entity.rs
+++ b/mcp/src/execution_tools/domain/entity.rs
@@ -115,6 +115,7 @@ pub trait EngineFacade: Send + Sync {
         &self,
         execution_id: &ExecutionId,
         step_names: Vec<String>,
+        identity: Option<crate::execution_tools::domain::value::ApprovalIdentity>,
     ) -> Result<ApprovalResult, EngineFacadeError>;
 
     /// Get the per-node state of an execution after it ran or resumed.

--- a/mcp/src/execution_tools/domain/value.rs
+++ b/mcp/src/execution_tools/domain/value.rs
@@ -701,6 +701,20 @@ pub struct StepCost {
 // ApprovalResult — outcome of a human sign-off on a paused execution
 // ---------------------------------------------------------------------------
 
+/// ADR-011 captured identity for an approval (R3).
+///
+/// With the approval binding enabled the approving identity is a required
+/// captured fact — the engine denies an approval that carries none.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ApprovalIdentity {
+    /// Human identity subject approving (see identity module).
+    pub approver_id: Option<String>,
+    /// Role / policy id (captured fact, not a judgment).
+    pub authority: Option<String>,
+    /// IdP token/claims presented at approval (credential-substitution check).
+    pub token_claims_ref: Option<String>,
+}
+
 /// Result of approving steps of an execution paused for human sign-off.
 ///
 /// Returned by `rigorix_approve_execution`. Indicates which steps were

--- a/mcp/src/execution_tools/infrastructure/engine_facade_impl.rs
+++ b/mcp/src/execution_tools/infrastructure/engine_facade_impl.rs
@@ -465,15 +465,16 @@ impl EngineFacade for EngineFacadeImpl {
         &self,
         execution_id: &ExecutionId,
         step_names: Vec<String>,
+        identity: Option<crate::execution_tools::domain::value::ApprovalIdentity>,
     ) -> Result<ApprovalResult, EngineFacadeError> {
         let output = self
             .orchestrator
             .approve_execution(ApproveExecutionInput {
                 execution_id: *execution_id.as_uuid(),
                 step_names,
-                approver_id: None,
-                authority: None,
-                token_claims_ref: None,
+                approver_id: identity.as_ref().and_then(|i| i.approver_id.clone()),
+                authority: identity.as_ref().and_then(|i| i.authority.clone()),
+                token_claims_ref: identity.as_ref().and_then(|i| i.token_claims_ref.clone()),
             })
             .await
             .map_err(|e| EngineFacadeError::Internal(e.to_string()))?;

--- a/mcp/src/execution_tools/interfaces/mcp/mod.rs
+++ b/mcp/src/execution_tools/interfaces/mcp/mod.rs
@@ -221,6 +221,18 @@ pub const RIGORIX_APPROVE_INPUT_SCHEMA: &str = r#"{
             "items": { "type": "string" },
             "minItems": 1,
             "description": "Step names to approve (human sign-off). Steps that declared requires_approval: true only run after approval."
+        },
+        "approver_id": {
+            "type": "string",
+            "description": "Optional — identity subject of the human approving. Required when the ADR-011 approval binding is enabled (R3: identity is a captured fact; the engine denies approval without it)."
+        },
+        "authority": {
+            "type": "string",
+            "description": "Optional — role/policy id of the approver (captured fact)."
+        },
+        "token_claims_ref": {
+            "type": "string",
+            "description": "Optional — IdP token/claims presented at approval (credential-substitution check)."
         }
     },
     "required": ["execution_id", "step_names"]

--- a/mcp/src/execution_tools/tests.rs
+++ b/mcp/src/execution_tools/tests.rs
@@ -161,6 +161,7 @@ mod tests {
             &self,
             execution_id: &ExecutionId,
             step_names: Vec<String>,
+            _identity: Option<crate::execution_tools::domain::value::ApprovalIdentity>,
         ) -> Result<crate::execution_tools::domain::value::ApprovalResult, EngineFacadeError>
         {
             Ok(crate::execution_tools::domain::value::ApprovalResult::new(

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -454,9 +454,24 @@ impl AppState {
                     }));
                 }
 
+                use rigorix_mcp::execution_tools::domain::value::ApprovalIdentity;
+                let identity = ApprovalIdentity {
+                    approver_id: params["approver_id"].as_str().map(|s| s.to_string()),
+                    authority: params["authority"].as_str().map(|s| s.to_string()),
+                    token_claims_ref: params["token_claims_ref"].as_str().map(|s| s.to_string()),
+                };
+                let identity = (identity.approver_id.is_some()
+                    || identity.authority.is_some()
+                    || identity.token_claims_ref.is_some())
+                .then_some(identity);
+
                 let approval = self
                     .engine
-                    .approve_execution(&ExecutionId::from_uuid(execution_id), step_names)
+                    .approve_execution(
+                        &ExecutionId::from_uuid(execution_id),
+                        step_names,
+                        identity,
+                    )
                     .await
                     .map_err(|e| serde_json::json!({"error": e.to_string()}))?;
 

--- a/mcp/tests/execution_tools_tdd_test.rs
+++ b/mcp/tests/execution_tools_tdd_test.rs
@@ -121,6 +121,7 @@ impl EngineFacade for TddMockEngine {
         &self,
         execution_id: &ExecutionId,
         step_names: Vec<String>,
+        _identity: Option<rigorix_mcp::execution_tools::domain::value::ApprovalIdentity>,
     ) -> Result<rigorix_mcp::execution_tools::domain::value::ApprovalResult, EngineFacadeError>
     {
         Ok(

--- a/mcp/tests/unit/execution-tools/checkenforcementhandler-domain-service-/checkenforcementhandler-domain-service-_test.rs
+++ b/mcp/tests/unit/execution-tools/checkenforcementhandler-domain-service-/checkenforcementhandler-domain-service-_test.rs
@@ -76,6 +76,7 @@ impl EngineFacade for MockEngineForEnforcer {
         &self,
         execution_id: &ExecutionId,
         step_names: Vec<String>,
+        _identity: Option<rigorix_mcp::execution_tools::domain::value::ApprovalIdentity>,
     ) -> Result<rigorix_mcp::execution_tools::domain::value::ApprovalResult, EngineFacadeError>
     {
         Ok(

--- a/mcp/tests/unit/execution-tools/enginefacade-aggregate-root-/enginefacade-aggregate-root-_test.rs
+++ b/mcp/tests/unit/execution-tools/enginefacade-aggregate-root-/enginefacade-aggregate-root-_test.rs
@@ -95,6 +95,7 @@ impl EngineFacade for EngineFacadeTddContract {
         &self,
         execution_id: &ExecutionId,
         step_names: Vec<String>,
+        _identity: Option<rigorix_mcp::execution_tools::domain::value::ApprovalIdentity>,
     ) -> Result<rigorix_mcp::execution_tools::domain::value::ApprovalResult, EngineFacadeError>
     {
         Ok(

--- a/mcp/tests/unit/execution-tools/executehandler-domain-service-/executehandler-domain-service-_test.rs
+++ b/mcp/tests/unit/execution-tools/executehandler-domain-service-/executehandler-domain-service-_test.rs
@@ -84,6 +84,7 @@ impl EngineFacade for MockEngineForHandler {
         &self,
         execution_id: &ExecutionId,
         step_names: Vec<String>,
+        _identity: Option<rigorix_mcp::execution_tools::domain::value::ApprovalIdentity>,
     ) -> Result<rigorix_mcp::execution_tools::domain::value::ApprovalResult, EngineFacadeError>
     {
         Ok(

--- a/mcp/tests/unit/execution-tools/validateplanhandler-domain-service-/validateplanhandler-domain-service-_test.rs
+++ b/mcp/tests/unit/execution-tools/validateplanhandler-domain-service-/validateplanhandler-domain-service-_test.rs
@@ -70,6 +70,7 @@ impl EngineFacade for MockEngineForValidator {
         &self,
         execution_id: &ExecutionId,
         step_names: Vec<String>,
+        _identity: Option<rigorix_mcp::execution_tools::domain::value::ApprovalIdentity>,
     ) -> Result<rigorix_mcp::execution_tools::domain::value::ApprovalResult, EngineFacadeError>
     {
         Ok(


### PR DESCRIPTION
## Final slice: boundary identity surface

- \`rigorix_approve_execution\` schema + handler accept optional \`approver_id\` / \`authority\` / \`token_claims_ref\`
- \`EngineFacade::approve_execution\` threads an \`ApprovalIdentity\` through the orchestrator to the engine (R3 captured at the real tool boundary)
- Engine denies identity-less approval when the binding is on (by design)
- 1948 engine lib tests + 87 mcp lib tests green; clippy clean