### PR TITLE
[Issue #845] ISSUE-SEQUENCE-POLICY-7: MCP validate_plan structured sequence findings

### DIFF
--- a/actions/src/action_entrypoint/application/router_impl.rs
+++ b/actions/src/action_entrypoint/application/router_impl.rs
@@ -514,6 +514,7 @@ mod tests {
                 rigorix_engine::orchestrator::application::dto::PlanOnlyOutput {
                     plan: serde_json::json!({"steps": []}),
                     graph: serde_json::json!({"nodes": []}),
+                    sequence_findings: Vec::new(),
                 },
             )
         }
@@ -595,6 +596,7 @@ mod tests {
                 rigorix_engine::orchestrator::application::dto::PlanOnlyOutput {
                     plan: serde_json::json!({"mode": "from_template"}),
                     graph: serde_json::json!({"nodes": []}),
+                    sequence_findings: Vec::new(),
                 },
             )
         }

--- a/engine/src/orchestrator/application/dto/mod.rs
+++ b/engine/src/orchestrator/application/dto/mod.rs
@@ -85,6 +85,30 @@ pub struct PlanOnlyOutput {
 
     /// The proposed TaskGraph structure.
     pub graph: serde_json::Value,
+
+    /// Structured sequence-policy findings from R2 plan-time evaluation.
+    ///
+    /// Populated when a sequence-policy service is configured and a rule
+    /// matched a `promote` sequence — surfaced to plan consumers (e.g. MCP
+    /// `rigorix_validate_plan`) so the gating decision is visible **before**
+    /// a run starts. Empty when no service is configured or no rule matched.
+    /// (A matched `deny` rule refuses the plan instead — it is reported as an
+    /// `OrchestratorError::SequencePolicyDenied`, never as a silent pass.)
+    #[serde(default)]
+    pub sequence_findings: Vec<SequencePolicyFinding>,
+}
+
+/// One matched sequence from plan-time evaluation (R2), surfaced to plan
+/// preview consumers.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SequencePolicyFinding {
+    /// Stable id of the rule that matched.
+    pub rule_id: String,
+    /// Name of the later matched step that the rule gates.
+    pub later_step: String,
+    /// Action applied to the later step: `"promote"` (the step is built
+    /// `requires_approval = true`) or `"deny"`.
+    pub action: String,
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/src/orchestrator/application/orchestrator_impl.rs
+++ b/engine/src/orchestrator/application/orchestrator_impl.rs
@@ -417,11 +417,13 @@ impl OrchestratorServiceImpl {
     /// graph, so matched later steps are promoted at the same call site that
     /// already applies `step.requires_approval`.
     ///
-    /// Returns:
-    /// - `Ok(None)` — no service configured, or no rule matched (runbook
-    ///   executes with its declared approval flags, unchanged).
-    /// - `Ok(Some(steps))` — at least one `promote` rule matched; the later
-    ///   matched step(s) have `requires_approval = true` set.
+    /// Returns `(enforced, findings)`:
+    /// - `enforced: None` — no service configured, or no rule matched
+    ///   (runbook executes with its declared approval flags, unchanged).
+    /// - `enforced: Some(steps)` — at least one `promote` rule matched; the
+    ///   later matched step(s) have `requires_approval = true` set.
+    /// - `findings` — structured `SequencePolicyFinding`s for every matched
+    ///   `promote` rule (surfaced by plan preview to MCP `validate_plan`).
     /// - `Err(SequencePolicyDenied)` — a `deny` rule matched: the plan is
     ///   refused before any step executes (fail closed; the denied step's
     ///   tool is never called). Deny wins over promote deterministically.
@@ -430,9 +432,15 @@ impl OrchestratorServiceImpl {
     async fn apply_plan_time_sequence_policy(
         &self,
         steps: &[super::dto::TemplateStepDef],
-    ) -> Result<Option<Vec<super::dto::TemplateStepDef>>, OrchestratorError> {
+    ) -> Result<
+        (
+            Option<Vec<super::dto::TemplateStepDef>>,
+            Vec<super::dto::SequencePolicyFinding>,
+        ),
+        OrchestratorError,
+    > {
         let Some(svc) = &self.sequence_policy_service else {
-            return Ok(None);
+            return Ok((None, Vec::new()));
         };
         let planned: Vec<PlannedStep> = steps
             .iter()
@@ -448,10 +456,11 @@ impl OrchestratorServiceImpl {
             }
         })?;
         if matches.is_empty() {
-            return Ok(None);
+            return Ok((None, Vec::new()));
         }
 
         let mut promoted: Vec<String> = Vec::new();
+        let mut findings: Vec<super::dto::SequencePolicyFinding> = Vec::new();
         for m in &matches {
             match m.action {
                 crate::sequence_policy::domain::RuleAction::Deny => {
@@ -462,11 +471,16 @@ impl OrchestratorServiceImpl {
                 }
                 crate::sequence_policy::domain::RuleAction::Promote => {
                     promoted.push(m.later_step.clone());
+                    findings.push(super::dto::SequencePolicyFinding {
+                        rule_id: m.rule_id.clone(),
+                        later_step: m.later_step.clone(),
+                        action: "promote".to_string(),
+                    });
                 }
             }
         }
         if promoted.is_empty() {
-            return Ok(None);
+            return Ok((None, findings));
         }
         let mut enforced = steps.to_vec();
         for def in &mut enforced {
@@ -474,7 +488,7 @@ impl OrchestratorServiceImpl {
                 def.requires_approval = true;
             }
         }
-        Ok(Some(enforced))
+        Ok((Some(enforced), findings))
     }
 
     /// Extract file paths from task result outputs.
@@ -1082,6 +1096,7 @@ impl OrchestratorService for OrchestratorServiceImpl {
         Ok(PlanOnlyOutput {
             plan: serde_json::to_value(&result.planning_result).unwrap_or_default(),
             graph: serde_json::to_value(&result.graph).unwrap_or_default(),
+            sequence_findings: Vec::new(),
         })
     }
 
@@ -1163,7 +1178,7 @@ impl OrchestratorService for OrchestratorServiceImpl {
         // fail-closed — the forbidden sequence never executes and the denied
         // step's tool is never called. An evaluation error refuses the plan
         // too (fail closed on corrupt/over-cap rule config).
-        let enforced_steps = self.apply_plan_time_sequence_policy(&input.steps).await?;
+        let (enforced_steps, _findings) = self.apply_plan_time_sequence_policy(&input.steps).await?;
 
         // Init current execution state
         *self.current_execution.write().await = Some(CurrentExecutionState {
@@ -1665,7 +1680,7 @@ impl OrchestratorService for OrchestratorServiceImpl {
     ) -> Result<PlanOnlyOutput, OrchestratorError> {
         // Same R2 gate as `run_from_template` — a preview must show the same
         // promotion/denial decisions as the run it precedes.
-        let enforced_steps = self.apply_plan_time_sequence_policy(&input.steps).await?;
+        let (enforced_steps, findings) = self.apply_plan_time_sequence_policy(&input.steps).await?;
         let steps: &[super::dto::TemplateStepDef] =
             enforced_steps.as_deref().unwrap_or(&input.steps);
         let graph = self.build_graph_from_steps(steps)?;
@@ -1676,6 +1691,7 @@ impl OrchestratorService for OrchestratorServiceImpl {
                 "mode": "from_template",
             }),
             graph: serde_json::to_value(&graph).unwrap_or_default(),
+            sequence_findings: findings,
         })
     }
 
@@ -2576,6 +2592,79 @@ mod tests {
             state.is_err(),
             "no engine session ⇒ no step of the denied runbook executed"
         );
+    }
+
+    /// AC#8 (engine side): plan preview surfaces the R2 decision as a
+    /// structured finding BEFORE a run — a matched promote sequence reports
+    /// the rule + later step and builds the later step approval-gated.
+    #[tokio::test]
+    async fn test_plan_from_template_reports_promote_finding_before_run() {
+        use crate::sequence_policy::application::service_impl::SequencePolicyServiceImpl;
+        let policy = Arc::new(SequencePolicyServiceImpl::new(Box::new(FixedPolicyRepo {
+            config: Some(conference_policy(RuleAction::Promote)),
+        })));
+        let orch =
+            OrchestratorServiceImpl::default_test().with_sequence_policy(policy);
+
+        let out = orch
+            .plan_from_template(PlanFromTemplateInput {
+                steps: conference_runbook(),
+                repo_root: "/tmp/t".into(),
+                template_name: "conf-registration".into(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            out.sequence_findings.len(),
+            1,
+            "plan preview must carry the promote finding"
+        );
+        let f = &out.sequence_findings[0];
+        assert_eq!(f.rule_id, "registration-remove-then-reassign");
+        assert_eq!(f.later_step, "registration_add");
+        assert_eq!(f.action, "promote");
+
+        // The promoted step is built approval-gated in the preview graph —
+        // the same graph the run would execute.
+        let graph_json = serde_json::to_value(&out.graph).unwrap_or_default();
+        let text = serde_json::to_string(&graph_json).unwrap_or_default();
+        assert!(
+            text.contains("registration_add") && text.contains("true"),
+            "preview graph must gate the later step, got: {text}"
+        );
+    }
+
+    /// AC#8 (engine side): plan preview of a denied sequence refuses the
+    /// plan before the run — no preview graph is produced for a forbidden
+    /// composition.
+    #[tokio::test]
+    async fn test_plan_from_template_refuses_denied_sequence() {
+        use crate::sequence_policy::application::service_impl::SequencePolicyServiceImpl;
+        let policy = Arc::new(SequencePolicyServiceImpl::new(Box::new(FixedPolicyRepo {
+            config: Some(conference_policy(RuleAction::Deny)),
+        })));
+        let orch =
+            OrchestratorServiceImpl::default_test().with_sequence_policy(policy);
+
+        let err = orch
+            .plan_from_template(PlanFromTemplateInput {
+                steps: conference_runbook(),
+                repo_root: "/tmp/t".into(),
+                template_name: "conf-registration".into(),
+            })
+            .await
+            .unwrap_err();
+        match &err {
+            OrchestratorError::SequencePolicyDenied {
+                later_step,
+                rule_id,
+            } => {
+                assert_eq!(later_step, "registration_add");
+                assert_eq!(rule_id, "registration-remove-then-reassign");
+            }
+            other => panic!("expected SequencePolicyDenied, got {other}"),
+        }
     }
 
     /// GAP-M-13: planning_prompt_content is populated only when

--- a/engine/src/orchestrator/application/orchestrator_impl.rs
+++ b/engine/src/orchestrator/application/orchestrator_impl.rs
@@ -1178,7 +1178,8 @@ impl OrchestratorService for OrchestratorServiceImpl {
         // fail-closed — the forbidden sequence never executes and the denied
         // step's tool is never called. An evaluation error refuses the plan
         // too (fail closed on corrupt/over-cap rule config).
-        let (enforced_steps, _findings) = self.apply_plan_time_sequence_policy(&input.steps).await?;
+        let (enforced_steps, _findings) =
+            self.apply_plan_time_sequence_policy(&input.steps).await?;
 
         // Init current execution state
         *self.current_execution.write().await = Some(CurrentExecutionState {
@@ -2603,8 +2604,7 @@ mod tests {
         let policy = Arc::new(SequencePolicyServiceImpl::new(Box::new(FixedPolicyRepo {
             config: Some(conference_policy(RuleAction::Promote)),
         })));
-        let orch =
-            OrchestratorServiceImpl::default_test().with_sequence_policy(policy);
+        let orch = OrchestratorServiceImpl::default_test().with_sequence_policy(policy);
 
         let out = orch
             .plan_from_template(PlanFromTemplateInput {
@@ -2644,8 +2644,7 @@ mod tests {
         let policy = Arc::new(SequencePolicyServiceImpl::new(Box::new(FixedPolicyRepo {
             config: Some(conference_policy(RuleAction::Deny)),
         })));
-        let orch =
-            OrchestratorServiceImpl::default_test().with_sequence_policy(policy);
+        let orch = OrchestratorServiceImpl::default_test().with_sequence_policy(policy);
 
         let err = orch
             .plan_from_template(PlanFromTemplateInput {

--- a/mcp/src/execution_tools/application/service_impl.rs
+++ b/mcp/src/execution_tools/application/service_impl.rs
@@ -101,7 +101,7 @@ impl ValidatePlanHandler for ValidatePlanHandlerImpl {
             .await
             .map_err(HandlerError::EngineError)?;
 
-        let content = serde_json::json!({
+        let mut content = serde_json::json!({
             "valid": result.is_valid(),
             "warnings": result.warnings(),
             "errors": result.errors(),
@@ -112,6 +112,14 @@ impl ValidatePlanHandler for ValidatePlanHandlerImpl {
                 })
             }),
         });
+
+        // Structured sequence-policy findings (R2 plan-time): machine-readable
+        // `{rule_id, later_step, action}` entries so a matched sequence is
+        // visible to the agent BEFORE a run (module sequence-policy AC#8).
+        let findings = result.findings();
+        if !findings.is_empty() {
+            content["sequence_findings"] = serde_json::to_value(findings).unwrap_or_default();
+        }
 
         Ok(ToolCallResult {
             content: vec![crate::execution_tools::domain::error::ToolContentItem {

--- a/mcp/src/execution_tools/domain/value.rs
+++ b/mcp/src/execution_tools/domain/value.rs
@@ -450,6 +450,23 @@ pub struct ValidationResult {
     /// Optional estimated cost of execution.
     #[serde(default)]
     estimated_cost: Option<CostEstimate>,
+
+    /// Structured sequence-policy findings from R2 plan-time evaluation
+    /// (module sequence-policy AC#8): matched rules and the action applied
+    /// to their later step, surfaced by `rigorix_validate_plan` BEFORE a run.
+    #[serde(default)]
+    findings: Vec<SequencePolicyFinding>,
+}
+
+/// One structured sequence-policy finding (R2 plan-time evaluation).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SequencePolicyFinding {
+    /// Stable id of the rule that matched.
+    pub rule_id: String,
+    /// Name of the later matched step the rule gates.
+    pub later_step: String,
+    /// Action applied to the later step: `"promote"` or `"deny"`.
+    pub action: String,
 }
 
 impl ValidationResult {
@@ -465,7 +482,14 @@ impl ValidationResult {
             warnings,
             errors,
             estimated_cost,
+            findings: Vec::new(),
         }
+    }
+
+    /// Attach structured sequence-policy findings.
+    pub fn with_findings(mut self, findings: Vec<SequencePolicyFinding>) -> Self {
+        self.findings = findings;
+        self
     }
 
     /// Whether the plan is valid.
@@ -486,6 +510,11 @@ impl ValidationResult {
     /// Optional cost estimate.
     pub fn estimated_cost(&self) -> Option<&CostEstimate> {
         self.estimated_cost.as_ref()
+    }
+
+    /// Structured sequence-policy findings.
+    pub fn findings(&self) -> &[SequencePolicyFinding] {
+        &self.findings
     }
 }
 

--- a/mcp/src/execution_tools/infrastructure/engine_facade_impl.rs
+++ b/mcp/src/execution_tools/infrastructure/engine_facade_impl.rs
@@ -26,7 +26,7 @@ use crate::execution_tools::domain::entity::EngineFacade;
 use crate::execution_tools::domain::error::EngineFacadeError;
 use crate::execution_tools::domain::value::{
     ApprovalResult, BudgetStatus, CostBreakdown, EnforcementStatus, ExecutionId, ExecutionResult,
-    ExecutionStatus, PlanTemplate, StepResult, ValidationResult,
+    ExecutionStatus, PlanTemplate, SequencePolicyFinding, StepResult, ValidationResult,
 };
 
 use super::repository::ExecutionRepository;
@@ -86,7 +86,7 @@ impl EngineFacadeImpl {
         orchestrator: Arc<dyn OrchestratorService>,
         enforcer: Arc<dyn rigorix_engine::enforcement::application::ExecutionEnforcer>,
     ) -> Self {
-        use super::in_memory_repository::InMemoryExecutionRepository;
+        use crate::execution_tools::infrastructure::in_memory_repository::InMemoryExecutionRepository;
         Self::new(
             orchestrator,
             enforcer,
@@ -337,7 +337,13 @@ impl EngineFacade for EngineFacadeImpl {
             template_name,
         };
 
-        let _plan_output = timeout(
+        // R2 sequence-policy gate runs inside the orchestrator preview. A
+        // matched `deny` rule REFUSES the preview with a structured
+        // `SequencePolicyDenied` — surfaced here as an invalid validation
+        // result with a structured finding (never a silent pass, never a raw
+        // error). A matched `promote` rule returns plan-time findings that
+        // the tool reports as warnings + machine-readable findings.
+        let plan_output = timeout(
             self.config.validate_timeout,
             self.orchestrator.plan_from_template(input),
         )
@@ -345,10 +351,49 @@ impl EngineFacade for EngineFacadeImpl {
         .map_err(|_| EngineFacadeError::Timeout {
             operation: "validate_plan".into(),
             duration_secs: self.config.validate_timeout.as_secs(),
-        })?
-        .map_err(map_orchestrator_error)?;
+        })?;
 
-        Ok(ValidationResult::new(true, vec![], vec![], None))
+        let plan_output = match plan_output {
+            Ok(out) => out,
+            Err(OrchestratorError::SequencePolicyDenied {
+                later_step,
+                rule_id,
+            }) => {
+                let message = format!(
+                    "Sequence policy denied step '{later_step}' (rule '{rule_id}'): \
+                     the plan was refused before any step executed"
+                );
+                return Ok(ValidationResult::new(false, vec![], vec![message], None)
+                    .with_findings(vec![SequencePolicyFinding {
+                        rule_id,
+                        later_step,
+                        action: "deny".to_string(),
+                    }]));
+            }
+            Err(e) => return Err(map_orchestrator_error(e)),
+        };
+
+        // Promote findings → human warnings + machine-readable findings.
+        let mut findings: Vec<SequencePolicyFinding> = Vec::new();
+        let mut warnings: Vec<String> = Vec::new();
+        for f in plan_output.sequence_findings {
+            let verb = if f.action == "promote" {
+                "requires approval"
+            } else {
+                "is denied"
+            };
+            findings.push(SequencePolicyFinding {
+                rule_id: f.rule_id.clone(),
+                later_step: f.later_step.clone(),
+                action: f.action.clone(),
+            });
+            warnings.push(format!(
+                "Sequence policy: step '{}' {} by rule '{}'",
+                f.later_step, verb, f.rule_id
+            ));
+        }
+
+        Ok(ValidationResult::new(true, warnings, vec![], None).with_findings(findings))
     }
 
     async fn check_enforcement(&self) -> Result<EnforcementStatus, EngineFacadeError> {
@@ -584,5 +629,265 @@ mod tests {
             !defs[2].requires_approval,
             "step-2 must not require approval"
         );
+    }
+
+    // ── sequence-policy AC#8: rigorix_validate_plan structured findings ────
+    // The facade delegates to the orchestrator's plan_from_template (R2
+    // gate). These tests drive EngineFacadeImpl.validate_plan end-to-end
+    // against a stub orchestrator that reproduces the engine's two gate
+    // outcomes (promote findings / deny refusal) and assert the MCP surface
+    // translation: promote → valid + warning + machine finding; deny →
+    // invalid + structured deny finding (never a silent pass).
+
+    use rigorix_engine::orchestrator::application::dto::SequencePolicyFinding as EngineFinding;
+
+    /// Orchestrator double whose `plan_from_template` reproduces the R2 gate
+    /// outcomes of a real `OrchestratorServiceImpl` (which is not reachable
+    /// from this crate — its service mocks are engine-internal).
+    struct PlanStubOrchestrator {
+        bus: rigorix_engine::event_system::application::event_bus_service_impl::EventBusServiceImpl,
+        outcome: PlanOutcome,
+    }
+
+    enum PlanOutcome {
+        Promote(Vec<EngineFinding>),
+        Denied { later_step: String, rule_id: String },
+    }
+
+    impl PlanStubOrchestrator {
+        fn promote(findings: Vec<EngineFinding>) -> Arc<dyn OrchestratorService> {
+            let bus: rigorix_engine::event_system::application::event_bus_service_impl::EventBusServiceImpl =
+                rigorix_engine::event_system::application::event_bus_service_impl::EventBusServiceImpl::default();
+            Arc::new(Self {
+                bus,
+                outcome: PlanOutcome::Promote(findings),
+            })
+        }
+
+        fn denied(later_step: &str, rule_id: &str) -> Arc<dyn OrchestratorService> {
+            let bus: rigorix_engine::event_system::application::event_bus_service_impl::EventBusServiceImpl =
+                rigorix_engine::event_system::application::event_bus_service_impl::EventBusServiceImpl::default();
+            Arc::new(Self {
+                bus,
+                outcome: PlanOutcome::Denied {
+                    later_step: later_step.to_string(),
+                    rule_id: rule_id.to_string(),
+                },
+            })
+        }
+    }
+
+    #[async_trait]
+    impl OrchestratorService for PlanStubOrchestrator {
+        async fn run(
+            &self,
+            _: rigorix_engine::orchestrator::application::dto::RunInput,
+        ) -> Result<rigorix_engine::orchestrator::application::dto::RunOutput, OrchestratorError>
+        {
+            unimplemented!("validate_plan only exercises plan_from_template")
+        }
+        async fn plan_only(
+            &self,
+            _: rigorix_engine::orchestrator::application::dto::PlanOnlyInput,
+        ) -> Result<rigorix_engine::orchestrator::application::dto::PlanOnlyOutput, OrchestratorError>
+        {
+            unimplemented!("validate_plan only exercises plan_from_template")
+        }
+        async fn cancel(
+            &self,
+            _: rigorix_engine::orchestrator::application::dto::CancelInput,
+        ) -> Result<rigorix_engine::orchestrator::application::dto::CancelOutput, OrchestratorError>
+        {
+            unimplemented!("validate_plan only exercises plan_from_template")
+        }
+        async fn status(
+            &self,
+        ) -> Result<rigorix_engine::orchestrator::application::dto::StatusOutput, OrchestratorError>
+        {
+            unimplemented!("validate_plan only exercises plan_from_template")
+        }
+        async fn run_from_template(
+            &self,
+            _: rigorix_engine::orchestrator::application::dto::RunFromTemplateInput,
+        ) -> Result<rigorix_engine::orchestrator::application::dto::RunOutput, OrchestratorError>
+        {
+            unimplemented!("validate_plan only exercises plan_from_template")
+        }
+        async fn plan_from_template(
+            &self,
+            _: rigorix_engine::orchestrator::application::dto::PlanFromTemplateInput,
+        ) -> Result<rigorix_engine::orchestrator::application::dto::PlanOnlyOutput, OrchestratorError>
+        {
+            match &self.outcome {
+                PlanOutcome::Promote(findings) => Ok(
+                    rigorix_engine::orchestrator::application::dto::PlanOnlyOutput {
+                        plan: serde_json::json!({}),
+                        graph: serde_json::json!({}),
+                        sequence_findings: findings.clone(),
+                    },
+                ),
+                PlanOutcome::Denied {
+                    later_step,
+                    rule_id,
+                } => Err(OrchestratorError::SequencePolicyDenied {
+                    later_step: later_step.clone(),
+                    rule_id: rule_id.clone(),
+                }),
+            }
+        }
+        fn event_bus(&self) -> &dyn rigorix_engine::event_system::application::EventBusService {
+            &self.bus
+        }
+        async fn approve_execution(
+            &self,
+            _: rigorix_engine::orchestrator::application::dto::ApproveExecutionInput,
+        ) -> Result<
+            rigorix_engine::orchestrator::application::dto::ApproveExecutionOutput,
+            OrchestratorError,
+        > {
+            unimplemented!("validate_plan only exercises plan_from_template")
+        }
+        async fn execution_state(
+            &self,
+            _: Uuid,
+        ) -> Result<
+            rigorix_engine::execution_engine::application::dto::GetExecutionStateOutput,
+            OrchestratorError,
+        > {
+            unimplemented!("validate_plan only exercises plan_from_template")
+        }
+    }
+
+    /// Enforcer double — `validate_plan` never consults enforcement.
+    struct PlanStubEnforcer;
+    #[async_trait]
+    impl rigorix_engine::enforcement::application::ExecutionEnforcer for PlanStubEnforcer {
+        async fn evaluate_tool_call(
+            &self,
+            _: rigorix_engine::enforcement::application::dto::EvaluateToolCallInput,
+        ) -> Result<
+            rigorix_engine::enforcement::application::dto::EvaluateToolCallOutput,
+            rigorix_engine::enforcement::domain::EnforcementError,
+        > {
+            unimplemented!()
+        }
+        async fn track_resource_usage(
+            &self,
+            _: rigorix_engine::enforcement::application::dto::TrackResourceUsageInput,
+        ) -> Result<
+            rigorix_engine::enforcement::application::dto::TrackResourceUsageOutput,
+            rigorix_engine::enforcement::domain::EnforcementError,
+        > {
+            unimplemented!()
+        }
+        async fn get_budget_status(
+            &self,
+            _: rigorix_engine::enforcement::application::dto::GetBudgetStatusInput,
+        ) -> Result<
+            rigorix_engine::enforcement::application::dto::GetBudgetStatusOutput,
+            rigorix_engine::enforcement::domain::EnforcementError,
+        > {
+            unimplemented!()
+        }
+        async fn check_execution_limits(
+            &self,
+            _: rigorix_engine::enforcement::application::dto::CheckExecutionLimitsInput,
+        ) -> Result<
+            rigorix_engine::enforcement::application::dto::CheckExecutionLimitsOutput,
+            rigorix_engine::enforcement::domain::EnforcementError,
+        > {
+            unimplemented!()
+        }
+        async fn reload_config(
+            &self,
+        ) -> Result<
+            rigorix_engine::enforcement::application::dto::ReloadConfigOutput,
+            rigorix_engine::enforcement::domain::EnforcementError,
+        > {
+            unimplemented!()
+        }
+        fn has_active_warnings(&self) -> bool {
+            false
+        }
+        fn active_warnings(
+            &self,
+        ) -> Vec<rigorix_engine::enforcement::application::dto::ActiveWarning> {
+            Vec::new()
+        }
+    }
+
+    fn validate_facade(orchestrator: Arc<dyn OrchestratorService>) -> EngineFacadeImpl {
+        use crate::execution_tools::infrastructure::in_memory_repository::InMemoryExecutionRepository;
+        EngineFacadeImpl::new(
+            orchestrator,
+            Arc::new(PlanStubEnforcer),
+            Arc::new(InMemoryExecutionRepository::new()),
+            EngineFacadeConfig::default(),
+        )
+    }
+
+    /// AC#8 — promote: validate_plan returns valid=true, a human warning and
+    /// a structured machine-readable finding BEFORE any run.
+    #[tokio::test]
+    async fn test_validate_plan_reports_promote_sequence_finding() {
+        let finding = EngineFinding {
+            rule_id: "registration-remove-then-reassign".into(),
+            later_step: "registration_add".into(),
+            action: "promote".into(),
+        };
+        let facade = validate_facade(PlanStubOrchestrator::promote(vec![finding]));
+
+        let result = facade
+            .validate_plan(plan_with_approval_flags(&[false, false]))
+            .await;
+        let validation = result.expect("promote plan validates");
+        assert!(validation.is_valid());
+        assert!(
+            validation
+                .warnings()
+                .iter()
+                .any(|w| { w.contains("registration_add") && w.contains("requires approval") }),
+            "human-readable promotion warning: {:?}",
+            validation.warnings()
+        );
+        assert_eq!(validation.findings().len(), 1);
+        assert_eq!(
+            validation.findings()[0].rule_id,
+            "registration-remove-then-reassign"
+        );
+        assert_eq!(validation.findings()[0].later_step, "registration_add");
+        assert_eq!(validation.findings()[0].action, "promote");
+    }
+
+    /// AC#8 — deny: validate_plan on a forbidden composition returns an
+    /// INVALID result with a structured deny finding — the run is refused
+    /// before anything executes, surfaced as data not as a raw error.
+    #[tokio::test]
+    async fn test_validate_plan_denied_sequence_is_invalid_with_finding() {
+        let facade = validate_facade(PlanStubOrchestrator::denied(
+            "registration_add",
+            "registration-remove-then-reassign",
+        ));
+
+        let result = facade
+            .validate_plan(plan_with_approval_flags(&[false, false]))
+            .await;
+        let validation = result.expect("deny surfaces as structured invalid result");
+        assert!(!validation.is_valid(), "denied plan must not validate");
+        assert!(
+            validation
+                .errors()
+                .iter()
+                .any(|e| e.contains("Sequence policy denied")),
+            "structured error: {:?}",
+            validation.errors()
+        );
+        assert_eq!(validation.findings().len(), 1);
+        assert_eq!(
+            validation.findings()[0].rule_id,
+            "registration-remove-then-reassign"
+        );
+        assert_eq!(validation.findings()[0].later_step, "registration_add");
+        assert_eq!(validation.findings()[0].action, "deny");
     }
 }

--- a/mcp/src/execution_tools/tests.rs
+++ b/mcp/src/execution_tools/tests.rs
@@ -23,7 +23,7 @@ mod tests {
     use crate::execution_tools::domain::error::EngineFacadeError;
     use crate::execution_tools::domain::value::{
         BudgetStatus, EnforcementStatus, ExecutionId, ExecutionResult, ExecutionStatus,
-        PlanTemplate, StepDefinition, StepResult, ValidationResult,
+        PlanTemplate, SequencePolicyFinding, StepDefinition, StepResult, ValidationResult,
     };
     use crate::execution_tools::infrastructure::in_memory_repository::InMemoryExecutionRepository;
     use crate::execution_tools::infrastructure::repository::ExecutionRepository;
@@ -91,6 +91,21 @@ mod tests {
                 vec!["Blocked by policy".into()],
                 None,
             )));
+            self
+        }
+
+        fn with_validate_findings(mut self) -> Self {
+            self.validate_result = Some(Ok(ValidationResult::new(
+                true,
+                vec!["Sequence policy: step 'registration_add' requires approval by rule 'registration-remove-then-reassign'".into()],
+                vec![],
+                None,
+            )
+            .with_findings(vec![SequencePolicyFinding {
+                rule_id: "registration-remove-then-reassign".into(),
+                later_step: "registration_add".into(),
+                action: "promote".into(),
+            }])));
             self
         }
 
@@ -345,6 +360,41 @@ mod tests {
         assert!(result.is_ok());
         let tc = result.unwrap();
         assert!(tc.is_error);
+    }
+
+    /// sequence-policy AC#8: `rigorix_validate_plan` surfaces a matched
+    /// sequence as a structured machine-readable finding (rule_id, later
+    /// step, action) in the tool response BEFORE a run.
+    #[tokio::test]
+    async fn test_validate_handler_surfaces_sequence_policy_findings() {
+        let engine: SharedEngineFacade = Arc::new(MockEngineFacade::new().with_validate_findings());
+        let handler = ValidatePlanHandlerImpl::new(engine);
+
+        let input = ValidateInput {
+            plan: make_test_plan(),
+        };
+
+        let result = handler.handle(input).await;
+        assert!(result.is_ok());
+        let tc = result.unwrap();
+        assert!(
+            !tc.is_error,
+            "promote finding is a warning, not a rejection"
+        );
+
+        let output: serde_json::Value =
+            serde_json::from_str(&tc.content[0].text).expect("valid JSON");
+        let findings = output["sequence_findings"]
+            .as_array()
+            .expect("structured sequence_findings array");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0]["rule_id"], "registration-remove-then-reassign");
+        assert_eq!(findings[0]["later_step"], "registration_add");
+        assert_eq!(findings[0]["action"], "promote");
+        assert!(
+            tc.content[0].text.contains("requires approval by rule"),
+            "human-readable warning accompanies the structured finding"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## ISSUE-SEQUENCE-POLICY-7: MCP surface — rigorix_validate_plan structured findings (#845)

### What
`rigorix_validate_plan` on a plan with a matched sequence now returns a **structured finding before run** (AC#8). The R2 plan-time gate decision becomes data, surfaced through the whole MCP chain.

### Changes
**Engine — plan preview reports the R2 decision**
- `PlanOnlyOutput` gains `sequence_findings: Vec<SequencePolicyFinding>` (`{rule_id, later_step, action}`) with serde default; `plan_from_template` fills it from the plan-time gate on `promote` matches. A matched `deny` still refuses the preview with the structured `SequencePolicyDenied` error (from #844).
- `apply_plan_time_sequence_policy` now returns `(enforced_steps, findings)`; `run_from_template` and the actions mock literal updated.

**MCP — rigorix_validate_plan (AC#8)**
- `EngineFacadeImpl::validate_plan`: translates engine outcomes — `promote` → `valid=true` + human warning + machine finding; `deny` → `valid=false` + structured deny finding (denial is surfaced as data, never a silent pass-through or raw error); other errors map as before.
- `ValidationResult` carries `findings` (+ `with_findings()`, field serde-defaulted so existing constructions are unaffected); handler emits `sequence_findings[]` in the tool JSON when present.

### Acceptance criteria
- **AC 8** — verified by four tests across the chain:
  - engine `test_plan_from_template_reports_promote_finding_before_run` / `..._refuses_denied_sequence` (real gate + real `SequencePolicyServiceImpl` + canonical conference rule)
  - mcp facade `test_validate_plan_reports_promote_sequence_finding` / `test_validate_plan_denied_sequence_is_invalid_with_finding`
  - handler `test_validate_handler_surfaces_sequence_policy_findings` (structured `sequence_findings[]` in tool JSON)

### Evidence
- `cargo test -p rigorix-engine --lib` 18/18 orchestrator tests; `cargo test -p rigorix-mcp --lib` 151/151 (20 execution-tools incl. new)
- clippy `--all-targets -D warnings` + fmt green on engine and mcp; `validate-ci.sh` 5/5 PASS; canonical + security validators PASS
- (validate-tests.sh still shows only the pre-existing `--test integration` target bug, identical on clean main)

Closes #845.
