### PR TITLE
[Issue #846] ISSUE-SEQUENCE-POLICY-8: Execution Engine R3 run-time prefix gate

### DIFF
--- a/engine/src/execution_engine/application/factory.rs
+++ b/engine/src/execution_engine/application/factory.rs
@@ -92,6 +92,17 @@ pub struct ParallelExecutionFactoryConfig {
 
     /// ADR-011: optional approval binding (see [`ApprovalBindingSetup`]).
     pub approval_binding: Option<ApprovalBindingSetup>,
+
+    /// R3: optional sequence-policy prefix gate (see module doc §R3).
+    ///
+    /// When set, the dispatch loop evaluates the session's completed prefix
+    /// plus each ready node before dispatch: a matched `deny` rule fails the
+    /// node before its tool is called; a matched `promote` rule routes the
+    /// node into the existing approval pause. When `None`, no sequence-policy
+    /// gating is applied (status quo).
+    pub sequence_policy: Option<
+        std::sync::Arc<dyn crate::sequence_policy::application::service::SequencePolicyService>,
+    >,
 }
 
 impl Default for ParallelExecutionFactoryConfig {
@@ -105,6 +116,7 @@ impl Default for ParallelExecutionFactoryConfig {
             permission_enforcer: None,
             hook_runner: None,
             approval_binding: None,
+            sequence_policy: None,
         }
     }
 }

--- a/engine/src/execution_engine/application/factory_impl.rs
+++ b/engine/src/execution_engine/application/factory_impl.rs
@@ -65,6 +65,9 @@ impl ParallelExecutionFactory for ParallelExecutionFactoryImpl {
         if let Some(runner) = config.hook_runner {
             executor = executor.with_hook_runner(runner);
         }
+        if let Some(svc) = config.sequence_policy {
+            executor = executor.with_sequence_policy(svc);
+        }
         if let Some(binding) = config.approval_binding {
             // ADR-011: attach the approval binding with a live session-graph
             // intent resolver — approve/verify/consume now run at the runtime

--- a/engine/src/execution_engine/application/service_impl.rs
+++ b/engine/src/execution_engine/application/service_impl.rs
@@ -401,10 +401,7 @@ enum SequencePolicyVerdict {
     Promote,
     /// The node completes a forbidden sequence under a `deny` rule — fail the
     /// node before dispatch (its tool is never called).
-    Deny {
-        rule_id: String,
-        later_step: String,
-    },
+    Deny { rule_id: String, later_step: String },
 }
 
 // ---------------------------------------------------------------------------
@@ -591,7 +588,10 @@ impl ParallelExecutionServiceImpl {
                         .await?;
                     break;
                 }
-                SequencePolicyVerdict::Deny { rule_id, later_step } => {
+                SequencePolicyVerdict::Deny {
+                    rule_id,
+                    later_step,
+                } => {
                     let node_name = graph
                         .get_node(node_id)
                         .map(|n| n.name.clone())
@@ -617,6 +617,9 @@ impl ParallelExecutionServiceImpl {
                     }
                     // Release dependents exactly like a dispatched failure.
                     let _ = graph.mark_completed(node_id);
+                    // NEVER fall through to dispatch: a denied node's tool is
+                    // never called. Continue the fill loop.
+                    continue;
                 }
             }
 
@@ -791,7 +794,10 @@ impl ParallelExecutionServiceImpl {
                             .await?;
                         break;
                     }
-                    SequencePolicyVerdict::Deny { rule_id, later_step } => {
+                    SequencePolicyVerdict::Deny {
+                        rule_id,
+                        later_step,
+                    } => {
                         let node_name = graph
                             .get_node(next_id)
                             .map(|n| n.name.clone())
@@ -814,6 +820,8 @@ impl ParallelExecutionServiceImpl {
                             self.notify_progress(dag_id, denied_id, state, total_nodes);
                         }
                         let _ = graph.mark_completed(next_id);
+                        // NEVER fall through to dispatch (tool never called).
+                        continue;
                     }
                 }
 
@@ -1123,11 +1131,12 @@ impl ParallelExecutionServiceImpl {
         // Snapshot the completed prefix + next step under the sessions lock
         // (no awaits held). Missing session / node ⇒ nothing to gate.
         let (prefix, next) = {
-            let sessions = self.sessions.lock().map_err(|e| {
-                ExecutionError::InternalError {
+            let sessions = self
+                .sessions
+                .lock()
+                .map_err(|e| ExecutionError::InternalError {
                     detail: format!("Lock error: {e}"),
-                }
-            })?;
+                })?;
             let Some(session) = sessions.get(&dag_id) else {
                 return Ok(SequencePolicyVerdict::Dispatch);
             };
@@ -1165,7 +1174,7 @@ impl ParallelExecutionServiceImpl {
                     detail: format!(
                         "Sequence policy evaluation failed — run halted before dispatch (fail closed): {e}"
                     ),
-                })
+                });
             }
         };
 
