### PR TITLE
feat(sequence-policy R7): cross-run conflicting-action rules over the signed audit trail (#871)

### DIFF
--- a/cli/src/cli_boundary/orchestrator.rs
+++ b/cli/src/cli_boundary/orchestrator.rs
@@ -498,12 +498,17 @@ pub async fn build_orchestrator_with_budget(
     let sender: Arc<dyn AuditSender> =
         Arc::new(AuditSenderImpl::new(None, audit_backend_url).with_api_key(audit_backend_key));
     let queue: Box<dyn AuditQueue> = Box::new(AuditQueueImpl::default());
-    let audit = Arc::new(AuditServiceImpl::new(
-        envelope_factory,
-        sender,
-        queue,
-        audit_enabled,
-    )) as Arc<dyn rigorix_engine::audit::application::service::AuditService>;
+    let mut audit_service = AuditServiceImpl::new(envelope_factory, sender, queue, audit_enabled);
+    // R7: persist envelopes to `.rigorix/audit` (cross-run policy history +
+    // offline read-back). Same directory the CliServices read-back repo uses.
+    let audit_dir = rigorix_dir.join("audit");
+    if std::fs::create_dir_all(&audit_dir).is_ok() {
+        audit_service = audit_service.with_local_repository(std::sync::Arc::new(
+            rigorix_engine::audit::infrastructure::LocalAuditEnvelopeRepository::new(audit_dir),
+        ));
+    }
+    let audit = Arc::new(audit_service)
+        as Arc<dyn rigorix_engine::audit::application::service::AuditService>;
 
     // ── 8. ScoredEvaluationService (optional) ──────────────────────────
     let scored_evaluation_config_path = rigorix_dir.join("scored_evaluation.toml");

--- a/engine/src/audit/application/audit_service_impl.rs
+++ b/engine/src/audit/application/audit_service_impl.rs
@@ -33,6 +33,13 @@ pub struct AuditServiceImpl {
     queue: Box<dyn AuditQueue>,
     /// Whether audit is enabled.
     enabled: bool,
+    /// R7 / local read-back: optional durable envelope store (e.g.
+    /// `.rigorix/audit`). When set, every built envelope is ALSO persisted
+    /// locally — the signed trail that cross-run policy (sequence-policy R7)
+    /// and offline read-back consume. `None` = remote-send only (status quo).
+    local_repository: Option<
+        std::sync::Arc<dyn crate::audit::infrastructure::repository::AuditEnvelopeRepository>,
+    >,
     /// Default retry configuration.
     max_retries: u32,
     backoff_base_secs: u64,
@@ -55,7 +62,18 @@ impl AuditServiceImpl {
             max_retries: 3,
             backoff_base_secs: 1,
             backoff_max_secs: 60,
+            local_repository: None,
         }
+    }
+
+    /// Attach a durable local envelope store (R7 cross-run policy input +
+    /// offline read-back). Save failures are logged, never fatal.
+    pub fn with_local_repository(
+        mut self,
+        repo: std::sync::Arc<dyn crate::audit::infrastructure::repository::AuditEnvelopeRepository>,
+    ) -> Self {
+        self.local_repository = Some(repo);
+        self
     }
 
     /// Create a new audit service with custom retry config.
@@ -76,6 +94,7 @@ impl AuditServiceImpl {
             max_retries,
             backoff_base_secs,
             backoff_max_secs,
+            local_repository: None,
         }
     }
 
@@ -110,6 +129,16 @@ impl AuditService for AuditServiceImpl {
         let envelope = self.envelope_factory.build_envelope(input).await?;
         let event_count = envelope.events.len();
         let signed = envelope.signature.is_some();
+
+        // R7 / offline read-back: persist to the local store when wired.
+        if let Some(repo) = &self.local_repository
+            && let Err(e) = repo.save(&envelope).await
+        {
+            tracing::warn!(
+                execution_id = %envelope.execution_id,
+                "audit: local envelope persistence failed ({e}) — cross-run policy history may be incomplete"
+            );
+        }
 
         // Try to send
         let deliver_input = DeliverEnvelopeInput {

--- a/engine/src/execution_engine/application/factory.rs
+++ b/engine/src/execution_engine/application/factory.rs
@@ -273,13 +273,31 @@ impl SequencePolicySetup {
             "sequence_policy: R3 prefix gate armed — rules read per-run from {} (absent file = no gating)",
             path.display()
         );
-        Some(std::sync::Arc::new(
+        let mut service =
             crate::sequence_policy::application::service_impl::SequencePolicyServiceImpl::new(
                 Box::new(
                     crate::sequence_policy::infrastructure::TomlSequencePolicyRepository::new(path),
                 ),
+            );
+        // R7: attach the signed-execution-history port over the same repo's
+        // `.rigorix/audit` envelope store — cross-run rules read prior runs'
+        // signed evidence. A missing audit dir yields empty history (status
+        // quo); the audit dir itself is created by the composition roots when
+        // they persist envelopes.
+        service = service.with_history(std::sync::Arc::new(
+            crate::sequence_policy::infrastructure::EnvelopeHistoryAdapter::new(
+                std::sync::Arc::new(
+                    crate::audit::infrastructure::LocalAuditEnvelopeRepository::new(
+                        repo_root.join(".rigorix").join("audit"),
+                    ),
+                ),
             ),
-        ))
+        ));
+        tracing::info!(
+            "sequence_policy: R7 cross-run history armed over {}/.rigorix/audit",
+            repo_root.display()
+        );
+        Some(std::sync::Arc::new(service))
     }
 }
 

--- a/engine/src/execution_engine/application/service_impl.rs
+++ b/engine/src/execution_engine/application/service_impl.rs
@@ -1215,7 +1215,7 @@ impl ParallelExecutionServiceImpl {
             (prefix, next)
         };
 
-        let matches = match svc.evaluate_prefix(&prefix, &next).await {
+        let matches = match svc.evaluate_prefix(&prefix, &next, None).await {
             Ok(m) => m,
             Err(e) => {
                 // R6: record the fail-closed halt (GAP-M-14 — never silent).

--- a/engine/src/execution_engine/tests.rs
+++ b/engine/src/execution_engine/tests.rs
@@ -2360,6 +2360,7 @@ fn r3_config(action: RuleAction, path_a: &str, path_b: &str) -> SequencePolicyCo
             ],
             window: Some(2),
             action,
+            history: None,
         }],
     }
 }

