### PR TITLE
[Issue #847] ISSUE-SEQUENCE-POLICY-9: Fail-closed corrupt config refuses plan

### DIFF
--- a/engine/src/orchestrator/application/orchestrator_impl.rs
+++ b/engine/src/orchestrator/application/orchestrator_impl.rs
@@ -2595,6 +2595,81 @@ mod tests {
         );
     }
 
+    /// AC#10: a CORRUPT rule config refuses the plan end-to-end — real TOML
+    /// repository over a corrupt operator file → service load error → R2
+    /// gate propagates the evaluation failure and no step executes.
+    #[tokio::test]
+    async fn test_sequence_policy_corrupt_config_refuses_run_no_steps_execute() {
+        use crate::event_system::application::event_bus_service_impl::EventBusServiceImpl;
+        use crate::execution_engine::application::service_impl::{
+            ParallelExecutionServiceImpl, RetryEvaluationServiceImpl,
+        };
+        use crate::execution_engine::domain::ParallelExecutorConfig;
+        use crate::sequence_policy::application::service_impl::SequencePolicyServiceImpl;
+        use crate::sequence_policy::infrastructure::TomlSequencePolicyRepository;
+
+        // Corrupt operator file (unterminated rule table) on disk — the
+        // repository must surface Err, and the R2 gate must refuse the plan.
+        let path = std::env::temp_dir().join(format!("rigorix-sp-corrupt-{}.toml", Uuid::new_v4()));
+        tokio::fs::write(&path, "fail_closed = true\n[[rules]]\nid = 'unterminated")
+            .await
+            .expect("write corrupt config");
+
+        let executor: Arc<dyn exec_svc::ParallelExecutionService> =
+            Arc::new(ParallelExecutionServiceImpl::new(
+                ParallelExecutorConfig::default(),
+                Box::new(RetryEvaluationServiceImpl::new()),
+                Arc::new(EventBusServiceImpl::default()),
+            ));
+        let policy = Arc::new(SequencePolicyServiceImpl::new(Box::new(
+            TomlSequencePolicyRepository::new(&path),
+        )));
+        let orch = OrchestratorServiceImpl::new(
+            OrchestratorConfig::default(),
+            Arc::new(super::super::orchestrator_mocks::MockPlanningService::new()),
+            executor,
+            Arc::new(super::super::orchestrator_mocks::MockStateService::new()),
+            Arc::new(super::super::orchestrator_mocks::MockCancellationService),
+            Arc::new(super::super::orchestrator_mocks::MockEventBusService::new()),
+            None,
+            Arc::new(super::super::orchestrator_mocks::MockBudgetService),
+            None,
+        )
+        .with_sequence_policy(policy);
+        let eid = Uuid::new_v4();
+
+        let err = orch
+            .run_from_template(RunFromTemplateInput {
+                steps: conference_runbook(),
+                repo_root: "/tmp/t".into(),
+                execution_id: Some(eid),
+                template_name: "conf-registration".into(),
+                repository: None,
+                author: None,
+                enforcement_preset: None,
+            })
+            .await
+            .unwrap_err();
+        match &err {
+            OrchestratorError::SequencePolicyEvaluationFailed { detail } => {
+                assert!(
+                    detail.contains("Rule config invalid"),
+                    "evaluation failure must surface the config error: {detail}"
+                );
+            }
+            other => panic!("expected SequencePolicyEvaluationFailed, got {other}"),
+        }
+
+        // Fail closed before graph build: no engine session ⇒ no step of the
+        // corrupt-config runbook ever executed.
+        let state = orch.execution_state(eid).await;
+        assert!(
+            state.is_err(),
+            "no engine session ⇒ no steps executed under a corrupt rule file"
+        );
+        let _ = tokio::fs::remove_file(&path).await;
+    }
+
     /// AC#8 (engine side): plan preview surfaces the R2 decision as a
     /// structured finding BEFORE a run — a matched promote sequence reports
     /// the rule + later step and builds the later step approval-gated.

--- a/engine/src/sequence_policy/domain/config.rs
+++ b/engine/src/sequence_policy/domain/config.rs
@@ -56,6 +56,21 @@ const fn default_fail_closed() -> bool {
     true
 }
 
