### PR TITLE
[Issue #842] ISSUE-SEQUENCE-POLICY-4: Implement StepPredicate matching

### DIFF
--- a/engine/src/sequence_policy/application/service_impl.rs
+++ b/engine/src/sequence_policy/application/service_impl.rs
@@ -38,7 +38,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::sequence_policy::domain::{
-    ParamMatchKind, ParamPredicate, SequenceMatch, SequencePolicyError, SequenceRule, StepPredicate,
+    SequenceMatch, SequencePolicyError, SequenceRule, StepPredicate,
 };
 use crate::sequence_policy::infrastructure::repository::SequencePolicyRepository;
 
@@ -204,105 +204,22 @@ fn match_rule(
     Ok(matches)
 }
 
-/// Whether a step predicate matches one step view (tool + parameter
-/// predicates). An invalid regex in a parameter predicate is a config error
-/// (fail closed).
+/// Whether a step predicate matches one step view. Delegates the
+/// tool + parameter matching to the domain component (`StepPredicate::matches`,
+/// domain/rule.rs) — single source of truth for predicate semantics.
 fn predicate_matches(
     predicate: &StepPredicate,
     step: &StepView<'_>,
 ) -> Result<bool, SequencePolicyError> {
-    if !tool_matches(&predicate.tool, step.tool) {
-        return Ok(false);
-    }
-    for pp in &predicate.params {
-        match json_pointer_lookup(step.params, &pp.pointer) {
-            // The pointed-to parameter is absent → the predicate does not
-            // match (non-matching params must not match).
-            None => return Ok(false),
-            Some(actual) => {
-                if !value_matches(actual, pp)? {
-                    return Ok(false);
-                }
-            }
-        }
-    }
-    Ok(true)
-}
-
-/// Exact or glob (`*` wildcard) tool-name match.
-fn tool_matches(pattern: &str, tool: &str) -> bool {
-    if !pattern.contains('*') {
-        return pattern == tool;
-    }
-    let p: Vec<char> = pattern.chars().collect();
-    let t: Vec<char> = tool.chars().collect();
-    let (mut pi, mut ti) = (0usize, 0usize);
-    let mut star: Option<usize> = None;
-    let mut backtrack_ti = 0usize;
-    while ti < t.len() {
-        if pi < p.len() && (p[pi] == '*' || p[pi] == t[ti]) {
-            if p[pi] == '*' {
-                star = Some(pi);
-                backtrack_ti = ti;
-                pi += 1;
-            } else {
-                pi += 1;
-                ti += 1;
-            }
-        } else if let Some(star_pi) = star {
-            pi = star_pi + 1;
-            backtrack_ti += 1;
-            ti = backtrack_ti;
-        } else {
-            return false;
-        }
-    }
-    while pi < p.len() && p[pi] == '*' {
-        pi += 1;
-    }
-    pi == p.len()
-}
-
-/// Resolve a JSON pointer (`/a/b`) against a value object. Array-index
-/// segments are not part of the frozen step-parameter schema.
-fn json_pointer_lookup<'a>(value: &'a Value, pointer: &str) -> Option<&'a Value> {
-    if pointer.is_empty() {
-        return Some(value);
-    }
-    let mut current = value;
-    for segment in pointer.split('/').skip(1) {
-        match current {
-            Value::Object(map) => current = map.get(segment)?,
-            _ => return None,
-        }
-    }
-    Some(current)
-}
-
-/// Apply a parameter predicate's kind (exact / glob / regex) to an actual
-/// value. Invalid regex patterns surface as a config error (fail closed).
-fn value_matches(actual: &Value, predicate: &ParamPredicate) -> Result<bool, SequencePolicyError> {
-    let text = match actual {
-        Value::String(s) => s.clone(),
-        other => other.to_string(),
-    };
-    match predicate.kind {
-        ParamMatchKind::Exact => Ok(text == predicate.value),
-        ParamMatchKind::Glob => Ok(tool_matches(&predicate.value, &text)),
-        ParamMatchKind::Regex => match regex::Regex::new(&predicate.value) {
-            Ok(re) => Ok(re.is_match(&text)),
-            Err(e) => Err(SequencePolicyError::InvalidConfig(format!(
-                "regex predicate '{}' failed to compile: {e}",
-                predicate.value
-            ))),
-        },
-    }
+    predicate.matches(step.tool, step.params)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sequence_policy::domain::{RuleAction, SafetyCaps, SequencePolicyConfig};
+    use crate::sequence_policy::domain::{
+        ParamMatchKind, ParamPredicate, RuleAction, SafetyCaps, SequencePolicyConfig,
+    };
     use serde_json::json;
 
     /// In-memory test repository serving a fixed config / outcome.

--- a/engine/src/sequence_policy/domain/rule.rs
+++ b/engine/src/sequence_policy/domain/rule.rs
@@ -32,6 +32,9 @@
 //!   data contract is frozen here
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::error::SequencePolicyError;
 
 /// Action taken on the later matched step of a rule.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -81,6 +84,110 @@ pub struct StepPredicate {
     pub params: Vec<ParamPredicate>,
 }
 
