### PR TITLE
[Issue #850] ISSUE-SEQUENCE-POLICY-12: Permission R5 — deny .rigorix/** agent writes by default

### DIFF
--- a/engine/src/execution_engine/application/service_impl.rs
+++ b/engine/src/execution_engine/application/service_impl.rs
@@ -159,6 +159,54 @@ async fn spawn_concurrent_node(
             }
         }
 
+        // File-path gating on the parallel path — same checks execute_tool
+        // applies on the single-node path (GAP-A-11 symmetry): a write tool
+        // is additionally checked against the file-write policy, which denies
+        // `.rigorix/**` (R5 — the operator config an agent must never edit)
+        // and out-of-workspace paths.
+        if enforce_permission
+            && let Some(ref enforcer) = permission
+            && matches!(
+                node_tool.as_str(),
+                "file_write" | "file_append" | "file_patch" | "edit_file"
+            )
+        {
+            let parsed: serde_json::Value =
+                serde_json::from_str(&node_intent).unwrap_or_default();
+            if let Some(path) = parsed["path"].as_str() {
+                let w_outcome = enforcer.check_file_write(path, ".", None).await;
+                if let crate::permission::domain::PermissionOutcome::Denied { ref reason, .. } =
+                    w_outcome
+                {
+                    let dur = start.elapsed().as_millis() as u64;
+                    let result = TaskResult::failure(
+                        node_id,
+                        &node_name,
+                        reason.clone(),
+                        "permission_denied".to_string(),
+                        dur,
+                        0,
+                    );
+                    if let Err(e) = eb
+                        .publish(crate::event_system::application::dto::PublishEventInput {
+                            event: ExecutionEvent::NodeCompleted {
+                                execution_id: exec_id,
+                                node_id: node_id.to_string(),
+                                node_name,
+                                duration_ms: dur,
+                                output: serde_json::json!(null),
+                                timestamp: chrono::Utc::now(),
+                            },
+                        })
+                        .await
+                    {
+                        tracing::warn!(error = %e, "event publish failed — evidence may be incomplete");
+                    }
+                    return (node_id, result);
+                }
+            }
+        }
+
         // ── PreToolUse hooks (parallel path) — same gating as execute_tool ──
         if let Some(ref hook_runner) = hook_runner {
             let abort = crate::hooks::domain::HookAbortSignal::default();

--- a/engine/src/execution_engine/tests.rs
+++ b/engine/src/execution_engine/tests.rs
@@ -936,6 +936,103 @@ async fn test_factory_threads_permission_enforcer_read_only_gates_bash_write() {
         "allow-listed read tool must still complete"
     );
 }
