### PR TITLE
[Issue #852] Architecture Readiness: runbook, DR, observability, docs — sequence-policy

### DIFF
--- a/engine/.pi/architecture/CHANGELOG.md
+++ b/engine/.pi/architecture/CHANGELOG.md
@@ -1,3 +1,39 @@
+## [2026-09-05] — Sequence Policy implemented (epic ISSUE-SEQUENCE-POLICY, tracking #837)
+
+### Added
+- **Sequence-policy module (R1–R6)**: declarative ordered-step rules in
+  `.rigorix/sequence-policy.toml` with deterministic matching — tool
+  exact/glob + JSON-pointer param predicates (exact/glob/regex), windowed
+  matching, `promote` (default) / `deny` actions. See the module doc AC table
+  (14 rows, each with unit/integration test).
+- **R2 plan-time gate**: orchestrator `run_from_template`/`plan_from_template`
+  evaluate the ordered runbook before anything executes — promote builds the
+  later step `requires_approval = true` (existing approval pause/approve/
+  resume), deny refuses the runbook (`SequencePolicyDenied`, no step runs).
+  Plan preview (`rigorix_validate_plan`) surfaces findings pre-run (AC#8).
+- **R3 run-time prefix gate**: `run_dispatch_loop` (shared by execute_graph
+  and resume_execution) evaluates the completed dispatch prefix + the next
+  ready node — promote routes into `AwaitingApproval`, deny fails the node
+  before its tool is called (structured `sequence_policy_denied`), eval
+  errors halt fail-closed. Optional service (`with_sequence_policy`);
+  `None` = status quo.
+- **Config hardening (AC#10/11)**: `TomlSequencePolicyRepository` — missing
+  file = `Ok(None)` (fail-open-absent, no gating); corrupt/over-cap = `Err`
+  (fail closed, plan refused). `SafetyCaps` defaults (100 rules / 8 steps per
+  rule / window 5 / 8 regex predicates) + `SequencePolicyConfig::validate`.
+- **R5 permission**: default permission config denies `workspace_write` agent
+  writes into `.rigorix/**` (operator rules are never agent-writable); the
+  parallel dispatch path now applies the file-write gate (was single-node
+  only). AC#13 integration test.
+- **R6 audit evidence**: `ExecutionEvent::SequenceRuleMatched /
+  SequencePolicyDenied / SequencePolicyConfigError`; envelope gains additive
+  `sequence_policy_findings[]` derived at build time with **redacted**
+  summaries (SpanPrivacy default — parameter values never captured). AC#12.
+- **Proofing**: contract check + real llvm-cov coverage wired as hardening
+  stage 36 `sequence-policy_proofing` (`.pi/scripts/ci/`).
+- Module status flipped Proposed → Implemented; runbook + DR plan +
+  observability (structured tracing on evaluate_plan/evaluate_prefix/load).
+
 ## [2026-09-02] — Approval binding production flip (ADR-011, env-driven)
 
 ### Added

--- a/engine/.pi/architecture/modules/sequence-policy.md
+++ b/engine/.pi/architecture/modules/sequence-policy.md
@@ -476,11 +476,16 @@ engine/src/sequence_policy/
 
 ---
 
-*Last updated: 2026-09-04*
-*Module version: 0.1.0 (proposed)*
+*Last updated: 2026-09-05*
+*Module version: 1.0.0 (implemented)*
 
 ---
 
-**Status:** Proposed — NOT YET BUILT. Architecture packet only; no code changes.
-**Implementation priority:** P0 hook demo → P1 contract freeze + plan-time (R2) → P1 run-time prefix (R3) → P2 evidence + config hardening (R5) → P3 enterprise rule type (gated on F-20260904-02/F-20260904-04).
-**Epic:** epic-sequence-policy-epic (tracking issue pending creation).
+**Status:** Implemented — plan-time gate (R2), run-time prefix gate (R3),
+fail-closed/absent config handling, permission hardening (R5), audit evidence
+(R6), and proofing are all in `src/sequence_policy/` + the orchestrator /
+execution-engine choke points. See the epic tracking issue (#837) and the
+14-row Acceptance Criteria table below for per-criterion tests.
+**Remaining (P3, gated):** enterprise-managed rules via the signed policy
+bundle seam (F-20260904-04); hooks P0 demo parity (agent-native boundary);
+ADR-011 remains separate.

--- a/engine/docs/dr-plan-sequence-policy.md
+++ b/engine/docs/dr-plan-sequence-policy.md
@@ -1,0 +1,86 @@
+# Disaster Recovery Plan: sequence-policy Module
+
+<!--
+Canonical Reference: .pi/architecture/modules/sequence-policy.md
+Last Updated: 2026-09-05
+-->
+
+## Scope
+
+This DR plan covers the `sequence-policy` module — deterministic gates over
+ordered step sequences: declarative rules (R1), plan-time evaluation (R2),
+run-time prefix gate (R3), no-judgment determinism (R4), operator-controlled
+rule authorship (R5), and envelope evidence (R6).
+
+The module is **stateless between runs**:
+
+| Tier | Artifact | Guarantee |
+|------|----------|-----------|
+| **Source of truth** | `.rigorix/sequence-policy.toml` (operator-authored, repo-controlled, agent-write-protected by R5) | Recreated from the repo on any environment |
+| **Evidence (end-state)** | Rule decisions land in the signed audit envelope as `sequence_policy_findings[]` (plus `sequence_rule_matched` / `sequence_policy_denied` / `sequence_policy_config_error` events) | Tamper-evident when envelope signing is on; summaries redacted by default |
+| **Operational (mid-run)** | A promoted node pauses inside the existing persisted `ExecutionState` (`AwaitingApproval`); resume re-reads rules fresh | Survives process restart via the standard hydrate/approve/resume flow — no module-owned state to restore |
+
+## RTO/RPO Targets
+
+| Metric | Target | Rationale |
+|--------|--------|-----------|
+| RTO (Recovery Time Objective) | < 1 minute | The module is stateless — recovery = ensure the operator rule file is present/valid and re-attach the service to the orchestrator/executor. A paused promoted run resumes via the existing persisted-state path |
+| RPO (Recovery Point Objective) | 0 writes | The module writes nothing itself — rules are read-only per run; decisions are derived deterministically and re-derivable from (rule file + ordered plan) |
+
+## Backup Strategy
+
+**Rule file (`.rigorix/sequence-policy.toml`):**
+
+- The rule file is part of the repository (same trust surface as
+  `policy.toml` / `permissions.toml`) — the normal VCS backup cadence backs it
+  up. Agent writes to `.rigorix/**` are denied by default permission config
+  (R5), so the committed copy is the operator's.
+- Keep the file **valid** as part of change control: a corrupt/over-cap file is
+  **fail closed** at plan time (runs refused) — never silently degrade.
+
+**Evidence (envelope):**
+
+- Sequence-policy decisions are part of the audit envelope; back up envelopes
+  on the audit module's schedule. Redacted summaries mean no parameter values
+  need special handling in backups (SpanPrivacy default).
+- Event-publish failures are warn-logged with the GAP-M-14 marker — never
+  silent — so evidence gaps are visible in logs.
+
+## Restore Procedure
+
+1. **Restore the rule file** — `git checkout <commit> -- .rigorix/sequence-policy.toml`
+   (or re-apply the operator-authored version). Validate it parses before
+   relying on it: `rigorix_validate_plan` on a representative plan previews
+   whether findings fire.
+2. **No module state to restore** — the engine reads rules per run.
+3. **Resume a paused promoted run** (if any were in flight):
+   - Hydrate the persisted `ExecutionState` (cross-process resume path).
+   - The promoted node is still `AwaitingApproval`; `approve_execution` +
+     resume continues the run. Rules are re-read on resume — if the restored
+     rule file differs, the gate re-evaluates with the restored rules
+     (deterministic).
+
+## Failover Plan
+
+The module is a per-run in-process component with no leader/election, no
+shared mutable state, and no external service. Failover = running the engine
+elsewhere:
+
+1. Provision the new environment with the same repository state
+   (`.rigorix/sequence-policy.toml` included) and the same HMAC run key for
+   envelope signing (evidence continuity).
+2. In-flight runs are recoverable via persisted `ExecutionState`
+   (hydrate → approve → resume); the R3 prefix gate re-evaluates the completed
+   prefix from the hydrated graph on resume.
+3. Determinism (R4): identical (rule file, ordered plan/prefix) input yields
+   identical decisions — no cross-instance coordination is needed.
+
+## RTO/RPO Verification (routine)
+
+- On every proofing run, `check_sequence-policy_contracts.sh` (hardening stage
+  36) verifies the module surface is implemented with no frozen stubs.
+- `validate-architecture-readiness.sh` confirms runbook + DR plan + canonical
+  refs + observability are present.
+- Local recovery drill: delete `.rigorix/sequence-policy.toml` → confirm runs
+  execute unchanged (fail-open-absent, AC#11); reintroduce a corrupt file →
+  confirm plans are refused (fail-closed, AC#10); then restore the good file.

--- a/engine/docs/runbook-sequence-policy.md
+++ b/engine/docs/runbook-sequence-policy.md
@@ -1,0 +1,134 @@
+# Runbook: sequence-policy Module
+
+<!--
+Canonical Reference: .pi/architecture/modules/sequence-policy.md
+Last Updated: 2026-09-05
+-->
+
+## Overview
+
+The `sequence-policy` module detects **composed abuse across ordered steps** —
+actions individually permitted but collectively outside operator intent (the
+"remove-then-reassign" conference class). Rules are declarative, deterministic,
+operator-authored (`no LLM judgment in the enforcement path`), and evaluated at
+two choke points:
+
+1. **Plan time (R2, primary)** — the ordered runbook/template step list is
+   evaluated before anything executes (`orchestrator.run_from_template` /
+   `plan_from_template`). A matched `promote` rule builds the later step
+   `requires_approval = true` (existing approval pause); a matched `deny` rule
+   refuses the runbook (fail closed, tool never called).
+2. **Run time (R3, fallback)** — for dynamic plans whose steps are not all
+   pre-materialized, `run_dispatch_loop` evaluates the session's completed
+   dispatch prefix + the next ready node before dispatching it. `promote`
+   routes the node into the existing `AwaitingApproval` pause; `deny` fails the
+   node with a structured `sequence_policy_denied` before its tool is called.
+
+The defensive property:
+
+> **A forbidden sequence never executes silently.** If an ordered plan contains
+> a step pair matching a rule, the later step pauses for a human (promote) or
+> is denied outright (deny) — deterministically, recorded into the signed
+> envelope (`sequence_policy_findings[]`, redacted by default).
+
+## Components
+
+| Component | Type | Description |
+|-----------|------|-------------|
+| `SequenceRule` | Domain aggregate | Ordered `StepPredicate` chain (≥2), optional `window`, `action` (`promote` default / `deny`) |
+| `StepPredicate` / `ParamPredicate` | Domain value objects | Tool exact/glob match + JSON-pointer param predicates (exact / glob / regex) |
+| `Matcher` | Domain/app algorithm | Deterministic windowed matching over ordered step views; earliest-extension, config order |
+| `SequenceMatch` | Domain value object | `rule_id`, `action`, `matched_indices`, `later_step` + redacted `decision_summary()` |
+| `SequencePolicyConfig` / `SafetyCaps` | Domain config | `fail_closed` (default true) + ordered rules; caps: 100 rules / 8 steps per rule / window 5 / 8 regex predicates per file |
+| `SequencePolicyService` / `SequencePolicyServiceImpl` | Application trait/impl | `evaluate_plan` (R2) + `evaluate_prefix` (R3); per-run rule loading |
+| `SequencePolicyRepository` / `TomlSequencePolicyRepository` | Infra trait/impl | Reads `.rigorix/sequence-policy.toml`; missing file → `Ok(None)`; corrupt/over-cap → `Err` |
+| Orchestrator R2 gate | Choke point | `apply_plan_time_sequence_policy` → promote flips `requires_approval`, deny refuses, publishes `SequenceRuleMatched` evidence |
+| Execution-engine R3 gate | Choke point | `sequence_policy_verdict` in `run_dispatch_loop` (promote/deny/config-error events) |
+
+## Dependencies
+
+| Dependency | Purpose | Failure behavior |
+|------------|---------|------------------|
+| `.rigorix/sequence-policy.toml` | Operator rule file (same trust surface as permissions/policy) | **Missing** → no rules → status quo (fail-open-absent); **corrupt / over cap** → `Err` → run refused at plan time (fail closed) |
+| Approval module (ADR-011) | Promote pause/approve/resume machinery | Promoted node waits in `AwaitingApproval`; unchanged semantics |
+| Execution engine | R3 dispatch choke point (`run_dispatch_loop`, shared by execute + resume) | Optional `sequence_policy` service; `None` = status quo |
+| Permission enforcer | R5 `.rigorix/**` write denial | `.rigorix/**` agent writes denied under `WorkspaceWrite` (operator-only via `DangerousFullAccess`) |
+| Audit envelope | R6 `sequence_policy_findings[]` + match/deny/config-error events | Event publish failures are warn-logged (GAP-M-14), never silent |
+
+## Startup Sequence
+
+1. **No module startup is required** — the module is stateless between runs.
+   Rules are loaded per run from the operator file through the injected
+   repository.
+2. **Wiring (factory-built engines)** — attach `with_sequence_policy(svc)` /
+   `ParallelExecutionFactoryConfig.sequence_policy` with a
+   `SequencePolicyServiceImpl` over a `TomlSequencePolicyRepository`
+   (config path: `<repo>/.rigorix/sequence-policy.toml`).
+3. **Orchestrator** — `OrchestratorServiceImpl::with_sequence_policy` (R2 gate
+   on runbook/template paths; plan preview via `plan_from_template`).
+4. **Execution engine** — same service injected at the dispatch loop (R3 gate
+   for dynamic plans).
+5. **Validate** — `rigorix_validate_plan` surfaces promote findings /
+   deny refusal pre-run (MCP surface).
+
+## Graceful Shutdown
+
+The module holds no cross-run state, timers, or background tasks — shutdown is
+immediate:
+
+1. **In-flight runs** follow the executor's pause/abort path; a promoted node
+   mid-approval remains `AwaitingApproval` in persisted state and resumes after
+   restart via the existing hydrate/approve/resume flow (no sequence-policy
+   state to rehydrate — rules are re-read per run).
+2. **Evidence** — any emitted `SequenceRuleMatched` / `SequencePolicyDenied`
+   events already drained into the envelope need no flush on the module side.
+3. No special drain, checkpoint, or lock release is module-owned.
+
+## Common Failure Modes and Recovery
+
+| Mode | Symptom | Recovery |
+|------|---------|----------|
+| **Corrupt rule file** | Plan refused: `SequencePolicyEvaluationFailed` / `SequencePolicyConfigError` (fail closed) | Operator fixes `.rigorix/sequence-policy.toml`; no plan runs under an unparseable rule set (by design). Config errors are non-retriable |
+| **Over-cap file** | Same as corrupt (`RuleExceedsCaps`) | Reduce rules / steps / window / regex predicates under the caps |
+| **Missing config file** | No gating at all (fail-open-absent, documented) | If gating is expected, create the file — a missing file is **not** an error |
+| **Promote rule pauses a run** | Record `PendingApproval`, node `AwaitingApproval` | Human approves (approve → executes) or declines (never dispatched); run stays resumable |
+| **Deny rule match (plan)** | `SequencePolicyDenied` refusal before any step | Operator re-authorizes the composition explicitly or amends the rule |
+| **Deny rule match (runtime)** | Node fails with `sequence_policy_denied`, tool never called | Same as above; siblings/dependents release like any dispatched failure |
+| **R3 eval error mid-dispatch** | Run halts fail-closed before the node dispatches | Operator fixes the config; the halted run surfaces `SequencePolicyConfigError` evidence |
+| **Regex ReDoS** | (Prevented) | Safety cap 8 regex predicates/file + compile once per load |
+| **Agent edits the rules** | (Prevented) | `.rigorix/**` writes denied to `workspace_write` agents (R5); operator mode only |
+| **Param leak into summaries** | (Prevented) | `decision_summary()` redacts by default (SpanPrivacy); full payload opt-in only |
+
+## Configuration Reference
+
+```toml
+# .rigorix/sequence-policy.toml — operator-authored. Never agent-writable (R5).
+fail_closed = true            # default true; corrupt/over-cap config refuses plans
+
+[[rules]]
+id = "registration-remove-then-reassign"
+name = "No remove-then-reassign of a full event seat"
+description = "Removing an attendee to free a seat, then registering the requester, is never autonomous"
+steps = [
+  { tool = "registration_remove", params = [{ pointer = "/event_id", kind = "exact", value = "conf-2026" }] },
+  { tool = "registration_add",    params = [{ pointer = "/event_id", kind = "exact", value = "conf-2026" }] },
+]
+window = 3                       # max index gap first→last matched step
+action = "promote"               # promote (default) | deny
+```
+
+**Safety caps (fixed defaults):** `max_rules_per_file = 100`,
+`max_steps_per_rule = 8`, `max_window = 5`,
+`max_regex_predicates_per_file = 8` (regex count is the ReDoS surface).
+
+## Escalation
+
+- **False pause** (promote fired where the pair is legitimate): the operator
+  approves explicitly (human in the loop) — no config change needed.
+- **False denial / over-blocking**: adjust the rule (narrow predicates,
+  extend `window`, or remove the rule). Rules are deterministic — same input,
+  same outcome (property-tested).
+- **Rule doesn't fire when it should**: verify step `tool` names / param JSON
+  pointers against the predicate contract; remember predicates are ordered and
+  `window` caps the gap; check the config actually loaded (missing file is
+  fail-open). `rigorix_validate_plan` previews findings pre-run.

--- a/engine/src/sequence_policy/application/service_impl.rs
+++ b/engine/src/sequence_policy/application/service_impl.rs
@@ -67,8 +67,18 @@ impl SequencePolicyServiceImpl {
     /// mapped to an empty rule set — fail-open-absent.
     async fn load_rules(&self) -> Result<Vec<SequenceRule>, SequencePolicyError> {
         match self.repository.load_config().await? {
-            Some(config) => Ok(config.rules),
-            None => Ok(Vec::new()),
+            Some(config) => {
+                tracing::debug!(
+                    rules = config.rules.len(),
+                    fail_closed = config.fail_closed,
+                    "sequence_policy: rule config loaded"
+                );
+                Ok(config.rules)
+            }
+            None => {
+                tracing::debug!("sequence_policy: no rule file — fail-open-absent, no gating");
+                Ok(Vec::new())
+            }
         }
     }
 }
@@ -80,7 +90,16 @@ impl SequencePolicyService for SequencePolicyServiceImpl {
         steps: &[PlannedStep],
     ) -> Result<Vec<SequenceMatch>, SequencePolicyError> {
         let rules = self.load_rules().await?;
-        Ok(self.matcher.find_matches(&rules, steps)?)
+        let matches = self.matcher.find_matches(&rules, steps)?;
+        if !matches.is_empty() {
+            tracing::info!(
+                rules = rules.len(),
+                steps = steps.len(),
+                matches = matches.len(),
+                "sequence_policy: plan-time matched sequence(s) — later steps gated"
+            );
+        }
+        Ok(matches)
     }
 
     async fn evaluate_prefix(
@@ -108,10 +127,19 @@ impl SequencePolicyService for SequencePolicyServiceImpl {
         // that finished entirely inside the completed prefix was already acted
         // on at the dispatch of its own later step.
         let matches = self.matcher.find_matches(&rules, &views)?;
-        Ok(matches
+        let actionable: Vec<SequenceMatch> = matches
             .into_iter()
             .filter(|m| m.matched_indices.last() == Some(&next_idx))
-            .collect())
+            .collect();
+        if !actionable.is_empty() {
+            tracing::info!(
+                rules = rules.len(),
+                prefix_len = prefix.len(),
+                matches = actionable.len(),
+                "sequence_policy: dispatch-boundary matched sequence(s) — node gated"
+            );
+        }
+        Ok(actionable)
     }
 }
 

--- a/engine/src/sequence_policy/infrastructure/repository/toml_repository.rs
+++ b/engine/src/sequence_policy/infrastructure/repository/toml_repository.rs
@@ -50,7 +50,13 @@ impl SequencePolicyRepository for TomlSequencePolicyRepository {
         // quo). Any other read failure is a load error (fail closed).
         let text = match tokio::fs::read_to_string(&self.config_path).await {
             Ok(text) => text,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                tracing::debug!(
+                    path = %self.config_path.display(),
+                    "sequence_policy: config file absent — fail-open-absent"
+                );
+                return Ok(None);
+            }
             Err(e) => {
                 return Err(SequencePolicyError::InvalidConfig(format!(
                     "failed to read {}: {e}",


### PR DESCRIPTION
## Architecture Readiness: sequence-policy (#852)

### What
Final epic issue — production readiness for the sequence-policy module: runbook, DR plan, observability, docs + changelog sync, CI enforcement verified.

### Deliverables
- **`docs/runbook-sequence-policy.md`** — startup/shutdown (stateless module, rules read per run), failure modes & recovery (corrupt/over-cap → fail closed; missing file → fail open; promote pause → approve/decline; plan + runtime deny; R3 eval halt), escalation, configuration reference with safety caps
- **`docs/dr-plan-sequence-policy.md`** — RTO < 1 min / RPO 0 writes (stateless, deterministic re-derivable decisions); backup = VCS rule file + envelope evidence; restore + failover via cross-process hydrate/approve/resume (rules re-read fresh); routine drill procedure
- **Observability** — structured tracing: `evaluate_plan`/`evaluate_prefix` matched-sequence summaries, rule-load (fail-open-absent marker), config-file load — degradations and decisions logged
- **Module doc** — Status **Proposed → Implemented** (v1.0.0), P3 gates documented
- **CHANGELOG** — sequence-policy implementation-complete entry (R1–R6)

### Acceptance criteria
1. Runbook exists ✓ 2. DR plan exists ✓ 3. Observability patterns ✓ (operations 2/0)
4. Canonical refs synced ✓ 5. CI validators ✓ (`validate-ci.sh` 5/5)
6. Proofing passes ✓ (hardening stage 36 `sequence-policy_proofing`) 7. Architecture docs updated ✓

### Evidence
- `validate-architecture-readiness.sh` **8/8 PASS** ("Epic can be closed")
- operations 2/0, architecture + canonical PASS; `validate-ci.sh` 5/5
- engine lib 2004/2004; clippy `--all-targets -D warnings` + fmt green

Closes #852. Refs #837.
