### PR TITLE
fix(approval): wire the evidence producers — ApprovalRecorded + ScopeViolationRecorded now publish

### DIFF
--- a/engine/src/approval/domain/intent.rs
+++ b/engine/src/approval/domain/intent.rs
@@ -59,14 +59,26 @@ impl ExecutionIntent {
     /// - **Populated:** tool + intent from a sealed graph node
     /// - **Error:** node missing tool or intent
     pub fn from_node(node: &TaskNode) -> Self {
-        let intent = serde_json::from_str(&node.intent)
-            .unwrap_or_else(|_| Value::String(node.intent.clone()));
+        let parsed = serde_json::from_str::<Value>(&node.intent).ok();
+        let declared_scope = parsed
+            .as_ref()
+            .and_then(|v| v.get("declared_scope"))
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|s| s.as_str().map(|x| x.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let intent = parsed.unwrap_or_else(|| Value::String(node.intent.clone()));
         Self {
             tool: node.tool.clone(),
             intent,
-            // The declared effect scope is declared at approval time, not on
-            // the raw node; a bare sealed node declares no scope.
-            declared_scope: Vec::new(),
+            // The declared effect scope may be declared in the node's resolved
+            // payload (`declared_scope: [..]`) — e.g. set by the planner or
+            // the approve surface. A bare sealed node without one declares no
+            // scope (R5 then has nothing to verify against).
+            declared_scope,
         }
     }
 

--- a/engine/src/execution_engine/application/service_impl.rs
+++ b/engine/src/execution_engine/application/service_impl.rs
@@ -639,7 +639,8 @@ impl ParallelExecutionServiceImpl {
                 if let Some(baseline) = &scope_baseline
                     && let Some(repo) = &config.approval_repo_path
                 {
-                    self.effect_scope_check(node_id, repo, baseline).await;
+                    self.effect_scope_check(dag_id, node_id, repo, baseline)
+                        .await;
                 }
             }
 
@@ -840,7 +841,13 @@ impl ParallelExecutionServiceImpl {
     /// Compares the run's net git changes against the approved record's
     /// declared scope and forwards any violation to the binding (non-blocking;
     /// the blocking check is R2 verification at the choke point).
-    async fn effect_scope_check(&self, node_id: Uuid, repo_path: &str, baseline: &ChangeSnapshot) {
+    async fn effect_scope_check(
+        &self,
+        dag_id: Uuid,
+        node_id: Uuid,
+        repo_path: &str,
+        baseline: &ChangeSnapshot,
+    ) {
         let Some(binding) = &self.approval_binding else {
             return;
         };
@@ -882,7 +889,21 @@ impl ParallelExecutionServiceImpl {
                 out_of_scope = ?violation.out_of_scope,
                 "effect-scope violation recorded (non-blocking evidence)"
             );
-            let _ = binding.service.record_scope_violation(violation).await;
+            let _ = binding
+                .service
+                .record_scope_violation(violation.clone())
+                .await;
+            // ADR-011 R5: publish ScopeViolationRecorded — the drained events
+            // are the source the audit envelope derives `scope_violations[]`
+            // from.
+            self.publish_event(ExecutionEvent::ScopeViolationRecorded {
+                execution_id: dag_id,
+                node_id: violation.node_id.to_string(),
+                step_name: violation.step_name.clone(),
+                out_of_scope: violation.out_of_scope.clone(),
+                timestamp: chrono::Utc::now(),
+            })
+            .await;
         }
     }
 
@@ -2852,6 +2873,29 @@ impl ParallelExecutionService for ParallelExecutionServiceImpl {
                         if !approved.contains(name) {
                             denied.push(name.clone());
                         }
+                    }
+                    // ADR-011 R3: publish ApprovalRecorded for every persisted
+                    // record — the drained events are the source the audit
+                    // envelope derives `approval_events[]` from.
+                    for record in &out.approval_records {
+                        let decision_context_ref =
+                            if record.decision_context.summary.trim().is_empty() {
+                                None
+                            } else {
+                                Some(record.decision_context.summary.clone())
+                            };
+                        self.publish_event(ExecutionEvent::ApprovalRecorded {
+                            execution_id: input.dag_id,
+                            node_id: record.node_id.to_string(),
+                            step_name: record.step_name.clone(),
+                            intent_hash: record.intent_hash.0.clone(),
+                            approver_id: record.approver_id.clone(),
+                            authority: record.authority.clone(),
+                            decided_at: record.decided_at,
+                            decision_context_ref,
+                            timestamp: chrono::Utc::now(),
+                        })
+                        .await;
                     }
                 }
                 None => {

--- a/engine/src/execution_engine/approval_binding_tests.rs
+++ b/engine/src/execution_engine/approval_binding_tests.rs
@@ -425,3 +425,183 @@ async fn test_factory_attached_binding_captures_verifies_consumes() {
     assert_eq!(record.status, ApprovalStatus::Consumed);
     let _ = std::fs::remove_file(&marker);
 }
+
+// ── Producer proofs: ApprovalRecorded + ScopeViolationRecorded reach the bus ─
+
+use crate::event_system::application::dto::DrainPersistedInput;
+use crate::event_system::domain::ExecutionEvent as EngineEvent;
+
+fn init_git(repo: &PathBuf) {
+    use std::process::Command;
+    for args in [
+        vec!["init", "-q", "-b", "main"],
+        vec!["config", "user.email", "t@t"],
+        vec!["config", "user.name", "t"],
+    ] {
+        let out = Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(&args)
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "{args:?}");
+    }
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["add", "-A"])
+        .status()
+        .unwrap();
+    assert!(out.success());
+}
+
+/// The R3 + R5 producers are real: after a bound approve→run cycle the event
+/// bus carries ApprovalRecorded (from the approve capture) and
+/// ScopeViolationRecorded (from the git-diff oracle on the out-of-scope
+/// side-effect). These drained events are exactly what the audit envelope
+/// derives `approval_events[]` / `scope_violations[]` from.
+#[tokio::test]
+async fn test_bound_cycle_publishes_approval_and_scope_events() {
+    let dag_id = Uuid::new_v4();
+    let node_id = Uuid::new_v4();
+    let repo_dir = std::env::temp_dir().join(format!("approval-scope-repo-{dag_id}"));
+    let _ = std::fs::remove_dir_all(&repo_dir);
+    std::fs::create_dir_all(repo_dir.join("docs")).unwrap();
+    std::fs::write(repo_dir.join("docs/readme.md"), "x").unwrap();
+    init_git(&repo_dir);
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&repo_dir)
+        .args(["commit", "-q", "-m", "base"])
+        .status()
+        .unwrap();
+    assert!(out.success());
+
+    // Node declares docs/ scope but the command side-effects src/leak.ts —
+    // outside the declared scope (the R5 git-diff oracle must flag it).
+    let side_effect = repo_dir.join("src/leak.ts");
+    std::fs::create_dir_all(repo_dir.join("src")).unwrap();
+    let graph = {
+        let mut g = TaskGraph::new();
+        let intent = serde_json::json!({
+            "command": format!("touch {}", side_effect.display()),
+            "declared_scope": ["docs/"]
+        });
+        g.add_unchecked(
+            TaskNode::new(
+                node_id,
+                "run_script",
+                "run_command",
+                vec![],
+                intent.to_string(),
+            )
+            .with_requires_approval(true),
+        )
+        .unwrap();
+        g.seal().unwrap();
+        g
+    };
+
+    let repo = Arc::new(InMemoryApprovalRepository::new());
+    let bus = Arc::new(
+        crate::event_system::application::event_bus_service_impl::EventBusServiceImpl::default(),
+    );
+    let config = ParallelExecutionFactoryConfig {
+        executor_config: ParallelExecutorConfig {
+            approval_repo_path: Some(repo_dir.to_str().unwrap().to_string()),
+            ..ParallelExecutorConfig::default()
+        },
+        event_bus: Some(bus.clone()),
+        approval_binding: Some(ApprovalBindingSetup {
+            repository: repo.clone(),
+            run_key: b"engine-run-key".to_vec(),
+            ttl_seconds: 3600,
+        }),
+        ..ParallelExecutionFactoryConfig::default()
+    };
+    let executor: Box<dyn ParallelExecutionService> = ParallelExecutionFactoryImpl::new()
+        .create(config)
+        .await
+        .unwrap();
+
+    executor
+        .execute_graph(ExecuteGraphInput {
+            dag_id,
+            graph: Some(graph.clone()),
+            config_override: None,
+        })
+        .await
+        .unwrap();
+    let approve = executor
+        .approve_node(ExecApproveNodeInput {
+            dag_id,
+            step_names: vec!["run_script".to_string()],
+            approver_id: Some("tester@org".into()),
+            authority: Some("role:operator".into()),
+            decision_context: None,
+            token_claims_ref: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(approve.approved, vec!["run_script".to_string()]);
+    executor
+        .resume_execution(ResumeExecutionInput { dag_id })
+        .await
+        .unwrap();
+    let state = executor
+        .get_execution_state(GetExecutionStateInput { dag_id })
+        .await
+        .unwrap();
+    assert!(state.is_complete);
+    assert!(side_effect.exists(), "command ran (the R5 side-effect)");
+
+    // Both producers must have published onto the bus.
+    use crate::event_system::application::EventBusService;
+    let bus_dyn: Arc<dyn EventBusService> = bus.clone();
+    let drained = bus_dyn
+        .drain_persisted(DrainPersistedInput { clear: false })
+        .await
+        .unwrap();
+    let mut saw_approval = false;
+    let mut saw_scope = false;
+    for pe in &drained.events {
+        match &pe.event {
+            EngineEvent::ApprovalRecorded {
+                step_name,
+                approver_id,
+                intent_hash,
+                ..
+            } => {
+                saw_approval = true;
+                assert_eq!(step_name, "run_script");
+                assert_eq!(approver_id, "tester@org");
+                assert!(!intent_hash.is_empty());
+            }
+            EngineEvent::ScopeViolationRecorded {
+                step_name,
+                out_of_scope,
+                ..
+            } => {
+                saw_scope = true;
+                assert_eq!(step_name, "run_script");
+                assert!(
+                    out_of_scope.iter().any(|p| p.ends_with("src/leak.ts")),
+                    "{out_of_scope:?}"
+                );
+            }
+            _ => {}
+        }
+    }
+    assert!(
+        saw_approval,
+        "ApprovalRecorded must be published by the bound approve path"
+    );
+    assert!(
+        saw_scope,
+        "ScopeViolationRecorded must be published by the R5 oracle hook"
+    );
+
+    let record = repo.load(node_id).await.unwrap().expect("record");
+    assert_eq!(record.status, ApprovalStatus::Consumed);
+    let _ = std::fs::remove_dir_all(&repo_dir);
+}


### PR DESCRIPTION
## Adjudication fix — the evidence leg now has producers

Adjudicator was right: emission claims were schema + consumer code with no producer (only IntentMismatchDetected published; R5 ended in the no-op sink; from_node never carried declared_scope so R5 could not fire).

1. Bound approve → publishes \`ApprovalRecorded\` per persisted record
2. Engine effect-scope hook → publishes \`ScopeViolationRecorded\` (dag/node/step/out_of_scope)
3. \`ExecutionIntent::from_node\` surfaces \`declared_scope\` from the node payload
4. Producer-proof test: real approve→run→drain asserts both events present + record Consumed

1949 lib tests + 58 approval unit tests green; clippy clean.