+impl StepPredicate {
+    /// Whether a step (tool + parameter object) satisfies this predicate.
+    ///
+    /// # Matching contract (AC row 2)
+    /// - `tool` matches exactly or by glob (`*` wildcard, e.g.
+    ///   `registration_*`)
+    /// - Every parameter predicate must match: its JSON pointer is resolved
+    ///   against the step's parameter object, then the actual value is
+    ///   compared by `kind` — exact string equality, glob, or regex
+    /// - A **missing** pointed-to parameter or a non-matching value → the
+    ///   predicate does **not** match
+    /// - A predicate with no parameter predicates matches on tool alone
+    ///
+    /// # Errors
+    /// - `SequencePolicyError::InvalidConfig` — a `regex` parameter predicate
+    ///   fails to compile (operator config error; fail closed)
+    pub fn matches(&self, tool: &str, parameters: &Value) -> Result<bool, SequencePolicyError> {
+        if !tool_matches(&self.tool, tool) {
+            return Ok(false);
+        }
+        for pp in &self.params {
+            match json_pointer_lookup(parameters, &pp.pointer) {
+                Some(actual) => {
+                    if !value_matches(actual, pp)? {
+                        return Ok(false);
+                    }
+                }
+                None => return Ok(false),
+            }
+        }
+        Ok(true)
+    }
+}
+
+/// Exact or glob (`*` wildcard) string match.
+fn tool_matches(pattern: &str, text: &str) -> bool {
+    if !pattern.contains('*') {
+        return pattern == text;
+    }
+    let p: Vec<char> = pattern.chars().collect();
+    let t: Vec<char> = text.chars().collect();
+    let (mut pi, mut ti) = (0usize, 0usize);
+    let mut star: Option<usize> = None;
+    let mut backtrack_ti = 0usize;
+    while ti < t.len() {
+        if pi < p.len() && (p[pi] == '*' || p[pi] == t[ti]) {
+            if p[pi] == '*' {
+                star = Some(pi);
+                backtrack_ti = ti;
+                pi += 1;
+            } else {
+                pi += 1;
+                ti += 1;
+            }
+        } else if let Some(star_pi) = star {
+            pi = star_pi + 1;
+            backtrack_ti += 1;
+            ti = backtrack_ti;
+        } else {
+            return false;
+        }
+    }
+    while pi < p.len() && p[pi] == '*' {
+        pi += 1;
+    }
+    pi == p.len()
+}
+
+/// Resolve a JSON pointer (`/a/b`) against a value object. Array-index
+/// segments are not part of the frozen step-parameter schema.
+fn json_pointer_lookup<'a>(value: &'a Value, pointer: &str) -> Option<&'a Value> {
+    if pointer.is_empty() {
+        return Some(value);
+    }
+    let mut current = value;
+    for segment in pointer.split('/').skip(1) {
+        match current {
+            Value::Object(map) => current = map.get(segment)?,
+            _ => return None,
+        }
+    }
+    Some(current)
+}
+
+/// Apply a parameter predicate's kind (exact / glob / regex) to an actual
+/// value. Invalid regex patterns surface as a config error (fail closed).
+fn value_matches(actual: &Value, predicate: &ParamPredicate) -> Result<bool, SequencePolicyError> {
+    let text = match actual {
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    };
+    match predicate.kind {
+        ParamMatchKind::Exact => Ok(text == predicate.value),
+        ParamMatchKind::Glob => Ok(tool_matches(&predicate.value, &text)),
+        ParamMatchKind::Regex => match regex::Regex::new(&predicate.value) {
+            Ok(re) => Ok(re.is_match(&text)),
+            Err(e) => Err(SequencePolicyError::InvalidConfig(format!(
+                "regex predicate '{}' failed to compile: {e}",
+                predicate.value
+            ))),
+        },
+    }
+}
+
 /// One declarative rule over an ordered step sequence.
 ///
 /// Example (the conference case from the module spec):