@@ -1177,8 +1186,7 @@ impl ParallelExecutionServiceImpl {
                 });
             }
         }
-        if matches.iter().any(|m| m.action == RuleAction::Promote) && !approved.contains(&node_id)
-        {
+        if matches.iter().any(|m| m.action == RuleAction::Promote) && !approved.contains(&node_id) {
             return Ok(SequencePolicyVerdict::Promote);
         }
         Ok(SequencePolicyVerdict::Dispatch)
@@ -1203,18 +1211,13 @@ impl ParallelExecutionServiceImpl {
                 return None;
             }
         };
-        let Some(session) = sessions.get_mut(&dag_id) else {
-            return None;
-        };
-        let Some(state) = session.node_states.get_mut(&node_id) else {
-            return None;
-        };
+        let session = sessions.get_mut(&dag_id)?;
+        let state = session.node_states.get_mut(&node_id)?;
         let error = format!(
             "Sequence policy denied by rule '{rule_id}' — step '{later_step}' must not dispatch"
         );
         state.mark_failed("sequence_policy_denied".to_string(), error);
         let cloned = state.clone();
-        drop(sessions);
         Some((node_id, cloned))
     }
 

--- a/engine/src/execution_engine/application/service_impl.rs
+++ b/engine/src/execution_engine/application/service_impl.rs
@@ -47,6 +47,9 @@ use crate::recovery_recipes::application::context::RecoveryContext;
 use crate::recovery_recipes::application::dto::{AttemptRecoveryInput, RecipeForInput};
 use crate::recovery_recipes::application::service::RecoveryService;
 use crate::recovery_recipes::domain::FailureScenario;
