### PR TITLE
fix(ci): coverage.sh --lcov produced an empty percentage + wrong output dir

### DIFF
--- a/.pi/scripts/coverage.sh
+++ b/.pi/scripts/coverage.sh
@@ -18,7 +18,7 @@
 set -uo pipefail
 
 COVERAGE_THRESHOLD="${COVERAGE_THRESHOLD:-60}"
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 GATE=0
 LCOV=0
 
@@ -38,11 +38,10 @@ fi
 cd "$ROOT"
 
 echo "═══ Workspace coverage (cargo llvm-cov) ═══"
+SUMMARY="$(cargo llvm-cov --workspace --summary-only)"
 if [ "$LCOV" -eq 1 ]; then
   mkdir -p target
-  SUMMARY="$(cargo llvm-cov --workspace --summary-only --lcov --output-path target/coverage.lcov)"
-else
-  SUMMARY="$(cargo llvm-cov --workspace --summary-only)"
+  cargo llvm-cov --workspace --lcov --output-path target/coverage.lcov >/dev/null 2>&1
 fi
 
 # Print the per-file table + TOTAL row (summary tail), then extract the


### PR DESCRIPTION
**The "pre-existing CI failure" the auth epic hit is real — two bugs in `coverage.sh`, now fixed.** Verified locally with the exact CI invocation before/after.

## Bug 1 — empty percentage (the CI failure)
`cargo llvm-cov --workspace --summary-only --lcov --output-path X` writes the lcov report to the file and leaves stdout with **no summary** — so `COVERAGE=""` → `Line coverage: % (threshold: 60%)` → awk syntax error → gate fails on every push.

Reproduced:
```
Line coverage: % (threshold: 60%)
awk: syntax error at source line 1
✗ Coverage below threshold (% < 60%)
```

Fix: extract the % from a plain `--summary-only` run, then export the lcov report as a separate step.

## Bug 2 — lcov written to the wrong directory
`ROOT` was computed one level short (`dirname(.pi/scripts/coverage.sh)/..` = `.pi`, not the repo root) — so the export landed in `.pi/target/coverage.lcov` and the CI `upload-artifact` step (`path: target/coverage.lcov`, `if-no-files-found: error`) would fail too. Fix: `../..`.

## Verified
```
$ bash .pi/scripts/coverage.sh --gate --lcov
Line coverage: 79.04% (threshold: 60%)
✓ Coverage gate passed
$ ls -la target/coverage.lcov
4542919 target/coverage.lcov
```

(also cleaned the stray `.pi/target/` dir from the buggy runs)