+/// AC#13 (permission R5): a `workspace_write` agent file-write to
+/// `.rigorix/**` is denied by the DEFAULT permission config — the operator's
+/// sequence rules are never writable by the agent they judge.
+#[tokio::test]
+async fn test_default_permission_denies_rigorix_config_write() {
+    use crate::dag_engine::domain::{TaskGraph, TaskNode};
+    use crate::execution_engine::application::factory::{
+        ParallelExecutionFactory, ParallelExecutionFactoryConfig,
+    };
+    use crate::execution_engine::application::factory_impl::ParallelExecutionFactoryImpl;
+    use crate::permission::application::enforcer_factory_impl::PermissionEnforcerFactoryImpl;
+    use crate::permission::application::factory::PermissionEnforcerFactory;
+
+    // Default posture: PermissionConfig::default() (workspace_write mode).
+    let enforcer = PermissionEnforcerFactoryImpl
+        .create_default()
+        .await
+        .expect("default enforcer construction");
+
+    let service = ParallelExecutionFactoryImpl::new()
+        .create(ParallelExecutionFactoryConfig {
+            permission_enforcer: Some(Arc::from(enforcer)),
+            ..Default::default()
+        })
+        .await
+        .expect("factory create");
+
+    let dag_id = Uuid::new_v4();
+    // Agent tries to overwrite the operator's sequence-policy rules.
+    let rule_write = TaskNode::new(
+        Uuid::new_v4(),
+        "write_rule",
+        "file_write",
+        vec![],
+        r#"{"path": ".rigorix/sequence-policy.toml", "content": "evil"}"#,
+    );
+    // Control: an ordinary workspace write under the same mode stays allowed.
+    let scratch = std::env::current_dir()
+        .expect("cwd")
+        .join(format!("rigorix-r5-control-{}.txt", Uuid::new_v4()))
+        .display()
+        .to_string();
+    let scratch_write = TaskNode::new(
+        Uuid::new_v4(),
+        "write_scratch",
+        "file_write",
+        vec![],
+        format!(r#"{{"path": "{}", "content": "ok"}}"#, scratch),
+    );
+    let mut graph = TaskGraph::new();
+    graph.add_unchecked(rule_write).unwrap();
+    graph.add_unchecked(scratch_write).unwrap();
+    graph.seal().unwrap();
+
+    let output = service
+        .execute_graph(ExecuteGraphInput {
+            dag_id,
+            graph: Some(graph),
+            config_override: None,
+        })
+        .await
+        .unwrap();
+
+    let rule_node_id = output
+        .result
+        .execution_states
+        .iter()
+        .find(|(_, s)| s.node_name == "write_rule")
+        .map(|(id, _)| *id)
+        .expect("write_rule node");
+    let rule_result = output
+        .result
+        .node_results
+        .get(&rule_node_id)
+        .expect("rule write result");
+    assert!(!rule_result.success, "rule file write must be denied");
+    assert_eq!(
+        rule_result.failure_type.as_deref(),
+        Some("permission_denied"),
+        "denial surfaces as the structured permission_denied failure"
+    );
+    assert!(
+        !std::path::Path::new(".rigorix/sequence-policy.toml").exists()
+            || std::fs::read_to_string(".rigorix/sequence-policy.toml")
+                .map(|c| !c.contains("evil"))
+                .unwrap_or(true),
+        "the operator rule file must be untouched"
+    );
+
+    // Control leg: same-mode ordinary write completed.
+    let state = service
+        .get_execution_state(GetExecutionStateInput { dag_id })
+        .await
+        .unwrap();
+    assert_eq!(state.completed_count, 1, "scratch write completes");
+    let _ = std::fs::remove_file(&scratch);
+}
 
 #[tokio::test]
 async fn test_approval_gate_rejects_unknown_step_name() {

--- a/engine/src/permission/application/enforcer_impl.rs
+++ b/engine/src/permission/application/enforcer_impl.rs
@@ -51,6 +51,15 @@ impl PermissionEnforcerImpl {
     ///
     /// Canonicalizes both paths (resolving symlinks, relative paths)
     /// to prevent symlink escape attacks.
+    /// R5 (sequence-policy, F-20260904-06a): `.rigorix/**` is the
+    /// operator-controlled repository config directory (permissions/policy/
+    /// sequence rules). An executing agent must NEVER edit the rules it is
+    /// judged by — the engine's default permission posture denies agent
+    /// writes there regardless of workspace location.
+    fn is_protected_config_path(path: &str) -> bool {
+        path.split(['/', '\\']).any(|seg| seg == ".rigorix")
+    }
+
     fn is_within_workspace(path: &str, workspace_root: &str) -> bool {
         let canonical_path = match std::fs::canonicalize(path) {
             Ok(p) => p,
@@ -146,6 +155,19 @@ impl PermissionEnforcer for PermissionEnforcerImpl {
                 reason: "file writes are not allowed in read_only mode".to_string(),
             },
             PermissionMode::WorkspaceWrite => {
+                // R5: deny agent writes to the operator-controlled config
+                // dir FIRST — protected regardless of workspace location.
+                if Self::is_protected_config_path(path) {
+                    return PermissionOutcome::Denied {
+                        tool: "write_file".to_string(),
+                        active_mode: effective_mode.as_str().to_string(),
+                        required_mode: PermissionMode::DangerousFullAccess.as_str().to_string(),
+                        reason: format!(
+                            "path '{}' is under .rigorix/** — operator-controlled config, agent writes denied by default permission config (R5)",
+                            path
+                        ),
+                    };
+                }
                 let within_workspace = Self::is_within_workspace(path, workspace_root);
                 if within_workspace {
                     PermissionOutcome::Allowed
@@ -601,5 +623,53 @@ mod tests {
         for handle in handles {
             handle.await.unwrap();
         }
+    }
+    // -----------------------------------------------------------------------
+    // R5: .rigorix/** agent writes (sequence-policy module)
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_workspace_write_denies_rigorix_config_writes_by_default() {
+        // AC#13 posture: the default permission config (workspace_write)
+        // must deny agent file-writes into .rigorix/** — the operator-owned
+        // rules the agent is judged by. Relative, ./-prefixed, nested and
+        // absolute forms all resolve to the protected dir.
+        let dir = std::env::temp_dir().join(format!("rigorix-r5-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let root = dir.to_str().unwrap().to_string();
+
+        let enforcer = test_enforcer(&root);
+        for path in [
+            ".rigorix/sequence-policy.toml",
+            "./.rigorix/permissions.toml",
+            ".rigorix/sub/dir/policy.toml",
+            format!("{root}/.rigorix/policy.toml").as_str(),
+        ] {
+            let outcome = enforcer.check_file_write(path, &root, None).await;
+            assert!(
+                outcome.is_denied(),
+                ".rigorix write must be denied by default, got {outcome:?} for {path}"
+            );
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn test_workspace_write_allows_non_config_file_in_workspace() {
+        // The R5 guard is scoped: an ordinary workspace file is still writable
+        // under workspace_write (only .rigorix/** is operator-controlled).
+        let dir = std::env::temp_dir().join(format!("rigorix-r5-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(dir.join("notes")).expect("temp dir");
+        let root = dir.to_str().unwrap().to_string();
+
+        let enforcer = test_enforcer(&root);
+        let outcome = enforcer
+            .check_file_write(format!("{root}/notes/scratch.txt").as_str(), &root, None)
+            .await;
+        assert!(
+            outcome.is_allowed(),
+            "ordinary workspace writes stay allowed, got {outcome:?}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }


### PR DESCRIPTION
## ISSUE-SEQUENCE-POLICY-12: Permission (R5) — .rigorix/** agent writes denied (#850)

### What
**AC#13**: *`workspace_write` agent file-write to `.rigorix/**` denied by default permission config* — integration test.

### Changes
- **`PermissionEnforcerImpl::check_file_write`**: under `WorkspaceWrite`, any write resolving into `.rigorix/**` (operator-controlled repo config: permissions/policy/sequence rules) is denied **before** the workspace-location check — so it holds regardless of path form (relative, `./`-prefixed, nested, absolute). Only `DangerousFullAccess` (operator) can write the rules an agent is judged by (F-20260904-06a).
- **Parallel dispatch gap closed**: `run_dispatch_loop`'s spawn path previously consulted only the tool-level `check()` — file-write path gating ran only on the single-node `execute_tool` path, so `.rigorix`/outside-workspace writes sailed through graph dispatch. `spawn_concurrent_node` now runs the same `check_file_write` gate for write tools (GAP-A-11 symmetry).

### Acceptance criteria
- **AC 13** — `test_default_permission_denies_rigorix_config_write`: default-config enforcer (`create_default`, workspace_write) threaded through the executor factory + `execute_graph`: `file_write` to `.rigorix/sequence-policy.toml` fails with structured `permission_denied` and never touches the file; an ordinary in-workspace write under the same mode completes.
- Enforcer unit tests: default workspace_write denies `.rigorix` writes in all four path forms; ordinary workspace files stay writable.

### Evidence
- `cargo test -p rigorix-engine --lib` 2004/2004; clippy `--all-targets -D warnings` + fmt green
- `validate-ci.sh` 5/5 PASS; canonical + security PASS
- (validate-tests.sh unchanged pre-existing `--test integration` main bug)

Closes #850.