--- a/engine/src/orchestrator/application/dto/mod.rs
+++ b/engine/src/orchestrator/application/dto/mod.rs
@@ -173,6 +173,10 @@ pub struct PlanFromTemplateInput {
 
     /// Template name for metadata.
     pub template_name: String,
+
+    /// Principal (author/attested identity) — lets the R2 gate evaluate R7
+    /// same-principal history rules during plan preview/validation.
+    pub author: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/src/orchestrator/application/orchestrator_impl.rs
+++ b/engine/src/orchestrator/application/orchestrator_impl.rs
@@ -433,6 +433,7 @@ impl OrchestratorServiceImpl {
         &self,
         steps: &[super::dto::TemplateStepDef],
         execution_id: Option<uuid::Uuid>,
+        principal: Option<&str>,
     ) -> Result<
         (
             Option<Vec<super::dto::TemplateStepDef>>,
@@ -451,7 +452,7 @@ impl OrchestratorServiceImpl {
                 parameters: s.parameters.clone(),
             })
             .collect();
-        let matches = svc.evaluate_plan(&planned).await.map_err(|e| {
+        let matches = svc.evaluate_plan(&planned, principal).await.map_err(|e| {
             OrchestratorError::SequencePolicyEvaluationFailed {
                 detail: e.to_string(),
             }
@@ -1217,7 +1218,11 @@ impl OrchestratorService for OrchestratorServiceImpl {
         // step's tool is never called. An evaluation error refuses the plan
         // too (fail closed on corrupt/over-cap rule config).
         let (enforced_steps, _findings) = self
-            .apply_plan_time_sequence_policy(&input.steps, Some(execution_id))
+            .apply_plan_time_sequence_policy(
+                &input.steps,
+                Some(execution_id),
+                input.author.as_deref(),
+            )
             .await?;
 
         // Init current execution state
@@ -1733,7 +1738,7 @@ impl OrchestratorService for OrchestratorServiceImpl {
         // Same R2 gate as `run_from_template` — a preview must show the same
         // promotion/denial decisions as the run it precedes.
         let (enforced_steps, findings) = self
-            .apply_plan_time_sequence_policy(&input.steps, None)
+            .apply_plan_time_sequence_policy(&input.steps, None, input.author.as_deref())
             .await?;
         let steps: &[super::dto::TemplateStepDef] =
             enforced_steps.as_deref().unwrap_or(&input.steps);
@@ -2414,6 +2419,7 @@ mod tests {
                 ],
                 window: Some(3),
                 action,
+                history: None,
             }],
         }
     }
@@ -2935,6 +2941,7 @@ mod tests {
                 steps: conference_runbook(),
                 repo_root: "/tmp/t".into(),
                 template_name: "conf-registration".into(),
+                author: None,
             })
             .await
             .unwrap();
@@ -2975,6 +2982,7 @@ mod tests {
                 steps: conference_runbook(),
                 repo_root: "/tmp/t".into(),
                 template_name: "conf-registration".into(),
+                author: None,
             })
             .await
             .unwrap_err();
@@ -3158,6 +3166,154 @@ mod tests {
                 assert!(detail.contains("2 of 2 calls"), "should name the budget");
             }
             e => panic!("expected Internal budget error, got {e:?}"),
+        }
+    }
+
+    /// R7 SCENE 9 (issue #871): two separate runs, minutes apart — run 1
+    /// removes a registrant (envelope persisted to the signed local trail),
+    /// run 2 adds the requester. Each run passes its own within-run gate; the
+    /// R7 history rule refuses run 2 AT PLAN TIME because the SAME principal
+    /// removed within the window. Uses the REAL EnvelopeHistoryAdapter over a
+    /// real envelope repository seeded with run 1's envelope.
+    #[tokio::test]
+    async fn test_r7_cross_run_same_principal_remove_then_add_refused_at_plan_time() {
+        use crate::audit::application::dto::BuildEnvelopeInput;
+        use crate::audit::application::envelope_factory_impl::AuditEnvelopeFactoryImpl;
+        use crate::audit::application::factory::AuditEnvelopeFactory;
+        use crate::audit::domain::envelope::{EventStatus, ExecutionEventRef};
+        use crate::audit::infrastructure::local_audit_repository::LocalAuditEnvelopeRepository;
+        use crate::event_system::application::event_bus_service_impl::EventBusServiceImpl;
+        use crate::execution_engine::application::service_impl::{
+            ParallelExecutionServiceImpl, RetryEvaluationServiceImpl,
+        };
+        use crate::execution_engine::domain::ParallelExecutorConfig;
+        use crate::sequence_policy::application::service_impl::SequencePolicyServiceImpl;
+        use crate::sequence_policy::domain::{HistoryPredicate, RuleAction};
+        use crate::sequence_policy::infrastructure::{EnvelopeHistoryAdapter, ExecutionHistory};
+        use serde_json::json;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        // ── Run 1's signed envelope: jeff@corp removed a registrant. ──
+        let repo: std::sync::Arc<
+            dyn crate::audit::infrastructure::repository::AuditEnvelopeRepository,
+        > = std::sync::Arc::new(LocalAuditEnvelopeRepository::new(dir.path().to_path_buf()));
+        let factory = AuditEnvelopeFactoryImpl::default();
+        let run1 = factory
+            .build_envelope(BuildEnvelopeInput {
+                execution_id: uuid::Uuid::new_v4(),
+                template_id: "attendance-remove".to_string(),
+                planning_prompt: "run 1".to_string(),
+                events: vec![ExecutionEventRef {
+                    event_type: "node_completed".to_string(),
+                    summary: "remove completed".to_string(),
+                    occurred_at: chrono::Utc::now(),
+                    correlation_id: None,
+                    status: EventStatus::Success,
+                    payload: Some(json!({ "step_name": "registration_remove" })),
+                }],
+                source: Some("rigorix_demo".to_string()),
+                total_tokens: 0,
+                duration_ms: 10,
+                git_commit: None,
+                git_branch: None,
+                model_version: None,
+                planning_prompt_content: None,
+                file_paths: vec![],
+                metadata: None,
+                scoring_results: std::collections::HashMap::new(),
+                sign: false,
+                repository: None,
+                author: Some("jeff@corp".to_string()),
+                identity: None,
+            })
+            .await
+            .expect("run-1 envelope");
+        repo.save(&run1).await.expect("run-1 envelope saved");
+
+        // ── R7 rule: adding a seat is DENIED when the same principal removed
+        // one within 15 minutes (single current-run predicate + history). ──
+        let policy_cfg = crate::sequence_policy::domain::SequencePolicyConfig {
+            fail_closed: true,
+            rules: vec![crate::sequence_policy::domain::SequenceRule {
+                id: "no-cross-run-remove-reassign".to_string(),
+                name: "No cross-run remove-then-reassign".to_string(),
+                description: "d".to_string(),
+                steps: vec![crate::sequence_policy::domain::StepPredicate {
+                    tool: "registration_add".to_string(),
+                    params: vec![crate::sequence_policy::domain::ParamPredicate {
+                        pointer: "/event_id".to_string(),
+                        kind: crate::sequence_policy::domain::ParamMatchKind::Exact,
+                        value: "conf-2026".to_string(),
+                    }],
+                }],
+                window: None,
+                action: RuleAction::Deny,
+                history: Some(HistoryPredicate {
+                    prior_node: "registration_remove".to_string(),
+                    same_principal: true,
+                    window_secs: 900,
+                }),
+            }],
+        };
+        let policy = std::sync::Arc::new(
+            SequencePolicyServiceImpl::new(Box::new(FixedPolicyRepo {
+                config: Some(policy_cfg),
+            }))
+            .with_history(std::sync::Arc::new(EnvelopeHistoryAdapter::new(repo))),
+        );
+
+        // ── Run 2: jeff's agent tries to add him to the full event. ──
+        let executor: Arc<dyn exec_svc::ParallelExecutionService> =
+            Arc::new(ParallelExecutionServiceImpl::new(
+                ParallelExecutorConfig::default(),
+                Box::new(RetryEvaluationServiceImpl::new()),
+                Arc::new(EventBusServiceImpl::default()),
+            ));
+        let orch = OrchestratorServiceImpl::new(
+            OrchestratorConfig::default(),
+            Arc::new(super::super::orchestrator_mocks::MockPlanningService::new()),
+            executor,
+            Arc::new(super::super::orchestrator_mocks::MockStateService::new()),
+            Arc::new(super::super::orchestrator_mocks::MockCancellationService),
+            Arc::new(super::super::orchestrator_mocks::MockEventBusService::new()),
+            None,
+            Arc::new(super::super::orchestrator_mocks::MockBudgetService),
+            None,
+        )
+        .with_sequence_policy(policy);
+
+        let step = crate::orchestrator::dto::TemplateStepDef {
+            name: "registration_add".to_string(),
+            tool: "registration_add".to_string(),
+            description: "add jeff".to_string(),
+            parameters: json!({ "event_id": "conf-2026" }),
+            requires_approval: false,
+            timeout_secs: None,
+            evaluate_score: false,
+        };
+        let err = orch
+            .run_from_template(RunFromTemplateInput {
+                steps: vec![step],
+                repo_root: dir.path().to_string_lossy().into_owned(),
+                execution_id: Some(uuid::Uuid::new_v4()),
+                template_name: "attendance-add".into(),
+                repository: None,
+                author: Some("jeff@corp".to_string()),
+                enforcement_preset: None,
+            })
+            .await
+            .expect_err("run 2 must be refused at plan time (cross-run R7)");
+
+        match err {
+            OrchestratorError::SequencePolicyDenied {
+                later_step,
+                rule_id,
+            } => {
+                assert_eq!(later_step, "registration_add");
+                assert_eq!(rule_id, "no-cross-run-remove-reassign");
+            }
+            other => panic!("expected SequencePolicyDenied from the cross-run rule, got {other:?}"),
         }
     }
 }