@@ -119,6 +226,7 @@ pub struct SequenceRule {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     /// The canonical conference rule exactly as an operator authors it in
     /// `.rigorix/sequence-policy.toml` (module spec §Configuration).
@@ -227,5 +335,181 @@ steps = [
         )
         .expect("regex rule parses");
         assert_eq!(regex_rule.steps[0].params[0].kind, ParamMatchKind::Regex);
+    }
+    // ── StepPredicate::matches (AC row 2) ──────────────────────────────────
+
+    fn predicate(tool: &str, params: Vec<ParamPredicate>) -> StepPredicate {
+        StepPredicate {
+            tool: tool.to_string(),
+            params,
+        }
+    }
+
+    fn param(pointer: &str, kind: ParamMatchKind, value: &str) -> ParamPredicate {
+        ParamPredicate {
+            pointer: pointer.to_string(),
+            kind,
+            value: value.to_string(),
+        }
+    }
+
+    #[test]
+    fn step_predicate_tool_exact_match() {
+        let p = predicate("registration_remove", vec![]);
+        assert!(p.matches("registration_remove", &json!({})).expect("m"));
+        assert!(!p.matches("registration_add", &json!({})).expect("m"));
+    }
+
+    #[test]
+    fn step_predicate_tool_glob_match() {
+        let p = predicate("registration_*", vec![]);
+        assert!(p.matches("registration_remove", &json!({})).expect("m"));
+        assert!(p.matches("registration_add", &json!({})).expect("m"));
+        // Glob is not a substring match — must anchor at the start.
+        assert!(!p.matches("audit_registration_add", &json!({})).expect("m"));
+        assert!(!p.matches("registration", &json!({})).expect("m"));
+    }
+
+    #[test]
+    fn step_predicate_param_exact_match_and_non_match() {
+        let p = predicate(
+            "registration_remove",
+            vec![param("/event_id", ParamMatchKind::Exact, "conf-2026")],
+        );
+        // Matching param value.
+        assert!(
+            p.matches("registration_remove", &json!({ "event_id": "conf-2026" }))
+                .expect("m")
+        );
+        // Non-matching param value → no match.
+        assert!(
+            !p.matches("registration_remove", &json!({ "event_id": "conf-2025" }))
+                .expect("m")
+        );
+        // Missing pointed-to parameter → no match.
+        assert!(
+            !p.matches("registration_remove", &json!({ "other": "x" }))
+                .expect("m")
+        );
+        // Tool mismatch is decisive even when params would match.
+        assert!(
+            !p.matches("registration_add", &json!({ "event_id": "conf-2026" }))
+                .expect("m")
+        );
+    }
+
+    #[test]
+    fn step_predicate_param_glob_and_regex_kinds() {
+        let glob = predicate(
+            "registration_add",
+            vec![param("/event_id", ParamMatchKind::Glob, "conf-*")],
+        );
+        assert!(
+            glob.matches("registration_add", &json!({ "event_id": "conf-2026" }))
+                .expect("m")
+        );
+        assert!(
+            !glob
+                .matches(
+                    "registration_add",
+                    &json!({ "event_id": "unconference-2026" })
+                )
+                .expect("m")
+        );
+
+        let regex = predicate(
+            "user_delete",
+            vec![param("/email", ParamMatchKind::Regex, "^admin@")],
+        );
+        assert!(
+            regex
+                .matches("user_delete", &json!({ "email": "admin@example.com" }))
+                .expect("m")
+        );
+        assert!(
+            !regex
+                .matches("user_delete", &json!({ "email": "user@example.com" }))
+                .expect("m")
+        );
+    }
+
+    #[test]
+    fn step_predicate_all_param_predicates_must_match() {
+        let p = predicate(
+            "registration_add",
+            vec![
+                param("/event_id", ParamMatchKind::Exact, "conf-2026"),
+                param("/seat_class", ParamMatchKind::Exact, "vip"),
+            ],
+        );
+        assert!(
+            p.matches(
+                "registration_add",
+                &json!({ "event_id": "conf-2026", "seat_class": "vip" }),
+            )
+            .expect("m")
+        );
+        // One of several predicates failing → no match.
+        assert!(
+            !p.matches(
+                "registration_add",
+                &json!({ "event_id": "conf-2026", "seat_class": "economy" }),
+            )
+            .expect("m")
+        );
+    }
+
+    #[test]
+    fn step_predicate_non_string_values_compare_as_strings() {
+        // Numeric / boolean params compare via their string form.
+        let p = predicate(
+            "grant_role",
+            vec![param("/role_id", ParamMatchKind::Exact, "42")],
+        );
+        assert!(
+            p.matches("grant_role", &json!({ "role_id": 42 }))
+                .expect("m")
+        );
+        let glob = predicate(
+            "grant_role",
+            vec![param("/role_id", ParamMatchKind::Glob, "4*")],
+        );
+        assert!(
+            glob.matches("grant_role", &json!({ "role_id": 42 }))
+                .expect("m")
+        );
+    }
+
+    #[test]
+    fn step_predicate_nested_pointer_and_absent_predicate_list() {
+        let p = predicate(
+            "run_command",
+            vec![param("/env/region", ParamMatchKind::Exact, "eu")],
+        );
+        assert!(
+            p.matches("run_command", &json!({ "env": { "region": "eu" } }))
+                .expect("m")
+        );
+        assert!(
+            !p.matches("run_command", &json!({ "env": { "region": "us" } }))
+                .expect("m")
+        );
+        // No params → any parameters acceptable (tool-only predicate).
+        let tool_only = predicate("run_command", vec![]);
+        assert!(
+            tool_only
+                .matches("run_command", &json!({ "anything": [1, 2, 3] }))
+                .expect("m")
+        );
+    }
+
+    #[test]
+    fn step_predicate_invalid_regex_is_a_config_error() {
+        let p = predicate("x", vec![param("/a", ParamMatchKind::Regex, "(unclosed")]);
+        let err = p
+            .matches("x", &json!({ "a": "b" }))
+            .expect_err("fail closed");
+        assert!(matches!(err, SequencePolicyError::InvalidConfig(_)));
+        assert!(!err.is_retriable());
     }
 }


