### PR TITLE
fix(ci): scope EngineFacade method count to the trait impl region

### DIFF
--- a/mcp/.pi/scripts/ci/check_execution-tools_contracts.sh
+++ b/mcp/.pi/scripts/ci/check_execution-tools_contracts.sh
@@ -49,7 +49,11 @@ fi
 # Verify all EngineFacade trait methods are implemented
 if [ -n "$IMPLEMENTATIONS" ]; then
     METHOD_COUNT=$(grep -c 'async fn ' "${MODULE_SRC}/domain/entity.rs" 2>/dev/null || echo 0)
-    IMPL_COUNT=$(grep -c 'async fn ' "${INFRA}/engine_facade_impl.rs" 2>/dev/null || echo 0)
+    # Count async fns INSIDE the `impl EngineFacade for` region only — a
+    # raw whole-file grep also counts async test fns in the `mod tests`
+    # module, which made the check spuriously fail as the test suite grew.
+    IMPL_COUNT=$(sed -n '/^impl EngineFacade for EngineFacadeImpl {/,/^}/p' \
+        "${INFRA}/engine_facade_impl.rs" | grep -c 'async fn ' || echo 0)
     if [ "$METHOD_COUNT" -eq "$IMPL_COUNT" ]; then
         pass "EngineFacade: $METHOD_COUNT trait methods → $IMPL_COUNT impl methods"
     else


### PR DESCRIPTION
Fixes the CI red that has failed 19 of the last 30 main runs (Lint mcp → Per-crate conventions → 'EngineFacade: 7 trait methods but 22 impl methods').

The trait is fully implemented — the checker's whole-file grep counted the 15 async fns in the `#[cfg(test)]` module as impl methods. The sed range now counts only the trait-impl region.

Verified locally: check passes 7/7, full mcp conformance suite 7/7.