--- a/engine/src/sequence_policy/application/matcher.rs
+++ b/engine/src/sequence_policy/application/matcher.rs
@@ -118,8 +118,15 @@ fn find_matches_for_rule<S: StepLike>(
     steps: &[S],
 ) -> Result<Vec<SequenceMatch>, SequencePolicyError> {
     // A sequence rule needs at least an ordered pair — single-predicate rules
-    // are per-action policy, not sequence policy.
-    if rule.steps.len() < 2 || steps.len() < rule.steps.len() {
+    // are per-action policy, not sequence policy. EXCEPTION (R7): a rule with
+    // a `history` predicate matches the current run's action AND the signed
+    // prior-execution trail — the cross-run case ("remove X" in run 1,
+    // "add Jeff" in run 2) is a single current-run action gated by history.
+    if rule.steps.is_empty()
+        || steps.is_empty()
+        || steps.len() < rule.steps.len()
+        || (rule.steps.len() < 2 && rule.history.is_none())
+    {
         return Ok(Vec::new());
     }
     let predicate_count = rule.steps.len();
@@ -204,6 +211,7 @@ mod tests {
             steps: tools.iter().map(|t| tool_predicate(t)).collect(),
             window,
             action,
+            history: None,
         }
     }
 

--- a/engine/src/sequence_policy/application/service.rs
+++ b/engine/src/sequence_policy/application/service.rs
@@ -48,14 +48,22 @@ pub trait SequencePolicyService: Send + Sync {
     /// `requires_approval = true`; a matched `deny` rule means it must fail
     /// before dispatch.
     ///
+    /// `principal` is the current run's initiating identity (envelope
+    /// `author` / attested claim subject). R7 rules with
+    /// `history.same_principal = true` match only prior actions by this
+    /// principal; `None` never yields a same-principal match (no false
+    /// denial).
+    ///
     /// # Errors
     /// - `SequencePolicyError::InvalidConfig` / `RuleExceedsCaps` — rule
     ///   config corrupt or over-cap → **fail closed**, plan refused, no steps
     ///   execute
-    /// - `SequencePolicyError::Internal` — evaluation failed unexpectedly
+    /// - `SequencePolicyError::Internal` — evaluation (incl. history read)
+    ///   failed unexpectedly → also fail closed
     async fn evaluate_plan(
         &self,
         steps: &[PlannedStep],
+        principal: Option<&str>,
     ) -> Result<Vec<SequenceMatch>, SequencePolicyError>;
 
     /// Evaluate a dispatch prefix plus the next node (run-time, R3).
@@ -64,6 +72,11 @@ pub trait SequencePolicyService: Send + Sync {
     /// shared by `execute_graph` and `resume_execution`) when the next step
     /// would complete a forbidden sequence over the completed prefix.
     ///
+    /// `principal` follows the same R7 semantics as [`Self::evaluate_plan`];
+    /// the executor does not currently track a per-run principal, so
+    /// callers pass `None` — same-principal history rules therefore evaluate
+    /// at plan time (R2), not mid-dispatch (documented in the module spec).
+    ///
     /// # Errors
     /// - Fail-closed: any error halts the run with `SequencePolicyError` —
     ///   the node is not dispatched
@@ -71,5 +84,6 @@ pub trait SequencePolicyService: Send + Sync {
         &self,
         prefix: &[DispatchedStep],
         next: &PlannedStep,
+        principal: Option<&str>,
     ) -> Result<Vec<SequenceMatch>, SequencePolicyError>;
 }

--- a/engine/src/sequence_policy/application/service_impl.rs
+++ b/engine/src/sequence_policy/application/service_impl.rs
@@ -35,8 +35,12 @@
 //!   directly (window semantics + determinism property)
 
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 
-use crate::sequence_policy::domain::{SequenceMatch, SequencePolicyError, SequenceRule};
+use crate::sequence_policy::domain::{
+    SequenceMatch, SequencePolicyError, SequenceRule, rule::tool_matches,
+};
+use crate::sequence_policy::infrastructure::ExecutionHistory;
 use crate::sequence_policy::infrastructure::repository::SequencePolicyRepository;
 
 use super::dto::{DispatchedStep, PlannedStep};
@@ -49,9 +53,13 @@ use super::service::SequencePolicyService;
 /// - `new(repository)` — inject the rule-config repository (filesystem-backed
 ///   `TomlSequencePolicyRepository`, or a signed-bundle seam for enterprise,
 ///   P3)
+/// - `.with_history(...)` — R7: inject the signed-execution-history port
+///   (envelope-backed). Omitted (`None`) = history rules never match —
+///   status quo, no cross-run gating.
 pub struct SequencePolicyServiceImpl {
     repository: Box<dyn SequencePolicyRepository>,
     matcher: Matcher,
+    history: Option<std::sync::Arc<dyn ExecutionHistory>>,
 }
 
 impl SequencePolicyServiceImpl {
@@ -60,7 +68,14 @@ impl SequencePolicyServiceImpl {
         Self {
             repository,
             matcher: Matcher::new(),
+            history: None,
         }
+    }
+
+    /// R7: attach the signed-execution-history port (envelope-backed).
+    pub fn with_history(mut self, history: std::sync::Arc<dyn ExecutionHistory>) -> Self {
+        self.history = Some(history);
+        self
     }
 
     /// Load the rule config for this run. `Ok(None)` (no config file) is
@@ -81,6 +96,89 @@ impl SequencePolicyServiceImpl {
             }
         }
     }
+
+    /// R7: drop within-run matches whose rule carries a `history` predicate
+    /// that the signed prior-execution history does NOT satisfy.
+    ///
+    /// A rule with `history` fires only when the within-run `steps[]` match
+    /// AND a prior action (glob-matching `prior_node`, by the same principal
+    /// when required, within `window_secs`) exists in the history. History is
+    /// read once per evaluation over the widest required window. A missing
+    /// history port means history rules never match (status quo). A read
+    /// failure fails closed.
+    async fn filter_matches_by_history(
+        &self,
+        rules: &[SequenceRule],
+        matches: Vec<SequenceMatch>,
+        principal: Option<&str>,
+        now: DateTime<Utc>,
+    ) -> Result<Vec<SequenceMatch>, SequencePolicyError> {
+        // Only matches whose rule carries a history predicate need checking.
+        let has_history = |rule_id: &str| -> bool {
+            rules
+                .iter()
+                .find(|r| r.id == rule_id)
+                .and_then(|r| r.history.as_ref())
+                .is_some()
+        };
+        let needs_history_count = matches.iter().filter(|m| has_history(&m.rule_id)).count();
+        if needs_history_count == 0 {
+            return Ok(matches);
+        }
+        let Some(history) = &self.history else {
+            // No history port wired — history rules cannot match (status quo).
+            tracing::warn!(
+                "sequence_policy: rule with history predicate matched within-run but no history \
+                 port is wired — treating as no-match"
+            );
+            return Ok(matches
+                .into_iter()
+                .filter(|m| !has_history(&m.rule_id))
+                .collect());
+        };
+
+        // Widest required window across the rules that matched.
+        let widest = matches
+            .iter()
+            .filter(|m| has_history(&m.rule_id))
+            .filter_map(|m| {
+                rules
+                    .iter()
+                    .find(|r| r.id == m.rule_id)
+                    .and_then(|r| r.history.as_ref())
+                    .map(|h| h.window_secs)
+            })
+            .max()
+            .unwrap_or(0);
+        let since = now - chrono::Duration::seconds(widest as i64);
+        let prior = history.prior_actions(since).await?;
+
+        let kept = matches
+            .into_iter()
+            .filter(|m| {
+                let Some(rule) = rules.iter().find(|r| r.id == m.rule_id) else {
+                    return false;
+                };
+                let Some(h) = &rule.history else {
+                    return true; // within-run only — unaffected by history
+                };
+                let cutoff = now - chrono::Duration::seconds(h.window_secs as i64);
+                prior.iter().any(|a| {
+                    a.at >= cutoff
+                        && tool_matches(&h.prior_node, &a.node)
+                        && (!h.same_principal
+                            || (principal.is_some() && a.principal.as_deref() == principal))
+                })
+            })
+            .collect::<Vec<_>>();
+        if kept.len() < needs_history_count {
+            tracing::info!(
+                prior = prior.len(),
+                "sequence_policy: cross-run history predicate filtered a within-run match"
+            );
+        }
+        Ok(kept)
+    }
 }
 
 #[async_trait]
