### PR TITLE
fix(fmt): cargo fmt the merged approval-wiring lines (mcp/cli/actions)

### DIFF
--- a/actions/src/main.rs
+++ b/actions/src/main.rs
@@ -381,7 +381,10 @@ async fn build_action_orchestrator(
         }
     };
     let hook_runner = load_hook_runner(repo_root);
-    let approval_binding = rigorix_engine::execution_engine::application::factory::ApprovalBindingSetup::from_env(std::path::Path::new(repo_root));
+    let approval_binding =
+        rigorix_engine::execution_engine::application::factory::ApprovalBindingSetup::from_env(
+            std::path::Path::new(repo_root),
+        );
     let execution = ParallelExecutionFactoryImpl
         .create(ParallelExecutionFactoryConfig {
             executor_config: ParallelExecutorConfig {

--- a/cli/src/cli_boundary/orchestrator.rs
+++ b/cli/src/cli_boundary/orchestrator.rs
@@ -303,7 +303,10 @@ pub async fn build_orchestrator_with_budget(
         }
     };
     let hook_runner = load_hook_runner(repo_root.as_str());
-    let approval_binding = rigorix_engine::execution_engine::application::factory::ApprovalBindingSetup::from_env(std::path::Path::new(&repo_root));
+    let approval_binding =
+        rigorix_engine::execution_engine::application::factory::ApprovalBindingSetup::from_env(
+            std::path::Path::new(&repo_root),
+        );
     let execution = ParallelExecutionFactoryImpl
         .create(ParallelExecutionFactoryConfig {
             executor_config: ParallelExecutorConfig {

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -467,11 +467,7 @@ impl AppState {
 
                 let approval = self
                     .engine
-                    .approve_execution(
-                        &ExecutionId::from_uuid(execution_id),
-                        step_names,
-                        identity,
-                    )
+                    .approve_execution(&ExecutionId::from_uuid(execution_id), step_names, identity)
                     .await
                     .map_err(|e| serde_json::json!({"error": e.to_string()}))?;
 


### PR DESCRIPTION
**cargo fmt drift from the merged approval wiring PRs** — caught by the first full local-ci since #813/#815 (7 failures, all the same drift).

- `#813` merged the `ApprovalBindingSetup::from_env(...)` lines unformatted in `cli/src/cli_boundary/orchestrator.rs:303` + `actions/src/main.rs:381`
- `#815` merged the `approve_execution(...)` call unformatted in `mcp/src/main.rs:467`
- engine (`#816`) was fmt-clean, hence only mcp/cli/actions failed

Fix: `cargo fmt` on the three crates — 3 files, 9 insertions / 7 deletions. All four crates now pass `cargo fmt --check`. No behavior change.