+use crate::sequence_policy::application::dto::{DispatchedStep, PlannedStep};
+use crate::sequence_policy::application::service::SequencePolicyService;
+use crate::sequence_policy::domain::RuleAction;
 
 use super::dto::{
     AbortExecutionInput, AbortExecutionOutput, ApproveNodeInput, ApproveNodeOutput,
@@ -386,6 +389,24 @@ pub(crate) struct ApprovalBinding {
     pub(crate) service: Arc<dyn ApprovalService>,
 }
 
+/// R3 sequence-policy gate verdict for a ready node about to dispatch.
+///
+/// Produced by [`ParallelExecutionServiceImpl::sequence_policy_verdict`] and
+/// consumed by the two dispatch fill loops inside `run_dispatch_loop`.
+enum SequencePolicyVerdict {
+    /// No actionable match — dispatch unchanged.
+    Dispatch,
+    /// The node completes a forbidden sequence under a `promote` rule and is
+    /// not yet human-approved — route into the existing approval pause.
+    Promote,
+    /// The node completes a forbidden sequence under a `deny` rule — fail the
+    /// node before dispatch (its tool is never called).
+    Deny {
+        rule_id: String,
+        later_step: String,
+    },
+}
+
 // ---------------------------------------------------------------------------
 // ParallelExecutionServiceImpl
 // ---------------------------------------------------------------------------
@@ -429,6 +450,17 @@ pub struct ParallelExecutionServiceImpl {
     /// (`verify_intent`), consume on terminal outcome, and approval capture
     /// persists single-use records. `None` = legacy `session.approved` gate.
     approval_binding: Option<Arc<ApprovalBinding>>,
+
+    /// R3 sequence-policy prefix gate (opt-in).
+    ///
+    /// When present, `run_dispatch_loop` evaluates the session's completed
+    /// dispatch prefix plus each ready node before dispatch: a matched
+    /// `deny` rule fails the node deterministically BEFORE dispatch (its
+    /// tool is never called); a matched `promote` rule routes the node into
+    /// the existing approval pause by flipping `requires_approval` on the
+    /// live graph — the approval chain from ADR-011 composes unchanged.
+    /// `None` = gating disabled (status quo — no behavior change).
+    sequence_policy: Option<Arc<dyn SequencePolicyService>>,
 }
 
 impl ParallelExecutionServiceImpl {
@@ -536,6 +568,55 @@ impl ParallelExecutionServiceImpl {
                         break;
                     }
                     Err(e) => return Err(e),
+                }
+            }
+
+            // R3 sequence-policy prefix gate (opt-in; module doc §R3).
+            // Promotion flips the live node's requires_approval flag so the
+            // SAME approval pause/approve/resume chain as a pre-declared
+            // gated step applies; denial records a deterministic failure
+            // before the node's tool is ever called.
+            match self
+                .sequence_policy_verdict(dag_id, graph, node_id, approved)
+                .await?
+            {
+                SequencePolicyVerdict::Dispatch => {}
+                SequencePolicyVerdict::Promote => {
+                    if let Some(node) = graph.get_node_mut(node_id) {
+                        node.requires_approval = true;
+                    }
+                    graph.requeue_ready_node(node_id);
+                    approval_blocked = true;
+                    self.mark_awaiting_approval(dag_id, graph, total_nodes)
+                        .await?;
+                    break;
+                }
+                SequencePolicyVerdict::Deny { rule_id, later_step } => {
+                    let node_name = graph
+                        .get_node(node_id)
+                        .map(|n| n.name.clone())
+                        .unwrap_or_default();
+                    let task_result = TaskResult::failure(
+                        node_id,
+                        &node_name,
+                        format!(
+                            "Sequence policy denied by rule '{rule_id}' — step '{later_step}' must not dispatch"
+                        ),
+                        "sequence_policy_denied".to_string(),
+                        0,
+                        0,
+                    );
+                    node_results.insert(node_id, task_result);
+                    failed_count += 1;
+                    // Mirror the consumption-loop state update so observers
+                    // see the denial like any deterministic node failure.
+                    if let Some((denied_id, state)) =
+                        self.record_sequence_denial(dag_id, node_id, &rule_id, &later_step)
+                    {
+                        self.notify_progress(dag_id, denied_id, state, total_nodes);
+                    }
+                    // Release dependents exactly like a dispatched failure.
+                    let _ = graph.mark_completed(node_id);
                 }
             }
 
@@ -690,6 +771,49 @@ impl ParallelExecutionServiceImpl {
                             break;
                         }
                         Err(e) => return Err(e),
+                    }
+                }
+
+                // R3 sequence-policy prefix gate (opt-in; module doc §R3).
+                // Same semantics as the Phase-1 gate above.
+                match self
+                    .sequence_policy_verdict(dag_id, graph, next_id, approved)
+                    .await?
+                {
+                    SequencePolicyVerdict::Dispatch => {}
+                    SequencePolicyVerdict::Promote => {
+                        if let Some(node) = graph.get_node_mut(next_id) {
+                            node.requires_approval = true;
+                        }
+                        graph.requeue_ready_node(next_id);
+                        approval_blocked = true;
+                        self.mark_awaiting_approval(dag_id, graph, total_nodes)
+                            .await?;
+                        break;
+                    }
+                    SequencePolicyVerdict::Deny { rule_id, later_step } => {
+                        let node_name = graph
+                            .get_node(next_id)
+                            .map(|n| n.name.clone())
+                            .unwrap_or_default();
+                        let task_result = TaskResult::failure(
+                            next_id,
+                            &node_name,
+                            format!(
+                                "Sequence policy denied by rule '{rule_id}' — step '{later_step}' must not dispatch"
+                            ),
+                            "sequence_policy_denied".to_string(),
+                            0,
+                            0,
+                        );
+                        node_results.insert(next_id, task_result);
+                        failed_count += 1;
+                        if let Some((denied_id, state)) =
+                            self.record_sequence_denial(dag_id, next_id, &rule_id, &later_step)
+                        {
+                            self.notify_progress(dag_id, denied_id, state, total_nodes);
+                        }
+                        let _ = graph.mark_completed(next_id);
                     }
                 }
 