@@ -88,9 +186,13 @@ impl SequencePolicyService for SequencePolicyServiceImpl {
     async fn evaluate_plan(
         &self,
         steps: &[PlannedStep],
+        principal: Option<&str>,
     ) -> Result<Vec<SequenceMatch>, SequencePolicyError> {
         let rules = self.load_rules().await?;
         let matches = self.matcher.find_matches(&rules, steps)?;
+        let matches = self
+            .filter_matches_by_history(&rules, matches, principal, Utc::now())
+            .await?;
         if !matches.is_empty() {
             tracing::info!(
                 rules = rules.len(),
@@ -106,6 +208,7 @@ impl SequencePolicyService for SequencePolicyServiceImpl {
         &self,
         prefix: &[DispatchedStep],
         next: &PlannedStep,
+        principal: Option<&str>,
     ) -> Result<Vec<SequenceMatch>, SequencePolicyError> {
         let rules = self.load_rules().await?;
         let next_idx = prefix.len();
@@ -127,6 +230,9 @@ impl SequencePolicyService for SequencePolicyServiceImpl {
         // that finished entirely inside the completed prefix was already acted
         // on at the dispatch of its own later step.
         let matches = self.matcher.find_matches(&rules, &views)?;
+        let matches = self
+            .filter_matches_by_history(&rules, matches, principal, Utc::now())
+            .await?;
         let actionable: Vec<SequenceMatch> = matches
             .into_iter()
             .filter(|m| m.matched_indices.last() == Some(&next_idx))
@@ -147,9 +253,11 @@ impl SequencePolicyService for SequencePolicyServiceImpl {
 mod tests {
     use super::*;
     use crate::sequence_policy::domain::{
-        ParamMatchKind, ParamPredicate, RuleAction, SafetyCaps, SequencePolicyConfig, SequenceRule,
-        StepPredicate,
+        HistoryAction, HistoryPredicate, ParamMatchKind, ParamPredicate, RuleAction, SafetyCaps,
+        SequencePolicyConfig, SequenceRule, StepPredicate,
     };
+    use crate::sequence_policy::infrastructure::ExecutionHistory;
+    use chrono::{DateTime, Utc};
     use serde_json::json;
 
     /// In-memory test repository serving a fixed config / outcome.
@@ -198,6 +306,7 @@ mod tests {
             ],
             window: Some(3),
             action: RuleAction::Promote,
+            history: None,
         }
     }
 
@@ -223,6 +332,136 @@ mod tests {
         }))
     }
 
+    /// R7 fake history port — in-memory prior actions.
+    struct FakeHistory {
+        actions: std::sync::Mutex<Vec<HistoryAction>>,
+    }
+    #[async_trait::async_trait]
+    impl ExecutionHistory for FakeHistory {
+        async fn prior_actions(
+            &self,
+            _since: DateTime<Utc>,
+        ) -> Result<Vec<HistoryAction>, SequencePolicyError> {
+            Ok(self.actions.lock().unwrap().clone())
+        }
+    }
+
+    fn history_rule() -> SequenceRule {
+        // remove(conf-2026) in a PRIOR run + add(conf-2026) now, same
+        // principal, within 15 min — the cross-run Jeff case (R7).
+        SequenceRule {
+            id: "no-cross-run-remove-reassign".to_string(),
+            name: "No cross-run remove-then-reassign".to_string(),
+            description: "d".to_string(),
+            steps: vec![StepPredicate {
+                tool: "registration_add".to_string(),
+                params: vec![ParamPredicate {
+                    pointer: "/event_id".to_string(),
+                    kind: ParamMatchKind::Exact,
+                    value: "conf-2026".to_string(),
+                }],
+            }],
+            window: None,
+            action: RuleAction::Deny,
+            history: Some(HistoryPredicate {
+                prior_node: "registration_remove".to_string(),
+                same_principal: true,
+                window_secs: 900,
+            }),
+        }
+    }
+
+    fn history_config() -> SequencePolicyConfig {
+        SequencePolicyConfig {
+            fail_closed: true,
+            rules: vec![history_rule()],
+        }
+    }
+
+    fn history_svc(actions: Vec<HistoryAction>) -> SequencePolicyServiceImpl {
+        SequencePolicyServiceImpl::new(Box::new(StubRepository {
+            outcome: Ok(Some(history_config())),
+        }))
+        .with_history(std::sync::Arc::new(FakeHistory {
+            actions: std::sync::Mutex::new(actions),
+        }))
+    }
+
+    fn history_at(secs_ago: i64) -> HistoryAction {
+        HistoryAction {
+            node: "registration_remove".to_string(),
+            principal: Some("jeff@corp".to_string()),
+            at: chrono::Utc::now() - chrono::Duration::seconds(secs_ago),
+        }
+    }
+
+    /// R7 scene 9: run 1 removed (in the signed history) by the SAME
+    /// principal → run 2's add is DENIED at plan time.
+    #[tokio::test]
+    async fn cross_run_same_principal_prior_remove_denies_add() {
+        let svc = history_svc(vec![history_at(120)]);
+        let runbook = vec![planned("add", "registration_add", "conf-2026")];
+        let matches = svc
+            .evaluate_plan(&runbook, Some("jeff@corp"))
+            .await
+            .expect("evaluate");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].rule_id, "no-cross-run-remove-reassign");
+        assert_eq!(matches[0].action, RuleAction::Deny);
+    }
+
+    /// Different principal's prior remove does NOT deny this run.
+    #[tokio::test]
+    async fn cross_run_other_principal_prior_remove_does_not_deny() {
+        let svc = history_svc(vec![history_at(120)]);
+        let runbook = vec![planned("add", "registration_add", "conf-2026")];
+        let matches = svc
+            .evaluate_plan(&runbook, Some("organizer@corp"))
+            .await
+            .expect("evaluate");
+        assert!(
+            matches.is_empty(),
+            "same_principal rule must not match another principal"
+        );
+    }
+
+    /// Prior remove OUTSIDE the window does not deny.
+    #[tokio::test]
+    async fn cross_run_out_of_window_prior_remove_does_not_deny() {
+        let svc = history_svc(vec![history_at(3600)]);
+        let runbook = vec![planned("add", "registration_add", "conf-2026")];
+        let matches = svc
+            .evaluate_plan(&runbook, Some("jeff@corp"))
+            .await
+            .expect("evaluate");
+        assert!(matches.is_empty(), "stale prior action must not deny");
+    }
+
+    /// No history port wired → history rules never match (status quo).
+    #[tokio::test]
+    async fn cross_run_without_history_port_never_denies() {
+        let svc = service_with(history_config());
+        let runbook = vec![planned("add", "registration_add", "conf-2026")];
+        let matches = svc
+            .evaluate_plan(&runbook, Some("jeff@corp"))
+            .await
+            .expect("evaluate");
+        assert!(matches.is_empty(), "no history port ⇒ no cross-run gating");
+    }
+
+    /// No principal on the run + same_principal rule → no match (never a
+    /// false denial).
+    #[tokio::test]
+    async fn cross_run_unknown_principal_never_denies() {
+        let svc = history_svc(vec![history_at(120)]);
+        let runbook = vec![planned("add", "registration_add", "conf-2026")];
+        let matches = svc.evaluate_plan(&runbook, None).await.expect("evaluate");
+        assert!(
+            matches.is_empty(),
+            "unknown principal ⇒ no same-principal match"
+        );
+    }
+
     #[tokio::test]
     async fn evaluate_plan_finds_remove_then_add_pair_and_returns_later_step() {
         // AC #5: a runbook containing remove-then-add yields a match whose
@@ -232,7 +471,7 @@ mod tests {
             planned("registration_remove", "registration_remove", "conf-2026"),
             planned("registration_add", "registration_add", "conf-2026"),
         ];
-        let matches = svc.evaluate_plan(&runbook).await.expect("evaluate");
+        let matches = svc.evaluate_plan(&runbook, None).await.expect("evaluate");
         assert_eq!(matches.len(), 1);
         let m = &matches[0];
         assert_eq!(m.rule_id, "registration-remove-then-reassign");
@@ -250,7 +489,7 @@ mod tests {
             planned("registration_remove", "registration_remove", "conf-2025"),
             planned("registration_add", "registration_add", "conf-2026"),
         ];
-        let matches = svc.evaluate_plan(&runbook).await.expect("evaluate");
+        let matches = svc.evaluate_plan(&runbook, None).await.expect("evaluate");
         assert!(matches.is_empty());
     }
 
@@ -263,7 +502,7 @@ mod tests {
             planned("intermediate", "audit_log", "x"),
             planned("registration_add", "registration_add", "conf-2026"),
         ];
-        assert_eq!(svc.evaluate_plan(&within).await.expect("e").len(), 1);
+        assert_eq!(svc.evaluate_plan(&within, None).await.expect("e").len(), 1);
 
         // Gap of 4 > window 3 → out of window, no match.
         let outside = vec![
@@ -274,7 +513,12 @@ mod tests {
             planned("s4", "audit_log", "x"),
             planned("registration_add", "registration_add", "conf-2026"),
         ];
-        assert!(svc.evaluate_plan(&outside).await.expect("e").is_empty());
+        assert!(
+            svc.evaluate_plan(&outside, None)
+                .await
+                .expect("e")
+                .is_empty()
+        );
     }
 
     #[tokio::test]
@@ -297,13 +541,14 @@ mod tests {
                 ],
                 window: None, // adjacent
                 action: RuleAction::Deny,
+                history: None,
             }],
         };
         let svc = service_with(config);
 
         // Adjacent A,B → matched.
         let adjacent = vec![planned("a", "step_a", "x"), planned("b", "step_b", "x")];
