### PR TITLE
[Issue #851] Proofing & CI enforcement: sequence-policy

### DIFF
--- a/engine/.pi/scripts/ci/check_sequence-policy_contracts.sh
+++ b/engine/.pi/scripts/ci/check_sequence-policy_contracts.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# ============================================================================
+# check_sequence-policy_contracts.sh
+#
+# Validates that every contract interface from the sequence-policy module has
+# a concrete implementation. Uses grep/find to detect trait definitions and
+# their implementing structs — no frameworks, no dependencies.
+#
+# Usage: bash .pi/scripts/ci/check_sequence-policy_contracts.sh [--help]
+#
+# Exit codes: 0 = all contracts implemented, 1 = violations found
+# ============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENGINE_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+SRC_DIR="$ENGINE_ROOT/src"
+SP_DIR="$SRC_DIR/sequence_policy"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+log_pass() { echo "  ✓ PASS: $1"; PASS=$((PASS + 1)); }
+log_fail() { echo "  ✗ FAIL: $1"; ERRORS+=("$1"); FAIL=$((FAIL + 1)); }
+
+if [ ! -d "$SP_DIR" ]; then
+    echo "sequence-policy module not found at $SP_DIR" >&2
+    exit 1
+fi
+
+echo ""
+echo "═══ Sequence-Policy Contract Implementation Check ═══"
+echo "Source: $SP_DIR"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Check 1: Module registration
+# ---------------------------------------------------------------------------
+echo "--- Module Registration ---"
+
+if grep -q 'pub mod sequence_policy;' "$SRC_DIR/lib.rs" 2>/dev/null; then
+    log_pass "sequence_policy module registered in lib.rs"
+else
+    log_fail "pub mod sequence_policy; missing from src/lib.rs"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 2: Service Contracts (SequencePolicyService → SequencePolicyServiceImpl)
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Service Contracts ---"
+
+if grep -q 'pub trait SequencePolicyService' "$SP_DIR/application/service.rs" 2>/dev/null; then
+    if grep -q 'impl SequencePolicyService for SequencePolicyServiceImpl' "$SP_DIR/application/service_impl.rs" 2>/dev/null; then
+        log_pass "SequencePolicyService → SequencePolicyServiceImpl"
+    else
+        log_fail "SequencePolicyService trait has no implementation in service_impl.rs"
+    fi
+else
+    log_fail "SequencePolicyService trait not found in application/service.rs"
+fi
+
+# R2 plan-time evaluation contract.
+if grep -q 'async fn evaluate_plan' "$SP_DIR/application/service.rs" 2>/dev/null; then
+    log_pass "evaluate_plan (R2 plan-time) declared"
+else
+    log_fail "evaluate_plan missing from the SequencePolicyService trait"
+fi
+
+# R3 run-time prefix contract.
+if grep -q 'async fn evaluate_prefix' "$SP_DIR/application/service.rs" 2>/dev/null; then
+    log_pass "evaluate_prefix (R3 run-time prefix) declared"
+else
+    log_fail "evaluate_prefix missing from the SequencePolicyService trait"
+fi
+
+# Factory contract.
+if grep -q 'pub trait SequencePolicyFactory' "$SP_DIR/application/factory.rs" 2>/dev/null; then
+    log_pass "SequencePolicyFactory trait defined"
+else
+    log_fail "SequencePolicyFactory trait not found"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 3: Repository Contracts (SequencePolicyRepository → TomlSequencePolicyRepository)
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Repository Contracts ---"
+
+if grep -q 'pub trait SequencePolicyRepository' "$SP_DIR/infrastructure/repository/mod.rs" 2>/dev/null; then
+    if grep -q 'impl SequencePolicyRepository for TomlSequencePolicyRepository' "$SP_DIR/infrastructure/repository/toml_repository.rs" 2>/dev/null; then
+        log_pass "SequencePolicyRepository → TomlSequencePolicyRepository"
+    else
+        log_fail "TomlSequencePolicyRepository does not implement SequencePolicyRepository"
+    fi
+else
+    log_fail "SequencePolicyRepository trait not found in infrastructure/repository/mod.rs"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 4: Domain entities exist
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Domain Entities ---"
+
+for type in SequenceRule StepPredicate ParamPredicate ParamMatchKind RuleAction; do
+    if grep -q "pub \(struct\|enum\) $type" "$SP_DIR/domain/rule.rs" 2>/dev/null; then
+        log_pass "$type exists in domain/rule.rs"
+    else
+        log_fail "$type not found in domain/rule.rs"
+    fi
+done
+
+if grep -q 'pub struct SequenceMatch' "$SP_DIR/domain/sequence_match.rs" 2>/dev/null; then
+    log_pass "SequenceMatch exists"
+else
+    log_fail "SequenceMatch struct not found"
+fi
+
+for type in SequencePolicyConfig SafetyCaps; do
+    if grep -q "pub struct $type" "$SP_DIR/domain/config.rs" 2>/dev/null; then
+        log_pass "$type exists in domain/config.rs"
+    else
+        log_fail "$type not found in domain/config.rs"
+    fi
+done
+
+if grep -q 'pub enum SequencePolicyError' "$SP_DIR/domain/error.rs" 2>/dev/null; then
+    log_pass "SequencePolicyError enum exists"
+else
+    log_fail "SequencePolicyError enum not found"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 5: DTO contracts
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- DTO Contracts ---"
+
+for dto in PlannedStep DispatchedStep; do
+    if grep -q "pub struct $dto" "$SP_DIR/application/dto/mod.rs" 2>/dev/null; then
+        log_pass "$dto DTO exists"
+    else
+        log_fail "$dto DTO not found"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Check 6: No frozen stubs left (every contract implemented, nothing todo!-ed)
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Implementation Completeness ---"
+
+STUBS=$(grep -rn 'todo!\|unimplemented!\|TODO: implemented in ISSUE' "$SP_DIR" --include="*.rs" 2>/dev/null | grep -v '^.*//' | head -10)
+if [ -z "$STUBS" ]; then
+    log_pass "no todo!/unimplemented! stubs remain in the sequence_policy module"
+else
+    log_fail "stubs remain — implementation issues not complete"
+    echo "$STUBS"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "═══ Summary ═══"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo ""
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo "FAILURES:"
+    for err in "${ERRORS[@]}"; do
+        echo "  - $err"
+    done
+    echo ""
+    echo "Some sequence-policy contracts are missing implementations."
+    exit 1
+fi
+
+echo "All sequence-policy contracts have implementations."
+exit 0

--- a/engine/.pi/scripts/ci/run_hardening_stages.sh
+++ b/engine/.pi/scripts/ci/run_hardening_stages.sh
@@ -345,6 +345,11 @@ run_stage "35" "approval_proofing" \
     "${SCRIPTS_DIR}/stage_approval_proofing.sh" \
     "always"
 
+# Stage 36: Sequence-Policy Proofing
+run_stage "36" "sequence-policy_proofing" \
+    "${SCRIPTS_DIR}/stage_sequence-policy_proofing.sh" \
+    "always"
+
 # ── Summary ──
 
 echo ""

--- a/engine/.pi/scripts/ci/stage_sequence-policy_proofing.sh
+++ b/engine/.pi/scripts/ci/stage_sequence-policy_proofing.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# ============================================================================
+# stage_sequence-policy_proofing.sh
+#
+# CI stage wrapper that runs all sequence-policy proofing checks:
+#   1. Contract implementation check — every frozen contract has an impl
+#   2. Coverage gate — mandatory test surface + real coverage threshold
+#
+# Usage: bash .pi/scripts/ci/stage_sequence-policy_proofing.sh [--help]
+#
+# Exit codes: 0 = all checks pass, 1 = any check fails
+# ============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+log_pass() { echo "  ✓ PASS: $1"; PASS=$((PASS + 1)); }
+log_fail() { echo "  ✗ FAIL: $1"; ERRORS+=("$1"); FAIL=$((FAIL + 1)); }
+
+echo ""
+echo "╔══════════════════════════════════════════════╗"
+echo "║   Sequence-Policy Proofing Stage              ║"
+echo "╚══════════════════════════════════════════════╝"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Check 1: Contract Implementation Check
+# ---------------------------------------------------------------------------
+echo "--- 1. Contract Implementation Check ---"
+echo ""
+
+if bash "${SCRIPT_DIR}/check_sequence-policy_contracts.sh" 2>&1; then
+    log_pass "Contract implementation check passed"
+else
+    log_fail "Contract implementation check failed"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 2: Coverage (real measurement)
+#
+# Coverage is NOT a per-module heuristic script — heuristic *_coverage.sh
+# scripts were removed repo-wide in #780 as coverage-theater. Real line
+# coverage is enforced by the workspace gate:
+#   bash .pi/scripts/coverage.sh --gate     (cargo llvm-cov, ≥ COVERAGE_THRESHOLD)
+# wired as ci.yml Stage 3b / local-ci Stage 4b. This module's tests (in-crate
+# + tests/unit/sequence-policy) are part of that workspace measurement.
+# ---------------------------------------------------------------------------
+if command -v cargo >/dev/null 2>&1 && cargo llvm-cov --version >/dev/null 2>&1; then
+    echo "  (real coverage gate runs in ci.yml Stage 3b: bash .pi/scripts/coverage.sh --gate)"
+fi
+log_pass "Coverage enforced via real cargo llvm-cov gate (not a per-module script)"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "═══ Stage Summary ═══"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo ""
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo "FAILURES:"
+    for err in "${ERRORS[@]}"; do
+        echo "  - $err"
+    done
+    echo ""
+    echo "Sequence-policy proofing stage FAILED."
+    exit 1
+fi
+
+echo "Sequence-policy proofing stage PASSED."
+exit 0


### PR DESCRIPTION
## Proofing & CI Enforcement: sequence-policy (#851)

### What
Deterministic, automated proofing for the sequence-policy epic — contract compliance + real coverage, wired into the hardening pipeline.

### Scripts (`.pi/scripts/ci/`)
| Script | Purpose |
|--------|---------|
| `check_sequence-policy_contracts.sh` | Validates every frozen contract has a concrete impl — module registration, `SequencePolicyService`→`SequencePolicyServiceImpl` (`evaluate_plan`/`evaluate_prefix`), `SequencePolicyFactory`, `SequencePolicyRepository`→`TomlSequencePolicyRepository`, domain entities (SequenceRule/StepPredicate/ParamPredicate/ParamMatchKind/RuleAction/SequenceMatch/SequencePolicyConfig/SafetyCaps/SequencePolicyError), DTOs (PlannedStep/DispatchedStep), and no remaining `todo!()`/`unimplemented!()` stubs — file:line on violation |
| `stage_sequence-policy_proofing.sh` | CI stage wrapper (contract check + coverage) |

**Coverage**: real `cargo llvm-cov` via the workspace gate `.pi/scripts/coverage.sh --gate` (repo-wide ≥ COVERAGE_THRESHOLD, ci.yml Stage 3b) — deliberately NOT a per-module heuristic script (removed repo-wide in #780 as coverage-theater).

**CI wiring**: `run_hardening_stages.sh` stage **36 `sequence-policy_proofing`** (`always`).

### Acceptance criteria
1. All interfaces have implementations → contract check 18/18 PASS
2. Coverage → real llvm-cov workspace gate (not a per-module script)
3. CI runs on every PR → stage 36 in the hardening runner; full local run shows `sequence-policy_proofing PASSED`
4. Exit 0/1, self-validating → standalone + stage + full-runner all exit cleanly

### Evidence
- `check_sequence-policy_contracts.sh` → 18 PASS / 0 FAIL, exit 0
- Full hardening pipeline: **33/36** — `sequence-policy_proofing` PASSES. Sole failure `docs_policy` = MR-traceability stage needing GitHub MR context (`Commit: unknown / Branch: unknown` on a local branch — unrelated to this change; `migration_verify`/`package_build` skipped as main-only conditionals)
- `validate-ci.sh` 5/5 PASS

Closes #851.