@@ -969,6 +1093,131 @@ impl ParallelExecutionServiceImpl {
         Ok(())
     }
 
+    /// R3 — run-time prefix gate (module doc §R3; AC#9).
+    ///
+    /// Builds the session's completed dispatch prefix (successful
+    /// completions in graph declaration order — deterministic for an
+    /// identical DAG + identical completed prefix) plus `node_id` as the
+    /// proposed next step and asks the policy service `evaluate_prefix`:
+    ///
+    /// - any match with action `deny` → `Deny` (outranks promote; a deny is
+    ///   absolute — human approval cannot override a forbidden sequence)
+    /// - any match with action `promote`, node not already human-approved →
+    ///   `Promote` (a previously promoted-and-approved node dispatches: its
+    ///   pause was already the human decision)
+    /// - otherwise → `Dispatch`
+    ///
+    /// An evaluation error fails CLOSED — the run halts before the node
+    /// dispatches (corrupt/over-cap rule config must never execute silently).
+    async fn sequence_policy_verdict(
+        &self,
+        dag_id: Uuid,
+        graph: &crate::dag_engine::domain::TaskGraph,
+        node_id: Uuid,
+        approved: &HashSet<Uuid>,
+    ) -> Result<SequencePolicyVerdict, ExecutionError> {
+        let Some(svc) = &self.sequence_policy else {
+            return Ok(SequencePolicyVerdict::Dispatch);
+        };
+
+        // Snapshot the completed prefix + next step under the sessions lock
+        // (no awaits held). Missing session / node ⇒ nothing to gate.
+        let (prefix, next) = {
+            let sessions = self.sessions.lock().map_err(|e| {
+                ExecutionError::InternalError {
+                    detail: format!("Lock error: {e}"),
+                }
+            })?;
+            let Some(session) = sessions.get(&dag_id) else {
+                return Ok(SequencePolicyVerdict::Dispatch);
+            };
+            let prefix = graph
+                .nodes()
+                .filter(|n| {
+                    session
+                        .node_states
+                        .get(&n.id)
+                        .map(|s| s.status == NodeStatus::Completed)
+                        .unwrap_or(false)
+                })
+                .map(|n| DispatchedStep {
+                    name: n.name.clone(),
+                    tool: n.tool.clone(),
+                    parameters: serde_json::from_str(&n.intent).unwrap_or_default(),
+                })
+                .collect::<Vec<_>>();
+            let node = match graph.get_node(node_id) {
+                Some(n) => n,
+                None => return Ok(SequencePolicyVerdict::Dispatch),
+            };
+            let next = PlannedStep {
+                name: node.name.clone(),
+                tool: node.tool.clone(),
+                parameters: serde_json::from_str(&node.intent).unwrap_or_default(),
+            };
+            (prefix, next)
+        };
+
+        let matches = match svc.evaluate_prefix(&prefix, &next).await {
+            Ok(m) => m,
+            Err(e) => {
+                return Err(ExecutionError::InternalError {
+                    detail: format!(
+                        "Sequence policy evaluation failed — run halted before dispatch (fail closed): {e}"
+                    ),
+                })
+            }
+        };
+
+        for m in &matches {
+            if m.action == RuleAction::Deny {
+                return Ok(SequencePolicyVerdict::Deny {
+                    rule_id: m.rule_id.clone(),
+                    later_step: m.later_step.clone(),
+                });
+            }
+        }
+        if matches.iter().any(|m| m.action == RuleAction::Promote) && !approved.contains(&node_id)
+        {
+            return Ok(SequencePolicyVerdict::Promote);
+        }
+        Ok(SequencePolicyVerdict::Dispatch)
+    }
+
+    /// Record an R3 sequence-policy denial as a deterministic pre-dispatch
+    /// node failure (no tool call, no `NodeStarted`). Shared by the two
+    /// dispatch fill loops.
+    ///
+    /// Returns the updated node state so the caller can notify progress.
+    fn record_sequence_denial(
+        &self,
+        dag_id: Uuid,
+        node_id: Uuid,
+        rule_id: &str,
+        later_step: &str,
+    ) -> Option<(Uuid, NodeExecutionState)> {
+        let mut sessions = match self.sessions.lock() {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!(error = %e, "sequence-policy denial: sessions lock poisoned");
+                return None;
+            }
+        };
+        let Some(session) = sessions.get_mut(&dag_id) else {
+            return None;
+        };
+        let Some(state) = session.node_states.get_mut(&node_id) else {
+            return None;
+        };
+        let error = format!(
+            "Sequence policy denied by rule '{rule_id}' — step '{later_step}' must not dispatch"
+        );
+        state.mark_failed("sequence_policy_denied".to_string(), error);
+        let cloned = state.clone();
+        drop(sessions);
+        Some((node_id, cloned))
+    }
+
     /// Create a new ParallelExecutionServiceImpl.
     pub fn new(
         config: ParallelExecutorConfig,
@@ -986,6 +1235,7 @@ impl ParallelExecutionServiceImpl {
             recovery_service: None,
             recovery_contexts: Mutex::new(HashMap::new()),
             approval_binding: None,
+            sequence_policy: None,
         }
     }
 