-        let matches = svc.evaluate_plan(&adjacent).await.expect("e");
+        let matches = svc.evaluate_plan(&adjacent, None).await.expect("e");
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].action, RuleAction::Deny);
         assert_eq!(matches[0].later_step, "b");
@@ -314,7 +559,12 @@ mod tests {
             planned("mid", "other", "x"),
             planned("b", "step_b", "x"),
         ];
-        assert!(svc.evaluate_plan(&gapped).await.expect("e").is_empty());
+        assert!(
+            svc.evaluate_plan(&gapped, None)
+                .await
+                .expect("e")
+                .is_empty()
+        );
     }
 
     #[tokio::test]
@@ -325,7 +575,7 @@ mod tests {
             planned("registration_remove", "registration_remove", "conf-2026"),
             planned("registration_add", "registration_add", "conf-2026"),
         ];
-        let matches = svc.evaluate_plan(&runbook).await.expect("no error");
+        let matches = svc.evaluate_plan(&runbook, None).await.expect("no error");
         assert!(matches.is_empty());
     }
 
@@ -338,7 +588,10 @@ mod tests {
             planned("registration_remove", "registration_remove", "conf-2026"),
             planned("registration_add", "registration_add", "conf-2026"),
         ];
-        let err = svc.evaluate_plan(&runbook).await.expect_err("fail closed");
+        let err = svc
+            .evaluate_plan(&runbook, None)
+            .await
+            .expect_err("fail closed");
         assert!(!err.is_retriable());
     }
 
@@ -353,7 +606,10 @@ mod tests {
             "conf-2026",
         )];
         let next = planned("registration_add", "registration_add", "conf-2026");
-        let matches = svc.evaluate_prefix(&prefix, &next).await.expect("evaluate");
+        let matches = svc
+            .evaluate_prefix(&prefix, &next, None)
+            .await
+            .expect("evaluate");
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].later_step, "registration_add");
         assert_eq!(matches[0].matched_indices, vec![0, 1]);