+impl Default for SafetyCaps {
+    /// Concrete default caps (the values the frozen contract tests use as
+    /// the example cap set): 100 rules / 8 step predicates per rule / window
+    /// 5 / 8 regex predicates per file. Operators who need more can extend
+    /// the caps surface; these defaults keep the rule engine bounded.
+    fn default() -> Self {
+        Self {
+            max_rules_per_file: 100,
+            max_steps_per_rule: 8,
+            max_window: 5,
+            max_regex_predicates_per_file: 8,
+        }
+    }
+}
+
 impl Default for SequencePolicyConfig {
     fn default() -> Self {
         Self {
@@ -77,7 +92,185 @@ impl SequencePolicyConfig {
     /// # Implementation
     /// TODO: enforced in the fail-closed / fail-open-absent issues (config
     /// load + parse land in `infrastructure/repository/toml_repository.rs`).
-    pub fn validate(&self, _caps: &SafetyCaps) -> Result<(), SequencePolicyError> {
-        todo!("ISSUE fail-closed/fail-open: enforce SafetyCaps over self.rules")
+    pub fn validate(&self, caps: &SafetyCaps) -> Result<(), SequencePolicyError> {
+        if self.rules.len() as u32 > caps.max_rules_per_file {
+            return Err(SequencePolicyError::RuleExceedsCaps {
+                rule: "<config>".to_string(),
+                detail: format!(
+                    "{} rules exceeds cap max_rules_per_file={}",
+                    self.rules.len(),
+                    caps.max_rules_per_file
+                ),
+            });
+        }
+
+        // Regex parameter predicates are a ReDoS / resource-exhaustion
+        // surface — counted across the whole file (module spec §Security).
+        let mut regex_predicates: u32 = 0;
+        for rule in &self.rules {
+            if rule.steps.len() as u32 > caps.max_steps_per_rule {
+                return Err(SequencePolicyError::RuleExceedsCaps {
+                    rule: rule.id.clone(),
+                    detail: format!(
+                        "{} step predicates exceeds cap max_steps_per_rule={}",
+                        rule.steps.len(),
+                        caps.max_steps_per_rule
+                    ),
+                });
+            }
+            if let Some(window) = rule.window
+                && window > caps.max_window
+            {
+                return Err(SequencePolicyError::RuleExceedsCaps {
+                    rule: rule.id.clone(),
+                    detail: format!("window {window} exceeds cap max_window={}", caps.max_window),
+                });
+            }
+            for step in &rule.steps {
+                regex_predicates += step
+                    .params
+                    .iter()
+                    .filter(|p| matches!(p.kind, super::rule::ParamMatchKind::Regex))
+                    .count() as u32;
+            }
+        }
+        if regex_predicates > caps.max_regex_predicates_per_file {
+            return Err(SequencePolicyError::RuleExceedsCaps {
+                rule: "<config>".to_string(),
+                detail: format!(
+                    "{regex_predicates} regex predicates exceeds cap max_regex_predicates_per_file={}",
+                    caps.max_regex_predicates_per_file
+                ),
+            });
+        }
+        Ok(())
+    }
+
+    /// Load-time convenience: validate against the concrete default caps.
+    pub fn validate_with_default_caps(&self) -> Result<(), SequencePolicyError> {
+        self.validate(&SafetyCaps::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sequence_policy::domain::{
+        ParamMatchKind, ParamPredicate, RuleAction, StepPredicate,
+    };
+
+    fn rule(id: &str, steps: usize) -> SequenceRule {
+        SequenceRule {
+            id: id.to_string(),
+            name: "n".to_string(),
+            description: "d".to_string(),
+            steps: (0..steps)
+                .map(|i| StepPredicate {
+                    tool: format!("tool_{i}"),
+                    params: vec![],
+                })
+                .collect(),
+            window: None,
+            action: RuleAction::Promote,
+        }
+    }
+
+    fn caps() -> SafetyCaps {
+        SafetyCaps {
+            max_rules_per_file: 2,
+            max_steps_per_rule: 3,
+            max_window: 5,
+            max_regex_predicates_per_file: 1,
+        }
+    }
+
+    #[test]
+    fn empty_config_validates() {
+        let config = SequencePolicyConfig::default();
+        assert!(config.validate_with_default_caps().is_ok());
+    }
+
+    #[test]
+    fn over_cap_rule_count_is_rejected() {
+        let config = SequencePolicyConfig {
+            fail_closed: true,
+            rules: vec![rule("r1", 2), rule("r2", 2), rule("r3", 2)],
+        };
+        let err = config.validate(&caps()).unwrap_err();
+        assert!(matches!(&err,
+            SequencePolicyError::RuleExceedsCaps { rule, .. } if rule == "<config>"
+        ));
+        assert!(!err.is_retriable());
+    }
+
+    #[test]
+    fn over_cap_steps_per_rule_is_rejected() {
+        let config = SequencePolicyConfig {
+            fail_closed: true,
+            rules: vec![rule("r1", 4)],
+        };
+        let err = config.validate(&caps()).unwrap_err();
+        assert!(matches!(&err,
+            SequencePolicyError::RuleExceedsCaps { rule, .. } if rule == "r1"
+        ));
+        assert!(err.to_string().contains("exceeds safety caps"));
+    }
+
+    #[test]
+    fn over_cap_window_is_rejected() {
+        let mut r = rule("r1", 2);
+        r.window = Some(6);
+        let config = SequencePolicyConfig {
+            fail_closed: true,
+            rules: vec![r],
+        };
+        let err = config.validate(&caps()).unwrap_err();
+        assert!(matches!(&err,
+            SequencePolicyError::RuleExceedsCaps { rule, .. } if rule == "r1"
+        ));
+    }
+
+    #[test]
+    fn over_cap_regex_predicates_are_rejected() {
+        // Two regex predicates > max_regex_predicates_per_file = 1.
+        let mut r = rule("r1", 1);
+        r.steps[0].params = vec![
+            ParamPredicate {
+                pointer: "/a".to_string(),
+                kind: ParamMatchKind::Regex,
+                value: ".*".to_string(),
+            },
+            ParamPredicate {
+                pointer: "/b".to_string(),
+                kind: ParamMatchKind::Regex,
+                value: "^x".to_string(),
+            },
+        ];
+        let config = SequencePolicyConfig {
+            fail_closed: true,
+            rules: vec![r],
+        };
+        let err = config.validate(&caps()).unwrap_err();
+        assert!(matches!(&err,
+            SequencePolicyError::RuleExceedsCaps { rule, .. } if rule == "<config>"
+        ));
+    }
+
+    #[test]
+    fn within_caps_validates_ok() {
+        let mut r = rule("r1", 2);
+        r.window = Some(3);
+        r.steps[0].params = vec![ParamPredicate {
+            pointer: "/a".to_string(),
+            kind: ParamMatchKind::Exact,
+            value: "x".to_string(),
+        }];
+        let config = SequencePolicyConfig {
+            fail_closed: true,
+            rules: vec![r],
+        };
+        assert!(config.validate(&caps()).is_ok());
+        // Default caps accept the same config.
+        assert!(config.validate_with_default_caps().is_ok());
     }
 }

--- a/engine/src/sequence_policy/infrastructure/repository/toml_repository.rs
+++ b/engine/src/sequence_policy/infrastructure/repository/toml_repository.rs
@@ -45,9 +45,124 @@ impl TomlSequencePolicyRepository {
 #[async_trait]
 impl SequencePolicyRepository for TomlSequencePolicyRepository {
     async fn load_config(&self) -> Result<Option<SequencePolicyConfig>, SequencePolicyError> {
-        todo!(
-            "fail-closed/fail-open-absent issues: read + parse {:?}, enforce SafetyCaps",
-            self.config_path
-        )
+        // Read the operator-authored rule file. A MISSING file is the
+        // fail-open-absent case: `Ok(None)` → no rules → no gating (status
+        // quo). Any other read failure is a load error (fail closed).
+        let text = match tokio::fs::read_to_string(&self.config_path).await {
+            Ok(text) => text,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => {
+                return Err(SequencePolicyError::InvalidConfig(format!(
+                    "failed to read {}: {e}",
+                    self.config_path.display()
+                )));
+            }
+        };
+
+        // Parse the flat operator schema: `fail_closed` (defaults true) at
+        // top level + ordered `[[rules]]` tables.
+        let config: SequencePolicyConfig = toml::from_str(&text).map_err(|e| {
+            SequencePolicyError::InvalidConfig(format!(
+                "parse error in {}: {e}",
+                self.config_path.display()
+            ))
+        })?;
+
+        // Enforce the safety caps (rule count, steps per rule, window, regex
+        // predicates) — an over-cap file refuses the plan like a corrupt one.
+        config.validate_with_default_caps()?;
+        Ok(Some(config))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sequence_policy::domain::{ParamMatchKind, RuleAction};
+
+    /// Write `content` to a unique temp file and return its path.
+    fn temp_file(content: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "rigorix-sp-toml-{}-{}.toml",
+            uuid::Uuid::new_v4(),
+            std::thread::current().name().unwrap_or("t")
+        ));
+        std::fs::write(&path, content).expect("write temp config");
+        path
+    }
+
+    fn conference_file() -> String {
+        r#"fail_closed = true
+
+[[rules]]
+id = "registration-remove-then-reassign"
+name = "No remove-then-reassign of a full event seat"
+description = "conference seat"
+steps = [
+  { tool = "registration_remove", params = [{ pointer = "/event_id", kind = "exact", value = "conf-2026" }] },
+  { tool = "registration_add",    params = [{ pointer = "/event_id", kind = "exact", value = "conf-2026" }] },
+]
+window = 3
+action = "promote"
+"#
+        .to_string()
+    }
+
+    #[tokio::test]
+    async fn missing_file_is_ok_none() {
+        let repo = TomlSequencePolicyRepository::new(
+            std::env::temp_dir()
+                .join("rigorix-absent-")
+                .join("no-such-config.toml"),
+        );
+        let loaded = repo.load_config().await.expect("missing file is Ok(None)");
+        assert!(loaded.is_none(), "absent config → no rules → no gating");
+    }
+
+    #[tokio::test]
+    async fn valid_operator_file_parses_into_config() {
+        let path = temp_file(&conference_file());
+        let repo = TomlSequencePolicyRepository::new(&path);
+        let loaded = repo.load_config().await.expect("load");
+        let config = loaded.expect("Some config");
+        assert!(config.fail_closed);
+        assert_eq!(config.rules.len(), 1);
+        let rule = &config.rules[0];
+        assert_eq!(rule.id, "registration-remove-then-reassign");
+        assert_eq!(rule.steps.len(), 2);
+        assert_eq!(rule.steps[0].params[0].kind, ParamMatchKind::Exact);
+        assert_eq!(rule.window, Some(3));
+        assert_eq!(rule.action, RuleAction::Promote);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn corrupt_file_is_err_invalid_config() {
+        let path = temp_file("fail_closed = true\n[[rules]]\nid = 'unterminated");
+        let repo = TomlSequencePolicyRepository::new(&path);
+        let err = repo.load_config().await.expect_err("corrupt TOML must Err");
+        assert!(matches!(err, SequencePolicyError::InvalidConfig(_)));
+        assert!(!err.is_retriable());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn over_cap_file_is_err_rule_exceeds_caps() {
+        // 9 step predicates > max_steps_per_rule default (8).
+        let mut toml = String::from(
+            "[[rules]]\nid = \"over-cap\"\nname = \"n\"\ndescription = \"d\"\nsteps = [\n",
+        );
+        for i in 0..9 {
+            toml.push_str(&format!("  {{ tool = \"tool_{i}\" }},\n"));
+        }
+        toml.push_str("]\n");
+        let path = temp_file(&toml);
+        let repo = TomlSequencePolicyRepository::new(&path);
+        let err = repo.load_config().await.expect_err("over-cap must Err");
+        assert!(matches!(&err,
+            SequencePolicyError::RuleExceedsCaps { rule, .. } if rule == "over-cap"
+        ));
+        assert!(!err.is_retriable());
+        let _ = std::fs::remove_file(&path);
     }
 }


### PR DESCRIPTION
## ISSUE-SEQUENCE-POLICY-9: Fail-closed — corrupt rule config refuses the plan (#847)

### What
**AC#10**: *Corrupt rule config → plan refused, no steps execute* — full-chain integration test.

### Changes
- **`TomlSequencePolicyRepository::load_config`** implemented (was a `todo!()` stub):
  - missing file → `Ok(None)` (fail-open-absent — never an error)
  - corrupt TOML → `Err(InvalidConfig)` (fail closed)
  - over safety caps → `Err(RuleExceedsCaps)` (fail closed)
  - valid flat operator schema (`fail_closed` defaults true + ordered `[[rules]]`) → parsed config
- **`SafetyCaps::default()`** — concrete caps (100 rules / 8 step predicates per rule / window 5 / 8 regex predicates per file) and **`SequencePolicyConfig::validate()`** enforcing every cap — rule count, steps per rule, window, and regex predicates (the ReDoS / resource-exhaustion surface) — across the file
- The orchestrator R2 gate (from #844) already propagates service load errors → `run_from_template` refuses with `SequencePolicyEvaluationFailed` **before graph build** — no step ever executes

### Acceptance criteria
- **AC 10** — `test_sequence_policy_corrupt_config_refuses_run_no_steps_execute`: real `TomlSequencePolicyRepository` over a corrupt temp operator file → real `SequencePolicyServiceImpl` → real-engine orchestrator; `run_from_template` returns `Err(SequencePolicyEvaluationFailed)` carrying the config error; no engine session exists (no step executed)
- Repository tests: missing → `Ok(None)`, valid file parses, corrupt → `InvalidConfig`, over-cap → `RuleExceedsCaps`
- Config tests: all four caps enforced; within-caps passes; empty config passes

### Evidence
- `cargo test -p rigorix-engine --lib` 1999/1999; clippy `--all-targets -D warnings` + fmt green
- `validate-ci.sh` 5/5 PASS; canonical + security PASS
- (validate-tests.sh unchanged pre-existing `--test integration` main bug)

Closes #847.