### PR DESCRIPTION
## Issue Closeout

Closes #842 (epic: sequence-policy, tracking #837)

### Summary

Implements **StepPredicate** matching (AC row 2) as the domain component's behavior: `StepPredicate::matches(tool, parameters)`.

- Tool matches exactly or by glob (`*` wildcard)
- Every parameter predicate must match: JSON pointer → exact / glob / regex value kinds; **missing or non-matching params do not match**
- Invalid regex in a parameter predicate → `SequencePolicyError::InvalidConfig` (fail closed)
- `service_impl` matching now delegates to `StepPredicate::matches` (single source of truth; duplicated helpers removed)
- 9 new in-crate unit tests (exact/glob tool, param exact/glob/regex, all-predicates-must-match, non-string values as strings, nested pointers, invalid-regex fail-closed)

### Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Tool glob + param exact/glob/regex match correctly; non-matching params do not match | ✅ | `step_predicate_tool_exact_match`, `step_predicate_tool_glob_match`, `step_predicate_param_exact_match_and_non_match`, `step_predicate_param_glob_and_regex_kinds`, `step_predicate_all_param_predicates_must_match`, `step_predicate_non_string_values_compare_as_strings`, `step_predicate_nested_pointer_and_absent_predicate_list`, `step_predicate_invalid_regex_is_a_config_error` |

### Validator Results

| Validator | Status | Details |
|-----------|--------|---------|
| CI | ✅ | `validate-ci.sh` 5/5: build, full `cargo test -p rigorix-engine`, clippy `-D warnings`, fmt |

### Files Changed

- `engine/src/sequence_policy/domain/rule.rs` — `StepPredicate::matches` + matching helpers + 9 unit tests
- `engine/src/sequence_policy/application/service_impl.rs` — delegate to `StepPredicate::matches`

Refs: #842, #838, #837, ADR-013