@@ -361,7 +617,7 @@ mod tests {
         // An unrelated next node completes nothing → no matches.
         let unrelated = planned("backup", "run_backup", "x");
         let matches = svc
-            .evaluate_prefix(&prefix, &unrelated)
+            .evaluate_prefix(&prefix, &unrelated, None)
             .await
             .expect("evaluate");
         assert!(matches.is_empty());
@@ -377,7 +633,10 @@ mod tests {
             dispatched("registration_add", "registration_add", "conf-2026"),
         ];
         let next = planned("backup", "run_backup", "x");
-        let matches = svc.evaluate_prefix(&prefix, &next).await.expect("evaluate");
+        let matches = svc
+            .evaluate_prefix(&prefix, &next, None)
+            .await
+            .expect("evaluate");
         assert!(matches.is_empty());
     }
 
@@ -402,6 +661,7 @@ mod tests {
                 ],
                 window: None,
                 action: RuleAction::Promote,
+                history: None,
             }],
         };
         let svc = service_with(config);
@@ -409,7 +669,7 @@ mod tests {
             planned("remove", "registration_remove", "conf-2026"),
             planned("add", "registration_add", "conf-2026"),
         ];
-        let matches = svc.evaluate_plan(&runbook).await.expect("evaluate");
+        let matches = svc.evaluate_plan(&runbook, None).await.expect("evaluate");
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].later_step, "add");
     }
@@ -423,6 +683,7 @@ mod tests {
             max_steps_per_rule: 8,
             max_window: 5,
             max_regex_predicates_per_file: 8,
+            max_history_window_secs: 604_800,
         };
         assert!(caps.max_window >= 1);
     }

--- a/engine/src/sequence_policy/domain/config.rs
+++ b/engine/src/sequence_policy/domain/config.rs
@@ -38,6 +38,9 @@ pub struct SafetyCaps {
     pub max_window: u32,
     /// Maximum number of regex parameter predicates across the file.
     pub max_regex_predicates_per_file: u32,
+    /// Maximum R7 `history.window_secs` look-back (default 7 days) — keeps
+    /// history scans bounded and stops a stale conflict from denying today.
+    pub max_history_window_secs: u64,
 }
 
 /// The loaded sequence-policy rule set.
@@ -67,6 +70,7 @@ impl Default for SafetyCaps {
             max_steps_per_rule: 8,
             max_window: 5,
             max_regex_predicates_per_file: 8,
+            max_history_window_secs: 604_800,
         }
     }
 }
@@ -126,6 +130,23 @@ impl SequencePolicyConfig {
                     detail: format!("window {window} exceeds cap max_window={}", caps.max_window),
                 });
             }
+            if let Some(hist) = &rule.history {
+                if hist.prior_node.trim().is_empty() {
+                    return Err(SequencePolicyError::InvalidConfig(format!(
+                        "rule '{}': history.prior_node cannot be empty",
+                        rule.id
+                    )));
+                }
+                if hist.window_secs > caps.max_history_window_secs {
+                    return Err(SequencePolicyError::RuleExceedsCaps {
+                        rule: rule.id.clone(),
+                        detail: format!(
+                            "history.window_secs {} exceeds cap max_history_window_secs={}",
+                            hist.window_secs, caps.max_history_window_secs
+                        ),
+                    });
+                }
+            }
             for step in &rule.steps {
                 regex_predicates += step
                     .params
@@ -172,6 +193,7 @@ mod tests {
                 .collect(),
             window: None,
             action: RuleAction::Promote,
+            history: None,
         }
     }
 
@@ -181,6 +203,7 @@ mod tests {
             max_steps_per_rule: 3,
             max_window: 5,
             max_regex_predicates_per_file: 1,
+            max_history_window_secs: 60,
         }
     }
 

--- a/engine/src/sequence_policy/domain/history.rs
+++ b/engine/src/sequence_policy/domain/history.rs
@@ -1,0 +1,27 @@
+//! HistoryAction — one executed action recovered from the signed audit trail.
+//!
+//! @canonical .pi/architecture/modules/sequence-policy.md#r7
+//! Issue: #871 (R7 cross-run conflicting-action rules)
+//!
+//! R7 rules consult actions that COMPLETED in PRIOR runs (the cross-run case:
+//! "remove X" in run 1, minutes later "add Jeff" in run 2 — each within-run
+//! gate passes on its own). The durable source is the signed envelope store
+//! (`.rigorix/audit`, LocalAuditEnvelopeRepository) — policy reads signed
+//! evidence, and tampering with the trail to evade a rule breaks the HMAC.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// One executed action in a prior, completed run.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HistoryAction {
+    /// The executed node's name (stable template identifier). Parameter
+    /// values are never recovered — the trail is pre-redacted (SpanPrivacy).
+    pub node: String,
+    /// Principal that triggered the prior run (envelope `author`, falling
+    /// back to the attested `identity.subject` when present). `None` when the
+    /// prior run recorded neither.
+    pub principal: Option<String>,
+    /// When the action completed (envelope / event timestamp).
+    pub at: DateTime<Utc>,
+}

--- a/engine/src/sequence_policy/domain/mod.rs
+++ b/engine/src/sequence_policy/domain/mod.rs
@@ -27,10 +27,13 @@
 
 pub mod config;
 pub mod error;
+pub mod history;
 pub mod rule;
 pub mod sequence_match;
 
 pub use config::{SafetyCaps, SequencePolicyConfig};
 pub use error::SequencePolicyError;
+pub use history::HistoryAction;
+pub use rule::HistoryPredicate;
 pub use rule::{ParamMatchKind, ParamPredicate, RuleAction, SequenceRule, StepPredicate};
 pub use sequence_match::SequenceMatch;

--- a/engine/src/sequence_policy/domain/rule.rs
+++ b/engine/src/sequence_policy/domain/rule.rs
@@ -119,7 +119,9 @@ impl StepPredicate {
 }
 
 /// Exact or glob (`*` wildcard) string match.
