### PR TITLE
[Issue #849] ISSUE-SEQUENCE-POLICY-11: Audit R6 — envelope events + redacted summaries

### DIFF
--- a/actions/src/main.rs
+++ b/actions/src/main.rs
@@ -405,6 +405,7 @@ async fn build_action_orchestrator(
             permission_enforcer,
             hook_runner,
             approval_binding,
+            sequence_policy: None,
         })
         .await
         .map_err(|e| format!("execution: {e}"))?;

--- a/cli/src/cli_boundary/orchestrator.rs
+++ b/cli/src/cli_boundary/orchestrator.rs
@@ -327,6 +327,7 @@ pub async fn build_orchestrator_with_budget(
             permission_enforcer,
             hook_runner,
             approval_binding,
+            sequence_policy: None,
         })
         .await
         .map_err(|e| CliError::General(format!("execution: {e}")))?;

--- a/cli/src/tui/event_bridge.rs
+++ b/cli/src/tui/event_bridge.rs
@@ -391,7 +391,10 @@ pub(crate) fn event_to_vm_command(event: &ExecutionEvent) -> Option<VmCommand> {
         | ExecutionEvent::AuditEnvelopeCreated { .. }
         | ExecutionEvent::ApprovalRecorded { .. }
         | ExecutionEvent::IntentMismatchDetected { .. }
-        | ExecutionEvent::ScopeViolationRecorded { .. } => None,
+        | ExecutionEvent::ScopeViolationRecorded { .. }
+        | ExecutionEvent::SequenceRuleMatched { .. }
+        | ExecutionEvent::SequencePolicyDenied { .. }
+        | ExecutionEvent::SequencePolicyConfigError { .. } => None,
     }
 }
 