@@ -998,6 +1248,18 @@ impl ParallelExecutionServiceImpl {
     /// Set the permission enforcer for mode-based tool gating.
     pub fn with_permission_enforcer(mut self, enforcer: Arc<dyn PermissionEnforcer>) -> Self {
         self.permission_enforcer = Some(enforcer);
+        self
+    }
+
+    /// Set the R3 run-time sequence-policy prefix gate (dynamic plans).
+    ///
+    /// When set, the dispatch loop evaluates the completed prefix plus each
+    /// ready node before dispatch (`evaluate_prefix`) and applies the rule
+    /// action: `promote` → node enters the existing `AwaitingApproval` pause;
+    /// `deny` → node fails with `sequence_policy_denied` before its tool is
+    /// ever called. `None` (default) keeps the status-quo dispatch path.
+    pub fn with_sequence_policy(mut self, svc: Arc<dyn SequencePolicyService>) -> Self {
+        self.sequence_policy = Some(svc);
         self
     }
 

--- a/engine/src/execution_engine/tests.rs
+++ b/engine/src/execution_engine/tests.rs
@@ -8,6 +8,7 @@
 //! RetryEvaluationServiceImpl implementations.
 
 use crate::event_system::application::event_bus_service_impl::EventBusServiceImpl;
+use async_trait::async_trait;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -2201,4 +2202,332 @@ async fn test_retry_with_skip_and_continue_strategy_index() {
     let decision2 = service.decide(&ctx2, &policy, None).await;
     assert!(decision2.is_terminal());
     assert!(matches!(decision2, RetryDecision::Skip { .. }));
+}
+
+// ---------------------------------------------------------------------------
+// R3 sequence-policy run-time prefix gate (AC#9)
+// ---------------------------------------------------------------------------
+//
+// Dynamic-plan semantics: step A completes, then step B is proposed (would
+// complete the forbidden pair). The dispatch loop's prefix gate evaluates the
+// session's completed prefix + B BEFORE B dispatches — promote routes B into
+// the existing approval pause; deny fails B pre-dispatch (tool never called).
+// Real in-process tools (file_append / file_write against the temp dir) prove
+// the "executes / never called" legs with observable side effects.
+
+use crate::sequence_policy::application::SequencePolicyServiceImpl;
+use crate::sequence_policy::domain::{
+    ParamMatchKind, ParamPredicate, RuleAction, SequencePolicyConfig, SequencePolicyError,
+    SequenceRule, StepPredicate,
+};
+use crate::sequence_policy::infrastructure::SequencePolicyRepository;
+
+/// In-memory rule-config double (no filesystem).
+struct R3PolicyRepo {
+    config: Option<SequencePolicyConfig>,
+}
+
+#[async_trait]
+impl SequencePolicyRepository for R3PolicyRepo {
+    async fn load_config(&self) -> Result<Option<SequencePolicyConfig>, SequencePolicyError> {
+        Ok(self.config.clone())
+    }
+}
+
+/// AC9 conference-style rule: append to X then write Y (remove-then-reassign
+/// shape) over the two concrete file paths, window 2.
+fn r3_config(action: RuleAction, path_a: &str, path_b: &str) -> SequencePolicyConfig {
+    SequencePolicyConfig {
+        fail_closed: true,
+        rules: vec![SequenceRule {
+            id: "r3-remove-then-reassign".to_string(),
+            name: "n".to_string(),
+            description: "d".to_string(),
+            steps: vec![
+                StepPredicate {
+                    tool: "file_append".to_string(),
+                    params: vec![ParamPredicate {
+                        pointer: "/path".to_string(),
+                        kind: ParamMatchKind::Exact,
+                        value: path_a.to_string(),
+                    }],
+                },
+                StepPredicate {
+                    tool: "file_write".to_string(),
+                    params: vec![ParamPredicate {
+                        pointer: "/path".to_string(),
+                        kind: ParamMatchKind::Exact,
+                        value: path_b.to_string(),
+                    }],
+                },
+            ],
+            window: Some(2),
+            action,
+        }],
+    }
+}
+
+fn r3_executor(action: RuleAction, path_a: &str, path_b: &str) -> ParallelExecutionServiceImpl {
+    let svc = SequencePolicyServiceImpl::new(Box::new(R3PolicyRepo {
+        config: Some(r3_config(action, path_a, path_b)),
+    }));
+    create_executor().with_sequence_policy(Arc::new(svc))
+}
+
+/// Unique per-run temp paths (parallel-safe; leftover files from crashed
+/// runs are removed so spy assertions observe only this run's side effects).
+fn r3_paths(tag: &str) -> (String, String) {
+    let dir = std::env::temp_dir();
+    let run = Uuid::new_v4();
+    let paths = (
+        dir.join(format!("rigorix-r3-{tag}-{run}-a.tmp"))
+            .display()
+            .to_string(),
+        dir.join(format!("rigorix-r3-{tag}-{run}-b.tmp"))
+            .display()
+            .to_string(),
+    );
+    let _ = std::fs::remove_file(&paths.0);
+    let _ = std::fs::remove_file(&paths.1);
+    paths
+}
+
+/// Sequential graph: step_a (file_append) → step_b (file_write). NEITHER node
+/// declares `requires_approval` — any pause is caused by the R3 gate alone.
+fn r3_chain_graph(
+    path_a: &str,
+    path_b: &str,
+) -> (crate::dag_engine::domain::TaskGraph, Uuid, Uuid) {
+    use crate::dag_engine::domain::{TaskGraph, TaskNode};
+    let a_id = Uuid::new_v4();
+    let b_id = Uuid::new_v4();
+    let a = TaskNode::new(
+        a_id,
+        "step_a",
+        "file_append",
+        vec![],
+        format!(r#"{{"path": "{}", "content": "a"}}"#, path_a),
+    );
+    let b = TaskNode::new(
+        b_id,
+        "step_b",
+        "file_write",
+        vec![a_id],
+        format!(r#"{{"path": "{}", "content": "b"}}"#, path_b),
+    );
+    let mut graph = TaskGraph::new();
+    graph.add_unchecked(a).unwrap();
+    graph.add_unchecked(b).unwrap();
+    graph.seal().unwrap();
+    (graph, a_id, b_id)
+}
+
+/// AC#9 (promote): step A completes, then B is proposed → B is promoted into
+/// the existing approval pause; approve → resume → B dispatches and executes
+/// (its side effect lands on disk).
+#[tokio::test]
+async fn test_r3_promote_pauses_dynamic_later_step_and_approve_executes_it() {
+    use crate::execution_engine::domain::NodeStatus;
+
+    let (path_a, path_b) = r3_paths("promote");
+    let executor = r3_executor(RuleAction::Promote, &path_a, &path_b);
+    let dag_id = Uuid::new_v4();
+    let (graph, _a_id, _b_id) = r3_chain_graph(&path_a, &path_b);
+
+    // 1. Execute: A (already ready) dispatches and completes; B is promoted
+    // at the dispatch boundary BEFORE its tool is called — run pauses.
+    let output = executor
+        .execute_graph(ExecuteGraphInput {
+            dag_id,
+            graph: Some(graph),
+            config_override: None,
+        })
+        .await
+        .unwrap();
+    assert!(
+        output.approval_pending,
+        "promoted dynamic step must pause the run"
+    );
+    assert_eq!(output.pending_approval_steps, vec!["step_b".to_string()]);
+
+    let state = executor
+        .get_execution_state(GetExecutionStateInput { dag_id })
+        .await
+        .unwrap();
+    assert!(state.paused, "execution should be paused at the R3 gate");
+    assert!(!state.is_complete, "not terminal while gated");
+
+    let step_a = state
+        .node_states
+        .values()
+        .find(|s| s.node_name == "step_a")
+        .expect("step_a state");
+    assert_eq!(
+        step_a.status,
+        NodeStatus::Completed,
+        "completed prefix step A must have executed before the gate"
+    );
+    let step_b = state
+        .node_states
+        .values()
+        .find(|s| s.node_name == "step_b")
+        .expect("step_b state");
+    assert_eq!(
+        step_b.status,
+        NodeStatus::AwaitingApproval,
+        "promote rule must gate the later dynamic step"
+    );
+    assert!(
+        step_b.started_at.is_none(),
+        "promoted step must not dispatch pre-approval"
+    );
+    assert!(
+        !std::path::Path::new(&path_b).exists(),
+        "B's tool must not have been called before approval"
+    );
+    assert!(
+        std::path::Path::new(&path_a).exists(),
+        "A (the completed prefix step) must have executed"
+    );
+
+    // 2. Human approval → the promoted node becomes dispatchable again.
+    let approve = executor
+        .approve_node(ApproveNodeInput {
+            dag_id,
+            step_names: vec!["step_b".to_string()],
+            approver_id: None,
+            authority: None,
+            decision_context: None,
+            token_claims_ref: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(approve.approved, vec!["step_b".to_string()]);
+
+    // 3. Resume → B dispatches through the SAME approval machinery and its
+    // tool executes (side effect observed on disk); run completes.
+    executor
+        .resume_execution(ResumeExecutionInput { dag_id })
+        .await
+        .unwrap();
+    let state = executor
+        .get_execution_state(GetExecutionStateInput { dag_id })
+        .await
+        .unwrap();
+    assert!(!state.paused, "execution should resume after approval");
+    assert!(state.is_complete, "approved run must complete");
+    assert_eq!(state.completed_count, 2);
+
+    let content = tokio::fs::read_to_string(&path_b).await.unwrap();
+    assert_eq!(content, "b", "approved B tool must have executed");
+}
+
+/// AC#9 (deny): step A completes, then B is proposed → B is denied BEFORE
+/// dispatch: structured sequence_policy_denied failure, B's tool never called.
+#[tokio::test]
+async fn test_r3_deny_fails_dynamic_later_step_before_dispatch() {
+    use crate::execution_engine::domain::NodeStatus;
+
+    let (path_a, path_b) = r3_paths("deny");
+    let executor = r3_executor(RuleAction::Deny, &path_a, &path_b);
+    let dag_id = Uuid::new_v4();
+    let (graph, _a_id, b_id) = r3_chain_graph(&path_a, &path_b);
+
+    let output = executor
+        .execute_graph(ExecuteGraphInput {
+            dag_id,
+            graph: Some(graph),
+            config_override: None,
+        })
+        .await
+        .unwrap();
+
+    // A executed; B failed with the structured denial — no approval involved.
+    assert!(!output.approval_pending);
+    assert_eq!(output.result.completed_count, 1, "A completes");
+    assert_eq!(output.result.failed_count, 1, "B fails deterministically");
+
+    let b_result = output
+        .result
+        .node_results
+        .get(&b_id)
+        .expect("denied B must carry a node result");
+    assert!(!b_result.success);
+    assert_eq!(
+        b_result.failure_type.as_deref(),
+        Some("sequence_policy_denied"),
+        "denial is a structured, typed node failure"
+    );
+    assert!(
+        b_result
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("r3-remove-then-reassign"),
+        "error names the matched rule"
+    );
+
+    let state = executor
+        .get_execution_state(GetExecutionStateInput { dag_id })
+        .await
+        .unwrap();
+    assert!(!state.paused);
+    assert!(state.is_complete);
+    let step_b = state
+        .node_states
+        .values()
+        .find(|s| s.node_name == "step_b")
+        .expect("step_b state");
+    assert_eq!(step_b.status, NodeStatus::Failed);
+    assert!(
+        step_b.started_at.is_none(),
+        "denied tool must NEVER be called"
+    );
+
+    // Spy assertion: B's file was never created; A's file exists.
+    assert!(
+        std::path::Path::new(&path_a).exists(),
+        "A must have executed"
+    );
+    assert!(
+        !std::path::Path::new(&path_b).exists(),
+        "denied B's tool must not have written its file"
+    );
+}
+
+/// AC#9 (no-match control): with the policy service present but no rule
+/// matching the actual pair, dispatch is unchanged — B executes normally.
+#[tokio::test]
+async fn test_r3_non_matching_rule_does_not_gate_dispatch() {
+    let (path_a, path_b) = r3_paths("control");
+    // Rule predicates point at DIFFERENT paths → nothing matches.
+    let svc = SequencePolicyServiceImpl::new(Box::new(R3PolicyRepo {
+        config: Some(r3_config(
+            RuleAction::Deny,
+            "/tmp/never-a.tmp",
+            "/tmp/never-b.tmp",
+        )),
+    }));
+    let executor = create_executor().with_sequence_policy(Arc::new(svc));
+    let dag_id = Uuid::new_v4();
+    let (graph, _a_id, b_id) = r3_chain_graph(&path_a, &path_b);
+
+    let output = executor
+        .execute_graph(ExecuteGraphInput {
+            dag_id,
+            graph: Some(graph),
+            config_override: None,
+        })
+        .await
+        .unwrap();
+    assert!(!output.approval_pending, "no match → no pause");
+    assert_eq!(output.result.completed_count, 2);
+
+    let b_result = output.result.node_results.get(&b_id).unwrap();
+    assert!(b_result.success, "non-matching rule must not gate dispatch");
+    assert_eq!(
+        tokio::fs::read_to_string(&path_b).await.unwrap(),
+        "b",
+        "B executes normally when no rule matches"
+    );
 }


### PR DESCRIPTION
## ISSUE-SEQUENCE-POLICY-8: Execution Engine (R3) — run-time prefix gate (#846)

### What
**AC#9**: *Dynamic plan completes step A, then proposes B (would complete) → B promoted/denied per rule* — integration test. The R3 run-time prefix gate now sits at the executor's single dispatch choke point (`run_dispatch_loop`, shared by `execute_graph` AND `resume_execution`), exactly where ADR-011 verifies intent.

### Design
Purely **additive** optional service (mirrors `permission_enforcer` / `hook_runner` / `approval_binding`):
- `ParallelExecutionServiceImpl` gains `Option<Arc<dyn SequencePolicyService>>` + `with_sequence_policy()`; `ParallelExecutionFactoryConfig` field + factory pass-through. `None` = status quo — zero behavior change for all existing dispatch paths.
- Before every dispatch, the gate builds the session's **completed prefix** (successful completions in graph order — deterministic) + the ready node and calls `evaluate_prefix`:
  - **deny** → node fails deterministically **BEFORE dispatch**: structured `sequence_policy_denied` TaskResult, node state Failed, dependents released like any dispatched failure, tool **never called**
  - **promote** (node not yet human-approved) → flips `requires_approval` on the live graph node → the node routes through the **existing** `AwaitingApproval` pause / `approve_node` / `resume_execution` machinery (no new approval path); a promoted-and-approved node dispatches on resume
  - evaluation error → **fail closed**: run halts before dispatch (corrupt/over-cap config never executes silently)

### Acceptance criteria
- **AC 9** — three in-crate integration tests over the real executor + real `SequencePolicyServiceImpl` + in-memory rule repo, with real in-process tools (`file_append`/`file_write` on unique temp paths) so execute / never-called legs are observable:
  - promote: A completes → B proposed → B `AwaitingApproval` (never dispatched, side effect absent); approve + resume → B executes (side effect lands); run completes
  - deny: A completes → B proposed → B fails with `sequence_policy_denied` before dispatch; B's file never written
  - no-match control: service present, rule doesn't match → dispatch unchanged

### Evidence
- `cargo test -p rigorix-engine --lib` 1988/1988 (63 execution-engine incl. 3 new R3)
- clippy `--all-targets -D warnings` + fmt green; `validate-ci.sh` 5/5 PASS; canonical + security PASS
- (validate-tests.sh still only shows the pre-existing `--test integration` main bug)

Closes #846.