-fn tool_matches(pattern: &str, text: &str) -> bool {
+///
+/// `pub(crate)`: also used by R7 history matching (prior node names).
+pub(crate) fn tool_matches(pattern: &str, text: &str) -> bool {
     if !pattern.contains('*') {
         return pattern == text;
     }
@@ -221,6 +223,39 @@ pub struct SequenceRule {
     /// Action on match: `promote` (default) or `deny`.
     #[serde(default)]
     pub action: RuleAction,
+
+    /// R7: optional cross-run predicate. When present, the rule fires ONLY
+    /// if the within-run `steps[]` match AND the signed execution history
+    /// shows a prior action matching [`HistoryPredicate::prior_node`] —
+    /// by the same principal (when `same_principal`), within
+    /// [`HistoryPredicate::window_secs`] of the evaluation — before this run.
+    /// Absent = the pre-R7 within-run behavior (status quo).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub history: Option<HistoryPredicate>,
+}
+
+/// R7: cross-run predicate — fires when a PRIOR, already-completed run
+/// (visible in the signed audit trail) contains a conflicting action by the
+/// same principal, minutes apart. This is the case a single-plan checkpoint
+/// cannot see: "remove X" run 1 + "add Jeff" run 2 each pass their own gate.
+///
+/// Operator TOML (inside a `[[rules]]` table):
+///
+/// ```toml
+/// history = { prior_node = "remove_attendance", same_principal = true, window_secs = 900 }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HistoryPredicate {
+    /// Glob over prior executed node names (e.g. `"remove_attendance"` or
+    /// `"remove_*"`). The rule's own `steps[]` match the CURRENT run; this
+    /// matches the signed history of runs that already completed.
+    pub prior_node: String,
+    /// When `true`, only history actions whose principal equals the current
+    /// run's principal satisfy the predicate. When the current run has no
+    /// principal, the predicate cannot match (never a false denial).
+    pub same_principal: bool,
+    /// Look-back window (seconds) over the signed history.
+    pub window_secs: u64,
 }
 
 #[cfg(test)]
@@ -248,6 +283,32 @@ action = "promote"
     struct RulesFile {
         #[serde(default)]
         rules: Vec<SequenceRule>,
+    }
+
+    #[test]
+    #[test]
+    fn toml_parse_yields_rule_with_history_predicate() {
+        // R7 operator schema: a single current-run predicate + the history
+        // predicate (prior conflicting action by the same principal).
+        let file: RulesFile = toml::from_str(
+            r#"
+[[rules]]
+id = "no-cross-run-remove-reassign"
+name = "No cross-run remove-then-reassign"
+description = "same principal removed within the window"
+steps = [{ tool = "registration_add", params = [{ pointer = "/event_id", kind = "exact", value = "conf-2026" }] }]
+action = "deny"
+history = { prior_node = "registration_remove", same_principal = true, window_secs = 900 }
+"#,
+        )
+        .expect("R7 operator TOML parses");
+        let rule = &file.rules[0];
+        let h = rule.history.as_ref().expect("history predicate present");
+        assert_eq!(h.prior_node, "registration_remove");
+        assert!(h.same_principal);
+        assert_eq!(h.window_secs, 900);
+        assert_eq!(rule.steps.len(), 1, "cross-run rule is single-predicate");
+        assert_eq!(rule.action, RuleAction::Deny);
     }
 
     #[test]

--- a/engine/src/sequence_policy/infrastructure/history.rs
+++ b/engine/src/sequence_policy/infrastructure/history.rs
@@ -1,0 +1,200 @@
+//! ExecutionHistory — outbound port over the signed audit trail (R7).
+//!
+//! @canonical .pi/architecture/modules/sequence-policy.md#r7
+//! Issue: #871 (R7 cross-run conflicting-action rules)
+//!
+//! R7 rules consult actions that COMPLETED in PRIOR runs. The port lives in
+//! the module's infrastructure layer (same convention as the rule-config
+//! `SequencePolicyRepository`); the default implementation reads the signed
+//! envelope store (`.rigorix/audit`, `LocalAuditEnvelopeRepository`), so
+//! policy input == signed evidence — tampering with the trail to evade a
+//! rule breaks the envelope HMAC.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+use crate::audit::domain::envelope::AuditEnvelope;
+use crate::sequence_policy::domain::{HistoryAction, SequencePolicyError};
+
+/// Durable record of executed actions from PRIOR runs.
+#[async_trait]
+pub trait ExecutionHistory: Send + Sync {
+    /// Return the actions completed since `since` (newest first).
+    ///
+    /// # Errors
+    /// - A history read failure is fail-closed (`SequencePolicyError`) —
+    ///   the run is refused rather than evaluated against partial history.
+    /// - A missing history store is NOT an error: it yields an empty list
+    ///   (no prior actions — status quo).
+    async fn prior_actions(
+        &self,
+        since: DateTime<Utc>,
+    ) -> Result<Vec<HistoryAction>, SequencePolicyError>;
+}
+
+/// Envelope-backed history: extracts per-node completions from the signed
+/// envelopes persisted by the composition roots (`LocalAuditEnvelopeRepository`
+/// under `<repo_root>/.rigorix/audit`).
+///
+/// - Node identity = the envelope's execution-event `step_name` payload
+///   (stable template identifiers; parameter values stay redacted —
+///   SpanPrivacy, never recovered into policy input).
+/// - Principal = the envelope `author`, falling back to the attested
+///   `identity.subject` when present.
+pub struct EnvelopeHistoryAdapter {
+    repo: std::sync::Arc<dyn crate::audit::infrastructure::repository::AuditEnvelopeRepository>,
+}
+
+impl EnvelopeHistoryAdapter {
+    /// Create the adapter over the given envelope repository.
+    pub fn new(
+        repo: std::sync::Arc<dyn crate::audit::infrastructure::repository::AuditEnvelopeRepository>,
+    ) -> Self {
+        Self { repo }
+    }
+}
+
+/// Extract the executed node names from one envelope's event refs.
+///
+/// Node-completion events carry `payload.step_name`; duplicate names within
+/// one envelope collapse to the last occurrence (per-node completion).
+fn actions_from_envelope(envelope: &AuditEnvelope) -> Vec<HistoryAction> {
+    let principal = envelope
+        .author
+        .clone()
+        .or_else(|| envelope.identity.as_ref().map(|i| i.subject.clone()));
+    let mut seen: Vec<String> = Vec::new();
+    let mut out = Vec::new();
+    for ev in &envelope.events {
+        let Some(payload) = &ev.payload else { continue };
+        let Some(step_name) = payload.get("step_name").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        if seen.contains(&step_name.to_string()) {
+            continue;
+        }
+        seen.push(step_name.to_string());
+        out.push(HistoryAction {
+            node: step_name.to_string(),
+            principal: principal.clone(),
+            at: ev.occurred_at,
+        });
+    }
+    out
+}
+
+#[async_trait]
+impl ExecutionHistory for EnvelopeHistoryAdapter {
+    async fn prior_actions(
+        &self,
+        since: DateTime<Utc>,
+    ) -> Result<Vec<HistoryAction>, SequencePolicyError> {
+        match self.repo.list(Some(since), None, Some(500)).await {
+            Ok(envelopes) => {
+                let mut actions: Vec<HistoryAction> = Vec::new();
+                for envelope in envelopes {
+                    actions.extend(actions_from_envelope(&envelope));
+                }
+                Ok(actions)
+            }
+            Err(e) => {
+                // A missing audit directory is the no-history case — status
+                // quo, not an error. Anything else fails closed.
+                if e.to_string().contains("No such file or directory")
+                    || e.to_string().contains("failed to read directory")
+                {
+                    return Ok(Vec::new());
+                }
+                Err(SequencePolicyError::Internal(format!(
+                    "history read failed: {e}"
+                )))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit::application::dto::BuildEnvelopeInput;
+    use crate::audit::application::envelope_factory_impl::AuditEnvelopeFactoryImpl;
+    use crate::audit::domain::envelope::{EventStatus, ExecutionEventRef};
+    use crate::audit::infrastructure::local_audit_repository::LocalAuditEnvelopeRepository;
+    use serde_json::json;
+
+    fn completed_envelope_input(node: &str, author: &str) -> BuildEnvelopeInput {
+        BuildEnvelopeInput {
+            execution_id: uuid::Uuid::new_v4(),
+            template_id: "attendance".to_string(),
+            planning_prompt: "run".to_string(),
+            events: vec![ExecutionEventRef {
+                event_type: "node_completed".to_string(),
+                summary: format!("{node} completed"),
+                occurred_at: chrono::Utc::now(),
+                correlation_id: None,
+                status: EventStatus::Success,
+                payload: Some(json!({ "step_name": node })),
+            }],
+            source: Some("rigorix_mcp".to_string()),
+            total_tokens: 0,
+            duration_ms: 10,
+            git_commit: None,
+            git_branch: None,
+            model_version: None,
+            planning_prompt_content: None,
+            file_paths: vec![],
+            metadata: None,
+            scoring_results: std::collections::HashMap::new(),
+            sign: false,
+            repository: None,
+            author: Some(author.to_string()),
+            identity: None,
+        }
+    }
+
+    /// R7 adapter over the REAL signed envelope store: an envelope written by
+    /// the local repo surfaces as a prior HistoryAction with node + principal.
+    #[tokio::test]
+    async fn adapter_recovers_prior_actions_from_saved_envelopes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let repo: std::sync::Arc<
+            dyn crate::audit::infrastructure::repository::AuditEnvelopeRepository,
+        > = std::sync::Arc::new(LocalAuditEnvelopeRepository::new(dir.path().to_path_buf()));
+
+        let factory = AuditEnvelopeFactoryImpl::default();
+        // Trait method — bring the factory trait into scope.
+        use crate::audit::application::factory::AuditEnvelopeFactory;
+        let envelope = factory
+            .build_envelope(completed_envelope_input("remove_attendance", "jeff@corp"))
+            .await
+            .expect("build");
+        repo.save(&envelope).await.expect("save");
+
+        let adapter = EnvelopeHistoryAdapter::new(repo.clone());
+        let since = chrono::Utc::now() - chrono::Duration::hours(1);
+        let actions = adapter.prior_actions(since).await.expect("history read");
+
+        assert!(
+            actions.iter().any(|a| {
+                a.node == "remove_attendance" && a.principal.as_deref() == Some("jeff@corp")
+            }),
+            "prior actions must include the saved node + principal: {actions:?}"
+        );
+    }
+
+    /// Missing audit directory = empty history (status quo), never an error.
+    #[tokio::test]
+    async fn adapter_missing_dir_is_empty_history() {
+        let dir =
+            std::env::temp_dir().join(format!("rigorix-r7-missing-{}/audit", uuid::Uuid::new_v4()));
+        let repo: std::sync::Arc<
+            dyn crate::audit::infrastructure::repository::AuditEnvelopeRepository,
+        > = std::sync::Arc::new(LocalAuditEnvelopeRepository::new(dir));
+        let adapter = EnvelopeHistoryAdapter::new(repo);
+        let actions = adapter
+            .prior_actions(chrono::Utc::now() - chrono::Duration::hours(1))
+            .await
+            .expect("missing dir must yield empty history");
+        assert!(actions.is_empty());
+    }
+}

--- a/engine/src/sequence_policy/infrastructure/mod.rs
+++ b/engine/src/sequence_policy/infrastructure/mod.rs
@@ -16,6 +16,8 @@
 //!   hooks/permissions); rules changed between runs apply to the next plan
 //!   evaluation — prior decisions stand (documented in the module spec)
 
+mod history;
 pub mod repository;
 
+pub use history::{EnvelopeHistoryAdapter, ExecutionHistory};
 pub use repository::{SequencePolicyRepository, TomlSequencePolicyRepository};

--- a/mcp/src/execution_tools/infrastructure/engine_facade_impl.rs
+++ b/mcp/src/execution_tools/infrastructure/engine_facade_impl.rs
@@ -335,6 +335,7 @@ impl EngineFacade for EngineFacadeImpl {
             steps: steps_def,
             repo_root: self.config.repo_root.clone(),
             template_name,
+            author: None,
         };
 
         // R2 sequence-policy gate runs inside the orchestrator preview. A

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -1196,12 +1196,26 @@ async fn build_real_engine(
         .clone()
         .or_else(|| std::env::var("RIGORIX_HMAC_KEY").ok())
         .filter(|k| !k.is_empty());
-    let audit_service: Arc<dyn AuditService> = Arc::new(AuditServiceImpl::new(
-        Box::new(AuditEnvelopeFactoryImpl::new(hmac_key)),
-        audit_sender,
-        Box::new(AuditQueueImpl::default()),
-        audit_url.is_some(),
-    ));
+    let audit_service: Arc<dyn AuditService> = {
+        let mut service = AuditServiceImpl::new(
+            Box::new(AuditEnvelopeFactoryImpl::new(hmac_key)),
+            audit_sender,
+            Box::new(AuditQueueImpl::default()),
+            audit_url.is_some(),
+        );
+        // R7: persist every built envelope to `<repo_root>/.rigorix/audit` —
+        // the signed trail that cross-run policy reads (SequencePolicySetup::
+        // from_env wires the EnvelopeHistoryAdapter over the same directory).
+        let audit_dir = std::path::PathBuf::from(repo_root)
+            .join(".rigorix")
+            .join("audit");
+        if std::fs::create_dir_all(&audit_dir).is_ok() {
+            service = service.with_local_repository(std::sync::Arc::new(
+                rigorix_engine::audit::infrastructure::LocalAuditEnvelopeRepository::new(audit_dir),
+            ));
+        }
+        Arc::new(service)
+    };
 
     if audit_url.is_some() {
         tracing::info!("Audit backend configured via rigorix.toml");


### PR DESCRIPTION
Closes #871 — cross-run conflicting-action rules (the Jeff Jenkins case across TWO separate runs, which Arman committed to in the thread).

## Validated gap
R2/R3 matched within ONE run's step list. "remove X" in run 1 + "add Jeff" in run 2 minutes apart passed every gate — no history source, no principal on dispatches, no rule kind over past runs. (ADR-013/module docs carried no cross-run claim — no doc overclaim this time.)

## What this adds
- **Rule schema**: optional `history = { prior_node = <glob>, same_principal = bool, window_secs = N }` — fires only when the current run's `steps[]` match AND the signed prior-execution trail shows the conflicting action by the same principal in the window
- **Single-action current-run predicates are legal only when `history` is present** (cross-run is a per-action gate; within-run still requires an ordered pair)
- **History source = signed evidence**: `AuditServiceImpl::with_local_repository` persists every built envelope to `<repo_root>/.rigorix/audit` (wired at the mcp + cli composition roots); `EnvelopeHistoryAdapter` reads it. Tampering to evade a rule breaks the HMAC
- **Principal**: the run's `author` threaded into `evaluate_plan` from the orchestrator R2 gate (the executor R3 passes `None` — documented; same-principal rules evaluate at plan time)
- Caps (`max_history_window_secs` 7d), evidence via existing events/findings, docs §R7 + ADR-013 scope note

## Tests (engine lib 2019/2019, 61 sequence-policy)
- toml parse + caps for the history predicate
- semantics: same-principal prior remove **denies** the later add; other principal / out-of-window / unknown principal / no history port do **not**
- `EnvelopeHistoryAdapter` over a real envelope repo (saved envelope → recovered action; missing dir → empty)
- **Scene 9 integration**: run 1's envelope persisted to the real store → run 2 refused at plan time (`SequencePolicyDenied`) — the two-runs demo proof