--- a/engine/src/audit/application/audit_queue_impl.rs
+++ b/engine/src/audit/application/audit_queue_impl.rs
@@ -158,6 +158,7 @@ mod tests {
             file_paths: vec![],
             scoring_results: std::collections::HashMap::new(),
             approval_events: Vec::new(),
+            sequence_policy_findings: Vec::new(),
             scope_violations: Vec::new(),
             decision_context_ref: None,
             signature: None,

--- a/engine/src/audit/application/audit_sender_impl.rs
+++ b/engine/src/audit/application/audit_sender_impl.rs
@@ -412,6 +412,7 @@ mod tests {
             file_paths: vec![],
             scoring_results: std::collections::HashMap::new(),
             approval_events: Vec::new(),
+            sequence_policy_findings: Vec::new(),
             scope_violations: Vec::new(),
             decision_context_ref: None,
             signature: None,

--- a/engine/src/audit/application/envelope_factory_impl.rs
+++ b/engine/src/audit/application/envelope_factory_impl.rs
@@ -108,6 +108,7 @@ impl AuditEnvelopeFactory for AuditEnvelopeFactoryImpl {
             scoring_results: input.scoring_results,
             approval_events: Self::approval_refs_from_events(&input.events),
             scope_violations: Self::scope_refs_from_events(&input.events),
+            sequence_policy_findings: Self::sequence_policy_findings_from_events(&input.events),
             decision_context_ref: Self::decision_context_ref_from_events(&input.events),
             signature: None,
             // GAP-M-12: an unsigned run is explicitly degraded evidence.
@@ -410,6 +411,56 @@ impl AuditEnvelopeFactoryImpl {
     }
 
     /// ADR-011 R5: derive scope-violation refs from drained events.
+    /// R6: derive redacted sequence-policy findings from the run's events
+    /// (`sequence_rule_matched` / `sequence_policy_denied`). Summaries are
+    /// pre-redacted at the source (SpanPrivacy default — parameter values
+    /// never enter event payloads).
+    fn sequence_policy_findings_from_events(
+        events: &[crate::audit::domain::ExecutionEventRef],
+    ) -> Vec<crate::audit::domain::SequencePolicyFindingRef> {
+        let mut out = Vec::new();
+        for e in events {
+            if e.event_type != "sequence_rule_matched" && e.event_type != "sequence_policy_denied" {
+                continue;
+            }
+            let Some(payload) = &e.payload else { continue };
+            let Some(rule_id) = payload.get("rule_id").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let Some(later_step) = payload.get("later_step").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let action = payload
+                .get("action")
+                .and_then(|v| v.as_str())
+                .unwrap_or("deny")
+                .to_string();
+            let matched_indices = payload
+                .get("matched_indices")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|x| x.as_u64())
+                        .map(|i| i as usize)
+                        .collect()
+                })
+                .unwrap_or_default();
+            let summary = payload
+                .get("summary")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            out.push(crate::audit::domain::SequencePolicyFindingRef {
+                rule_id: rule_id.to_string(),
+                action,
+                later_step: later_step.to_string(),
+                matched_indices,
+                summary,
+            });
+        }
+        out
+    }
+
     fn scope_refs_from_events(
         events: &[crate::audit::domain::ExecutionEventRef],
     ) -> Vec<crate::audit::domain::ScopeViolationRef> {

--- a/engine/src/audit/domain/envelope.rs
+++ b/engine/src/audit/domain/envelope.rs
@@ -126,6 +126,17 @@ pub struct AuditEnvelope {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub scope_violations: Vec<ScopeViolationRef>,
 
+    /// Sequence-policy decisions recorded during the run (R6): every matched
+    /// rule — promoted later step or dispatch-boundary deny — as a redacted
+    /// finding. Answers "why did the run pause / why was this step denied"
+    /// from the signed record.
+    ///
+    /// Additive and serde-defaulted: absent in pre-sequence-policy envelopes.
+    /// Summaries redact parameter values by default (SpanPrivacy pattern);
+    /// full payloads are opt-in and never leave the local store.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sequence_policy_findings: Vec<SequencePolicyFindingRef>,
+
     /// Reference + summary of the decision context shown to the approver;
     /// the full payload is opt-in and stored locally (R4 privacy pattern).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -150,6 +161,28 @@ pub struct ApprovalRecordRef {
     pub authority: Option<String>,
     /// When the human approved.
     pub decided_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// A redacted reference to a sequence-policy decision (R6).
+///
+/// Summary fields only — the rule id, action taken, the concrete matched
+/// step indices, and a decision summary that NEVER carries step parameter
+/// values (SpanPrivacy default; the full payload is opt-in and local).
+/// Derived from `sequence_rule_matched` / `sequence_policy_denied` events
+/// at envelope build time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SequencePolicyFindingRef {
+    /// Stable id of the rule that matched.
+    pub rule_id: String,
+    /// Action taken: `"promote"` (later step paused for a human) or
+    /// `"deny"` (step denied before dispatch).
+    pub action: String,
+    /// Name of the later matched step — the step the rule gated.
+    pub later_step: String,
+    /// Indices (into the evaluated ordered step list) of the matched steps.
+    pub matched_indices: Vec<usize>,
+    /// Redacted decision summary (parameter values never included).
+    pub summary: String,
 }
 
 /// A reference to a recorded effect-scope violation (ADR-011 R5).

--- a/engine/src/audit/infrastructure/local_audit_repository.rs
+++ b/engine/src/audit/infrastructure/local_audit_repository.rs
@@ -240,6 +240,7 @@ mod tests {
             file_paths: vec![],
             scoring_results: std::collections::HashMap::new(),
             approval_events: Vec::new(),
+            sequence_policy_findings: Vec::new(),
             scope_violations: Vec::new(),
             decision_context_ref: None,
             signature: None,

--- a/engine/src/event_system/application/event_bus_service_impl.rs
+++ b/engine/src/event_system/application/event_bus_service_impl.rs
@@ -205,6 +205,9 @@ impl EventBusService for EventBusServiceImpl {
                         | ExecutionEvent::ApprovalRecorded { execution_id, .. }
                         | ExecutionEvent::IntentMismatchDetected { execution_id, .. }
                         | ExecutionEvent::ScopeViolationRecorded { execution_id, .. }
+                        | ExecutionEvent::SequenceRuleMatched { execution_id, .. }
+                        | ExecutionEvent::SequencePolicyDenied { execution_id, .. }
+                        | ExecutionEvent::SequencePolicyConfigError { execution_id, .. }
                         | ExecutionEvent::AuditEnvelopeCreated { execution_id, .. } => {
                             if execution_id != eid {
                                 return false;
@@ -249,6 +252,11 @@ impl EventBusService for EventBusServiceImpl {
                         ExecutionEvent::ApprovalRecorded { .. } => "approval_recorded",
                         ExecutionEvent::IntentMismatchDetected { .. } => "intent_mismatch_detected",
                         ExecutionEvent::ScopeViolationRecorded { .. } => "scope_violation_recorded",
+                        ExecutionEvent::SequenceRuleMatched { .. } => "sequence_rule_matched",
+                        ExecutionEvent::SequencePolicyDenied { .. } => "sequence_policy_denied",
+                        ExecutionEvent::SequencePolicyConfigError { .. } => {
+                            "sequence_policy_config_error"
+                        }
                     };
                     if variant_name != event_type {
                         return false;
@@ -278,7 +286,10 @@ impl EventBusService for EventBusServiceImpl {
                         ExecutionEvent::AuditEnvelopeCreated { timestamp, .. } => timestamp,
                         ExecutionEvent::ApprovalRecorded { timestamp, .. }
                         | ExecutionEvent::IntentMismatchDetected { timestamp, .. }
-                        | ExecutionEvent::ScopeViolationRecorded { timestamp, .. } => timestamp,
+                        | ExecutionEvent::ScopeViolationRecorded { timestamp, .. }
+                        | ExecutionEvent::SequenceRuleMatched { timestamp, .. }
+                        | ExecutionEvent::SequencePolicyDenied { timestamp, .. }
+                        | ExecutionEvent::SequencePolicyConfigError { timestamp, .. } => timestamp,
                     };
                     if ts < after {
                         return false;
@@ -307,7 +318,10 @@ impl EventBusService for EventBusServiceImpl {
                         ExecutionEvent::AuditEnvelopeCreated { timestamp, .. } => timestamp,
                         ExecutionEvent::ApprovalRecorded { timestamp, .. }
                         | ExecutionEvent::IntentMismatchDetected { timestamp, .. }
-                        | ExecutionEvent::ScopeViolationRecorded { timestamp, .. } => timestamp,
+                        | ExecutionEvent::ScopeViolationRecorded { timestamp, .. }
+                        | ExecutionEvent::SequenceRuleMatched { timestamp, .. }
+                        | ExecutionEvent::SequencePolicyDenied { timestamp, .. }
+                        | ExecutionEvent::SequencePolicyConfigError { timestamp, .. } => timestamp,
                     };
                     if ts > before {
                         return false;

--- a/engine/src/event_system/domain/event.rs
+++ b/engine/src/event_system/domain/event.rs
@@ -331,6 +331,57 @@ pub enum ExecutionEvent {
         /// ISO 8601 timestamp of the event.
         timestamp: DateTime<Utc>,
     },
+
+    /// A sequence-policy rule matched at plan time (R2) or the runtime
+    /// dispatch boundary (R3): the later step was promoted (`requires_approval`
+    /// flipped — the existing approval pause decides) or denied. First-class
+    /// evidence — the envelope's `sequence_policy_findings[]` answer "why did
+    /// the run pause / why was this step denied".
+    SequenceRuleMatched {
+        /// Globally unique execution identifier.
+        execution_id: uuid::Uuid,
+        /// Stable id of the rule that matched.
+        rule_id: String,
+        /// Action taken: `"promote"` or `"deny"`.
+        action: String,
+        /// Name of the later matched step (the gated step).
+        later_step: String,
+        /// Indices (into the evaluated ordered step list) of the matched
+        /// concrete steps, in rule order.
+        matched_indices: Vec<usize>,
+        /// Redacted decision summary — parameter VALUES are never captured
+        /// (SpanPrivacy default; full payload opt-in only).
+        summary: String,
+        /// ISO 8601 timestamp of the event.
+        timestamp: DateTime<Utc>,
+    },
+
+    /// A runtime (R3) dispatch-boundary deny: the step completing a forbidden
+    /// sequence was denied BEFORE dispatch — its tool was never called.
+    SequencePolicyDenied {
+        /// Globally unique execution identifier.
+        execution_id: uuid::Uuid,
+        /// Stable id of the rule that matched.
+        rule_id: String,
+        /// Name of the later matched step that was denied.
+        later_step: String,
+        /// Human-readable reason (names the rule; never parameter values).
+        reason: String,
+        /// ISO 8601 timestamp of the event.
+        timestamp: DateTime<Utc>,
+    },
+
+    /// Sequence-policy evaluation failed (corrupt / over-cap rule config or
+    /// internal) — the run halts fail-closed. Recorded so the refusal is
+    /// never silent (GAP-M-14 pattern).
+    SequencePolicyConfigError {
+        /// Globally unique execution identifier.
+        execution_id: uuid::Uuid,
+        /// What failed (the config error detail).
+        detail: String,
+        /// ISO 8601 timestamp of the event.
+        timestamp: DateTime<Utc>,
+    },
 }
 
 /// A persisted execution event with a monotonic sequence number.
@@ -376,6 +427,9 @@ impl ExecutionEvent {
             ExecutionEvent::AuditEnvelopeDropped { .. } => "audit_envelope_dropped",
             ExecutionEvent::CircuitBreakerStateChanged { .. } => "circuit_breaker_state_changed",
             ExecutionEvent::ApprovalRecorded { .. } => "approval_recorded",
+            ExecutionEvent::SequenceRuleMatched { .. } => "sequence_rule_matched",
+            ExecutionEvent::SequencePolicyDenied { .. } => "sequence_policy_denied",
+            ExecutionEvent::SequencePolicyConfigError { .. } => "sequence_policy_config_error",
             ExecutionEvent::IntentMismatchDetected { .. } => "intent_mismatch_detected",
             ExecutionEvent::ScopeViolationRecorded { .. } => "scope_violation_recorded",
             ExecutionEvent::AuditEnvelopeCreated { .. } => "audit_envelope_created",
@@ -403,7 +457,10 @@ impl ExecutionEvent {
             | ExecutionEvent::AuditEnvelopeCreated { execution_id, .. } => execution_id,
             ExecutionEvent::ApprovalRecorded { execution_id, .. }
             | ExecutionEvent::IntentMismatchDetected { execution_id, .. }
-            | ExecutionEvent::ScopeViolationRecorded { execution_id, .. } => execution_id,
+            | ExecutionEvent::ScopeViolationRecorded { execution_id, .. }
+            | ExecutionEvent::SequenceRuleMatched { execution_id, .. }
+            | ExecutionEvent::SequencePolicyDenied { execution_id, .. }
+            | ExecutionEvent::SequencePolicyConfigError { execution_id, .. } => execution_id,
         }
     }
 
@@ -428,13 +485,26 @@ impl ExecutionEvent {
             | ExecutionEvent::AuditEnvelopeCreated { timestamp, .. }
             | ExecutionEvent::ApprovalRecorded { timestamp, .. }
             | ExecutionEvent::IntentMismatchDetected { timestamp, .. }
-            | ExecutionEvent::ScopeViolationRecorded { timestamp, .. } => timestamp,
+            | ExecutionEvent::ScopeViolationRecorded { timestamp, .. }
+            | ExecutionEvent::SequenceRuleMatched { timestamp, .. }
+            | ExecutionEvent::SequencePolicyDenied { timestamp, .. }
+            | ExecutionEvent::SequencePolicyConfigError { timestamp, .. } => timestamp,
         }
     }
 
     /// Returns a human-friendly summary string for this event.
     pub fn summary(&self) -> String {
         match self {
+            ExecutionEvent::SequenceRuleMatched { summary, .. } => summary.clone(),
+            ExecutionEvent::SequencePolicyDenied {
+                rule_id,
+                later_step,
+                reason,
+                ..
+            } => format!("Sequence policy denied: {later_step} by rule '{rule_id}' — {reason}"),
+            ExecutionEvent::SequencePolicyConfigError { detail, .. } => {
+                format!("Sequence policy config error: {detail}")
+            }
             ExecutionEvent::ApprovalRecorded {
                 step_name,
                 approver_id,
@@ -590,6 +660,33 @@ impl ExecutionEvent {
     /// tool usage, errors) and `None` for informational events.
     pub fn payload_json(&self) -> Option<serde_json::Value> {
         match self {
+            ExecutionEvent::SequenceRuleMatched {
+                rule_id,
+                action,
+                later_step,
+                matched_indices,
+                summary,
+                ..
+            } => Some(serde_json::json!({
+                "rule_id": rule_id,
+                "action": action,
+                "later_step": later_step,
+                "matched_indices": matched_indices,
+                "summary": summary,
+            })),
+            ExecutionEvent::SequencePolicyDenied {
+                rule_id,
+                later_step,
+                reason,
+                ..
+            } => Some(serde_json::json!({
+                "rule_id": rule_id,
+                "later_step": later_step,
+                "reason": reason,
+            })),
+            ExecutionEvent::SequencePolicyConfigError { detail, .. } => Some(serde_json::json!({
+                "detail": detail,
+            })),
             ExecutionEvent::ApprovalRecorded {
                 node_id,
                 step_name,

--- a/engine/src/event_system/infrastructure/in_memory_event_repository.rs
+++ b/engine/src/event_system/infrastructure/in_memory_event_repository.rs
@@ -118,6 +118,9 @@ impl PersistedEventRepository for InMemoryEventRepository {
                         | ExecutionEvent::ApprovalRecorded { execution_id, .. }
                         | ExecutionEvent::IntentMismatchDetected { execution_id, .. }
                         | ExecutionEvent::ScopeViolationRecorded { execution_id, .. }
+                        | ExecutionEvent::SequenceRuleMatched { execution_id, .. }
+                        | ExecutionEvent::SequencePolicyDenied { execution_id, .. }
+                        | ExecutionEvent::SequencePolicyConfigError { execution_id, .. }
                         | ExecutionEvent::AuditEnvelopeCreated { execution_id, .. } => {
                             if execution_id != eid {
                                 return false;
@@ -159,6 +162,11 @@ impl PersistedEventRepository for InMemoryEventRepository {
                         ExecutionEvent::ApprovalRecorded { .. } => "approval_recorded",
                         ExecutionEvent::IntentMismatchDetected { .. } => "intent_mismatch_detected",
                         ExecutionEvent::ScopeViolationRecorded { .. } => "scope_violation_recorded",
+                        ExecutionEvent::SequenceRuleMatched { .. } => "sequence_rule_matched",
+                        ExecutionEvent::SequencePolicyDenied { .. } => "sequence_policy_denied",
+                        ExecutionEvent::SequencePolicyConfigError { .. } => {
+                            "sequence_policy_config_error"
+                        }
                     };
                     if variant_name != event_type {
                         return false;
@@ -186,7 +194,10 @@ impl PersistedEventRepository for InMemoryEventRepository {
                     ExecutionEvent::AuditEnvelopeCreated { timestamp, .. } => timestamp,
                     ExecutionEvent::ApprovalRecorded { timestamp, .. }
                     | ExecutionEvent::IntentMismatchDetected { timestamp, .. }
-                    | ExecutionEvent::ScopeViolationRecorded { timestamp, .. } => timestamp,
+                    | ExecutionEvent::ScopeViolationRecorded { timestamp, .. }
+                    | ExecutionEvent::SequenceRuleMatched { timestamp, .. }
+                    | ExecutionEvent::SequencePolicyDenied { timestamp, .. }
+                    | ExecutionEvent::SequencePolicyConfigError { timestamp, .. } => timestamp,
                 };
                 if let Some(after) = &input.after_timestamp
                     && ts < after
@@ -260,7 +271,10 @@ impl PersistedEventRepository for InMemoryEventRepository {
                 ExecutionEvent::AuditEnvelopeCreated { timestamp, .. } => timestamp,
                 ExecutionEvent::ApprovalRecorded { timestamp, .. }
                 | ExecutionEvent::IntentMismatchDetected { timestamp, .. }
-                | ExecutionEvent::ScopeViolationRecorded { timestamp, .. } => timestamp,
+                | ExecutionEvent::ScopeViolationRecorded { timestamp, .. }
+                | ExecutionEvent::SequenceRuleMatched { timestamp, .. }
+                | ExecutionEvent::SequencePolicyDenied { timestamp, .. }
+                | ExecutionEvent::SequencePolicyConfigError { timestamp, .. } => timestamp,
             };
             ts >= &older_than
         });

--- a/engine/src/execution_engine/application/service_impl.rs
+++ b/engine/src/execution_engine/application/service_impl.rs
@@ -1170,6 +1170,13 @@ impl ParallelExecutionServiceImpl {
         let matches = match svc.evaluate_prefix(&prefix, &next).await {
             Ok(m) => m,
             Err(e) => {
+                // R6: record the fail-closed halt (GAP-M-14 — never silent).
+                self.publish_event(ExecutionEvent::SequencePolicyConfigError {
+                    execution_id: dag_id,
+                    detail: e.to_string(),
+                    timestamp: chrono::Utc::now(),
+                })
+                .await;
                 return Err(ExecutionError::InternalError {
                     detail: format!(
                         "Sequence policy evaluation failed — run halted before dispatch (fail closed): {e}"
@@ -1178,15 +1185,43 @@ impl ParallelExecutionServiceImpl {
             }
         };
 
+        // R6 evidence: record the runtime gate decision as first-class
+        // events BEFORE acting on it (envelope `sequence_policy_findings[]`
+        // derives from these). Summaries are pre-redacted (SpanPrivacy).
         for m in &matches {
             if m.action == RuleAction::Deny {
+                self.publish_event(ExecutionEvent::SequencePolicyDenied {
+                    execution_id: dag_id,
+                    rule_id: m.rule_id.clone(),
+                    later_step: m.later_step.clone(),
+                    reason: format!(
+                        "rule '{}' denies step '{}' before dispatch",
+                        m.rule_id, m.later_step
+                    ),
+                    timestamp: chrono::Utc::now(),
+                })
+                .await;
                 return Ok(SequencePolicyVerdict::Deny {
                     rule_id: m.rule_id.clone(),
                     later_step: m.later_step.clone(),
                 });
             }
         }
+        // A previously promoted-and-approved node dispatches on resume — its
+        // promotion was already recorded when it was first gated.
         if matches.iter().any(|m| m.action == RuleAction::Promote) && !approved.contains(&node_id) {
+            for m in matches.iter().filter(|m| m.action == RuleAction::Promote) {
+                self.publish_event(ExecutionEvent::SequenceRuleMatched {
+                    execution_id: dag_id,
+                    rule_id: m.rule_id.clone(),
+                    action: "promote".to_string(),
+                    later_step: m.later_step.clone(),
+                    matched_indices: m.matched_indices.clone(),
+                    summary: m.decision_summary(),
+                    timestamp: chrono::Utc::now(),
+                })
+                .await;
+            }
             return Ok(SequencePolicyVerdict::Promote);
         }
         Ok(SequencePolicyVerdict::Dispatch)

--- a/engine/src/orchestrator/application/orchestrator_impl.rs
+++ b/engine/src/orchestrator/application/orchestrator_impl.rs
@@ -432,6 +432,7 @@ impl OrchestratorServiceImpl {
     async fn apply_plan_time_sequence_policy(
         &self,
         steps: &[super::dto::TemplateStepDef],
+        execution_id: Option<uuid::Uuid>,
     ) -> Result<
         (
             Option<Vec<super::dto::TemplateStepDef>>,
@@ -471,6 +472,31 @@ impl OrchestratorServiceImpl {
                 }
                 crate::sequence_policy::domain::RuleAction::Promote => {
                     promoted.push(m.later_step.clone());
+                    // R6 evidence: every plan-time promotion is a first-class
+                    // event before anything executes — the envelope derives
+                    // `sequence_policy_findings[]` from it. Summary is
+                    // pre-redacted (SpanPrivacy — parameter values never
+                    // captured). Plan PREVIEW (None execution id) records no
+                    // events: the finding data travels in PlanOnlyOutput.
+                    if let Some(execution_id) = execution_id {
+                        self.event_bus
+                            .publish(event_app::PublishEventInput {
+                                event: crate::event_system::domain::ExecutionEvent::SequenceRuleMatched {
+                                    execution_id,
+                                    rule_id: m.rule_id.clone(),
+                                    action: "promote".to_string(),
+                                    later_step: m.later_step.clone(),
+                                    matched_indices: m.matched_indices.clone(),
+                                    summary: m.decision_summary(),
+                                    timestamp: chrono::Utc::now(),
+                                },
+                            })
+                            .await
+                            .map_err(|e| OrchestratorError::Internal {
+                                detail: format!("Sequence-policy evidence publish failed: {e}"),
+                                source_module: "orchestrator".into(),
+                            })?;
+                    }
                     findings.push(super::dto::SequencePolicyFinding {
                         rule_id: m.rule_id.clone(),
                         later_step: m.later_step.clone(),
@@ -980,6 +1006,18 @@ impl OrchestratorService for OrchestratorServiceImpl {
                             | crate::event_system::domain::ExecutionEvent::ScopeViolationRecorded {
                                 timestamp,
                                 ..
+                            }
+                            | crate::event_system::domain::ExecutionEvent::SequenceRuleMatched {
+                                timestamp,
+                                ..
+                            }
+                            | crate::event_system::domain::ExecutionEvent::SequencePolicyDenied {
+                                timestamp,
+                                ..
+                            }
+                            | crate::event_system::domain::ExecutionEvent::SequencePolicyConfigError {
+                                timestamp,
+                                ..
                             } => *timestamp,
                         };
                         ExecutionEventInfo {
@@ -1178,8 +1216,9 @@ impl OrchestratorService for OrchestratorServiceImpl {
         // fail-closed — the forbidden sequence never executes and the denied
         // step's tool is never called. An evaluation error refuses the plan
         // too (fail closed on corrupt/over-cap rule config).
-        let (enforced_steps, _findings) =
-            self.apply_plan_time_sequence_policy(&input.steps).await?;
+        let (enforced_steps, _findings) = self
+            .apply_plan_time_sequence_policy(&input.steps, Some(execution_id))
+            .await?;
 
         // Init current execution state
         *self.current_execution.write().await = Some(CurrentExecutionState {
@@ -1559,6 +1598,18 @@ impl OrchestratorService for OrchestratorServiceImpl {
                             | crate::event_system::domain::ExecutionEvent::ScopeViolationRecorded {
                                 timestamp,
                                 ..
+                            }
+                            | crate::event_system::domain::ExecutionEvent::SequenceRuleMatched {
+                                timestamp,
+                                ..
+                            }
+                            | crate::event_system::domain::ExecutionEvent::SequencePolicyDenied {
+                                timestamp,
+                                ..
+                            }
+                            | crate::event_system::domain::ExecutionEvent::SequencePolicyConfigError {
+                                timestamp,
+                                ..
                             } => *timestamp,
                         };
                         ExecutionEventInfo {
@@ -1681,7 +1732,9 @@ impl OrchestratorService for OrchestratorServiceImpl {
     ) -> Result<PlanOnlyOutput, OrchestratorError> {
         // Same R2 gate as `run_from_template` — a preview must show the same
         // promotion/denial decisions as the run it precedes.
-        let (enforced_steps, findings) = self.apply_plan_time_sequence_policy(&input.steps).await?;
+        let (enforced_steps, findings) = self
+            .apply_plan_time_sequence_policy(&input.steps, None)
+            .await?;
         let steps: &[super::dto::TemplateStepDef] =
             enforced_steps.as_deref().unwrap_or(&input.steps);
         let graph = self.build_graph_from_steps(steps)?;
@@ -1900,6 +1953,7 @@ mod tests {
                     events: vec![],
                     scoring_results: std::collections::HashMap::new(),
                     approval_events: Vec::new(),
+                    sequence_policy_findings: Vec::new(),
                     scope_violations: Vec::new(),
                     decision_context_ref: None,
                     signature: None,
@@ -2750,6 +2804,118 @@ mod tests {
         assert!(
             remove.started_at.is_some() && add.started_at.is_some(),
             "both runbook steps must dispatch unchanged (no pause, no denial)"
+        );
+    }
+
+    /// AC#12: the matched rule + promotion are recorded as first-class
+    /// envelope events — the run's drained events carry `sequence_rule_matched`
+    /// (rule id, action, later step, matched indices) and the envelope's
+    /// `sequence_policy_findings[]` derives redacted decision summaries
+    /// (SpanPrivacy: parameter VALUES never captured by default).
+    #[tokio::test]
+    async fn test_sequence_policy_promotion_recorded_in_envelope_events_redacted() {
+        use crate::audit::application::envelope_factory_impl::AuditEnvelopeFactoryImpl;
+        use crate::audit::application::factory::AuditEnvelopeFactory;
+        use crate::event_system::application::event_bus_service_impl::EventBusServiceImpl;
+        use crate::execution_engine::application::service_impl::{
+            ParallelExecutionServiceImpl, RetryEvaluationServiceImpl,
+        };
+        use crate::execution_engine::domain::ParallelExecutorConfig;
+        use crate::sequence_policy::application::service_impl::SequencePolicyServiceImpl;
+
+        // Real engine + policy service + REAL shared event bus so the
+        // promotion evidence lands in the run's drained events.
+        let captured = Arc::new(std::sync::Mutex::new(None));
+        let bus: Arc<dyn event_app::EventBusService> = Arc::new(EventBusServiceImpl::default());
+        let executor: Arc<dyn exec_svc::ParallelExecutionService> =
+            Arc::new(ParallelExecutionServiceImpl::new(
+                ParallelExecutorConfig::default(),
+                Box::new(RetryEvaluationServiceImpl::new()),
+                Arc::clone(&bus),
+            ));
+        let policy = Arc::new(SequencePolicyServiceImpl::new(Box::new(FixedPolicyRepo {
+            config: Some(conference_policy(RuleAction::Promote)),
+        })));
+        let orch = OrchestratorServiceImpl::new(
+            OrchestratorConfig::default(),
+            Arc::new(super::super::orchestrator_mocks::MockPlanningService::new()),
+            executor,
+            Arc::new(super::super::orchestrator_mocks::MockStateService::new()),
+            Arc::new(super::super::orchestrator_mocks::MockCancellationService),
+            Arc::clone(&bus),
+            Some(Arc::new(CapturingAuditService {
+                captured: captured.clone(),
+            })),
+            Arc::new(super::super::orchestrator_mocks::MockBudgetService),
+            None,
+        )
+        .with_sequence_policy(policy);
+
+        // The promote rule pauses the runbook at the later step; the R2 gate
+        // published the SequenceRuleMatched evidence BEFORE any step ran.
+        let out = orch
+            .run_from_template(RunFromTemplateInput {
+                steps: conference_runbook(),
+                repo_root: "/tmp/t".into(),
+                execution_id: None,
+                template_name: "conf-registration".into(),
+                repository: None,
+                author: None,
+                enforcement_preset: None,
+            })
+            .await
+            .expect("promoted runbook pauses (not an error)");
+        assert_eq!(out.record.status, ExecutionStatus::PendingApproval);
+
+        // 1. The run's events carry the structured match — rule, action,
+        // later step, indices — and NO parameter values anywhere.
+        let input = captured
+            .lock()
+            .unwrap()
+            .take()
+            .expect("audit service must receive the envelope input");
+        let matched = input
+            .events
+            .iter()
+            .find(|e| e.event_type == "sequence_rule_matched")
+            .expect("promotion must be recorded as an envelope event");
+        let payload = matched
+            .payload
+            .as_ref()
+            .expect("match event carries a structured payload");
+        assert_eq!(
+            payload["rule_id"], "registration-remove-then-reassign",
+            "envelope event names the matched rule"
+        );
+        assert_eq!(payload["later_step"], "registration_add");
+        assert_eq!(payload["action"], "promote");
+        assert_eq!(payload["matched_indices"], serde_json::json!([0, 1]));
+        let event_json = serde_json::to_string(payload).expect("serialize event payload");
+        assert!(
+            !event_json.contains("conf-2026"),
+            "SpanPrivacy: parameter values must not leak into the event payload: {event_json}"
+        );
+
+        // 2. The envelope derives the redacted sequence_policy_findings[].
+        let envelope = AuditEnvelopeFactoryImpl::new(None)
+            .build_envelope(input)
+            .await
+            .expect("envelope build");
+        assert_eq!(envelope.sequence_policy_findings.len(), 1);
+        let finding = &envelope.sequence_policy_findings[0];
+        assert_eq!(finding.rule_id, "registration-remove-then-reassign");
+        assert_eq!(finding.action, "promote");
+        assert_eq!(finding.later_step, "registration_add");
+        assert_eq!(finding.matched_indices, vec![0, 1]);
+        assert!(
+            finding.summary.contains("registration_add")
+                && finding.summary.contains("parameter values redacted"),
+            "decision summary is redacted by default: {}",
+            finding.summary
+        );
+        assert!(
+            !finding.summary.contains("conf-2026"),
+            "redacted summary must not carry parameter values"
         );
     }
 

--- a/engine/src/orchestrator/application/orchestrator_mocks.rs
+++ b/engine/src/orchestrator/application/orchestrator_mocks.rs
@@ -502,6 +502,7 @@ impl crate::audit::application::AuditService for MockAuditService {
                 events: vec![],
                 scoring_results: std::collections::HashMap::new(),
                 approval_events: Vec::new(),
+                sequence_policy_findings: Vec::new(),
                 scope_violations: Vec::new(),
                 decision_context_ref: None,
                 signature: None,

--- a/engine/src/sequence_policy/domain/sequence_match.rs
+++ b/engine/src/sequence_policy/domain/sequence_match.rs
@@ -45,3 +45,21 @@ pub struct SequenceMatch {
     /// (`requires_approval = true`) or denied.
     pub later_step: String,
 }
+
+impl SequenceMatch {
+    /// Redacted decision summary (R6 / SpanPrivacy pattern).
+    ///
+    /// Names the rule, the action and the later matched step — step
+    /// parameter VALUES are never included by default. Full payloads are
+    /// opt-in and never leave the local store.
+    pub fn decision_summary(&self) -> String {
+        let action = match self.action {
+            RuleAction::Promote => "promoted",
+            RuleAction::Deny => "denied",
+        };
+        format!(
+            "rule '{}' {}: later step '{}' matched at {:?} — parameter values redacted",
+            self.rule_id, action, self.later_step, self.matched_indices
+        )
+    }
+}


### PR DESCRIPTION
## ISSUE-SEQUENCE-POLICY-11: Audit (R6) — matches + promotion in envelope events, redacted summaries (#849)

### What
**AC#12**: *Matched rule + promotion recorded in envelope events; decision summaries redact parameter values by default (SpanPrivacy pattern)* — integration test.

### Changes
**Events (`ExecutionEvent`)** — three new first-class variants wired through every exhaustive consumer (query filters, in-memory repo, orchestrator drains, CLI TUI):
- `SequenceRuleMatched { rule_id, action, later_step, matched_indices, summary }`
- `SequencePolicyDenied { rule_id, later_step, reason }`
- `SequencePolicyConfigError { detail }`

**Evidence recording:**
- R2 plan-time gate (`run_from_template`) publishes `SequenceRuleMatched` per promote match **before anything executes** (plan preview records data only — no events)
- R3 dispatch gate publishes `SequenceRuleMatched` on promote routing, `SequencePolicyDenied` on deny, `SequencePolicyConfigError` on fail-closed evaluation errors (GAP-M-14: never silent)
- `SequenceMatch::decision_summary()` — redacted **by default**; parameter values never enter events

**Envelope (`AuditEnvelope`)** — additive serde-defaulted `sequence_policy_findings: Vec<SequencePolicyFindingRef>` (`rule_id`, `action`, `later_step`, `matched_indices`, `summary`) derived at build time from the two match/deny event types; literals updated in audit queue/sender/repo + orchestrator mocks.

### Acceptance criteria
- **AC 12** — `test_sequence_policy_promotion_recorded_in_envelope_events_redacted`: promoted conference runbook through the REAL engine + shared real bus + capturing audit service → the run's drained events carry `sequence_rule_matched` (rule `registration-remove-then-reassign`, action promote, later step, indices [0,1]) with **zero parameter values** (`conf-2026` absent); the built envelope derives `sequence_policy_findings[0]` whose summary says "parameter values redacted" and never contains the value

### Evidence
- `cargo test -p rigorix-engine --lib` 2001/2001; clippy `--all-targets -D warnings` green (engine + cli + mcp + actions); fmt green
- `validate-ci.sh` 5/5 PASS; canonical + security PASS
- (validate-tests.sh unchanged pre-existing `--test integration` main bug)

Closes #849.
