### PR TITLE
fix(r7/runtime): sign envelopes + template-level history + shared event bus

### DIFF
--- a/engine/.pi/architecture/decisions/ADR-013-sequence-policy.md
+++ b/engine/.pi/architecture/decisions/ADR-013-sequence-policy.md
@@ -7,6 +7,12 @@ Blueprint Source: Guardian Framework v1.2
 
 **Status:** Proposed
 **Date:** 2026-09-04
+**Scope note (2026-09-06, R7):** the ADR originally scoped matching to ONE
+run's ordered step list. R7 (#871) extends the module to cross-run
+conflicting-action rules: a rule with a `history` predicate consults the
+signed prior-execution trail (.rigorix/audit envelopes) at the same plan-time
+gate — same principal, windowed, deny/promote as within-run. Same bounded
+context (sequence_policy module); see modules/sequence-policy.md §R7.
 
 **Tech Stack:** Rust
 

--- a/engine/.pi/architecture/modules/sequence-policy.md
+++ b/engine/.pi/architecture/modules/sequence-policy.md
@@ -23,7 +23,34 @@ This directly answers the "conference registration" composition case raised in i
 
 > **A forbidden sequence never executes silently.** If an ordered plan contains steps `A → B` matching a rule, then `B` requires human approval before dispatch (promote), or is denied outright (deny mode). The decision is deterministic, derived from the same ordered step list the executor will run, and recorded into the signed envelope.
 
-## Requirements (R1–R6)
+> **R7 extends the property across runs:** a rule with a `history` predicate additionally consults the **signed prior-execution trail** — *"remove X" in run 1, "add Jeff" in run 2, minutes apart* — each run passes its own within-run gate, but the second is refused at plan time because the same principal acted within the window. Policy input == signed evidence: tampering with the trail to evade a rule breaks the envelope HMAC.
+
+## Requirements (R1–R7)
+
+### R7 — Cross-Run Conflicting-Action Rules (audit trail as policy input)
+
+A rule may carry an optional `history` predicate inside its `[[rules]]` table:
+
+```toml
+[[rules]]
+id = "no-cross-run-remove-reassign"
+action = "deny"
+steps = [{ tool = "registration_add", params = [{ pointer = "/event_id", kind = "exact", value = "conf-2026" }] }]
+history = { prior_node = "registration_remove", same_principal = true, window_secs = 900 }
+```
+
+Semantics (frozen):
+- The rule fires only when the **current run's** `steps[]` match **AND** the signed prior-execution history shows an action glob-matching `prior_node` — by the **same principal** when `same_principal = true`, completed within `window_secs` — before this run.
+- `same_principal = true` with an unknown current-run principal **never** matches (no false denial).
+- History is read once per evaluation over the widest required window; a missing history store is empty (status quo), a read failure is fail-closed.
+- A single-step current-run predicate is legal **only** when `history` is present (cross-run is a per-action gate; the within-run matcher still requires an ordered pair).
+- Principal = the run's `author` (falls back to attested `identity.subject` on the envelope). The runtime prefix gate (R3) has no per-run principal and passes `None` — same-principal history rules therefore evaluate at plan time (R2).
+- **History source**: the composition roots persist every built envelope to `<repo_root>/.rigorix/audit` (`AuditServiceImpl::with_local_repository`); `EnvelopeHistoryAdapter` reads it through the audit module's repository interface. Policy never writes the trail.
+
+| Cap | Default |
+|-----|---------|
+| `max_history_window_secs` | 604 800 (7 days) |
+| `history.prior_node` | non-empty |
 
 ### R1 — Declarative Sequence Rules
 

--- a/engine/.pi/plans/contract-freeze-pr-body.md
+++ b/engine/.pi/plans/contract-freeze-pr-body.md
@@ -1,0 +1,44 @@
+## Issue Closeout
+
+Closes #838 (epic: sequence-policy, tracking #837)
+
+### Summary
+
+Contract freeze for the **sequence-policy** bounded context (ADR-013) — declarative gating of composed actions ("remove-then-reassign" class). All public interfaces, data contracts, DTO schemas, and error formats are defined with `todo!()` behavior stubs; no implementation ships in this MR. Implementation issues (ISSUE-SEQUENCE-POLICY-1…5 + R2/R3/R5/R6 integration issues) depend on these frozen contracts.
+
+New module `src/sequence_policy/` — 3 DDD layers (matches `approval` / `quality_gates` / `scored_evaluation`):
+
+- **domain/** — `SequenceRule` + `StepPredicate` + `ParamPredicate` + `ParamMatchKind` + `RuleAction` (rule.rs), `SequenceMatch` (sequence_match.rs), `SequencePolicyConfig` + `SafetyCaps` (config.rs), `SequencePolicyError` + `is_retriable()` (error.rs)
+- **application/** — `SequencePolicyService` trait (R2 `evaluate_plan` / R3 `evaluate_prefix`), stub `SequencePolicyServiceImpl`, `SequencePolicyFactory`, `PlannedStep` / `DispatchedStep` DTOs
+- **infrastructure/** — `SequencePolicyRepository` trait + `TomlSequencePolicyRepository` stub (`.rigorix/sequence-policy.toml`; missing file → `Ok(None)` fail-open, corrupt → fail-closed)
+- Registered `pub mod sequence_policy` in `lib.rs`
+
+The 12 inert TDD scaffolds under `tests/unit/sequence-policy/**` were rewritten as real Rust contract tests (39 passing) that pin the frozen surface without invoking `todo!()` behavior — registered in `tests/unit/mod.rs`. Behavior tests land with each implementation issue.
+
+### Acceptance Criteria Verification
+
+| # | Criterion | Status | Evidence |
+|---|-----------|--------|----------|
+| 1 | All component interfaces defined as stubs (TODO bodies) | ✅ | `src/sequence_policy/domain/` + `application/`; behavior methods are `todo!()` stubs (service_impl.rs, toml_repository.rs, config `validate`) |
+| 2 | Contracts reviewed and frozen | ✅ | This MR (review); issue metadata committed; canonical spec `.pi/architecture/modules/sequence-policy.md` |
+| 3 | DTO schemas documented with field names and types | ✅ | `application/dto/mod.rs` + field-level doc comments; all DTOs/domain types serde-serializable with frozen wire formats (`promote`/`deny`, `exact`/`glob`/`regex`) |
+| 4 | Implementation depends on contracts | ✅ | No implementation files — only interfaces, value types, and stubs |
+
+### Validator Results
+
+| Validator | Status | Details |
+|-----------|--------|---------|
+| CI | ✅ PASSED | `validate-ci.sh` 4/4: build, `cargo test -p rigorix-engine` (1949 lib + all integration targets green), clippy `-D warnings`, fmt |
+| Test | ✅ PASSED* | 39 new contract tests pass; doctests + 80% coverage PASS (*the `--test integration` branch of validate-tests.sh is a pre-existing target-naming bug — fails identically on main; real integration targets run green under `cargo test`) |
+| Security | ✅ PASSED | `validate-security.sh` exit 0 (repo-wide pre-existing warnings only; no new unsafe/unwrap/secrets in this additive change) |
+| Canonical | ✅ PASSED | 534/549 files (97%) carry canonical refs; module mapped to implementation; ADR references present |
+
+### Files Changed
+
+- `engine/src/sequence_policy/**` — new module (domain/application/infrastructure, 15 files)
+- `engine/src/lib.rs` — `pub mod sequence_policy;`
+- `engine/tests/unit/mod.rs` — `mod sequence_policy` registration
+- `engine/tests/unit/sequence-policy/**` — 12 rewritten contract test files
+- `engine/.pi/issues/` — epic issue metadata (chore)
+
+Refs: #838, #837, ADR-013

--- a/engine/.pi/plans/sequence-policy-handoff.md
+++ b/engine/.pi/plans/sequence-policy-handoff.md
@@ -1,0 +1,42 @@
+# sequence-policy epic — session handoff (item 9+)
+
+Pipeline PL-9787, tracking issue #837. **8/15 items merged.** Next:
+item 9/15 `issue-execution-engine-r3` (#846, AC9), step: implement.
+
+Full design brief (scoped, ready to implement) is on **issue #846 comment**:
+https://github.com/arman-jalili/rigorix-oss/issues/846#issuecomment-5553422650
+Plus earlier handoffs on #837 for items 1–8.
+
+## Resume
+```bash
+cd engine
+git checkout main && git pull          # green at 6ad5209c
+git checkout -b feat/issue-execution-engine-r3
+pipeline_status / pipeline_next_task    # item 9/15, implement
+```
+After `gh pr merge --delete-branch` always `git checkout -B main origin/main`.
+
+## Merged so far (all local-CI 5/5 green, issues auto-closed)
+| Item | MR | Issue |
+|------|----|-------|
+| 1 contract-freeze | #853 | #838 |
+| 2 sequencerule | #854 | #839 |
+| 3 sequencepolicyservice | #855 | #840 |
+| 4 sequencepolicyerror | #856 | #841 |
+| 5 steppredicate | #857 | #842 |
+| 6 matcher | #858 | #843 |
+| 7 orchestrator-r2 | #859 | #844 |
+| 8 mcp-surface | #860 | #845 |
+
+## Items 9–15
+execution-engine-r3 (#846) — CRITICAL risk, brief on #846 · fail-closed (#847) ·
+fail-open-absent (#848) · audit-r6 (#849) · permission-r5 (#850) · proofing
+(#851) · architecture-readiness (#852).
+
+## Workflow rules
+- Validators from `engine/` only; gate = `validate-ci.sh` (5/5). The
+  `validate-tests.sh` `--test integration` failure is a pre-existing main bug.
+- `async_trait`/`tokio`/`serde_json`/`toml` are lib deps → behavior tests
+  in-crate (`#[cfg(test)]`), scaffolds under `tests/unit/sequence-policy/` are
+  contract-level only.
+- `toml` isn't a dev-dep → TOML parse tests live in-crate in the domain file.

--- a/engine/src/orchestrator/application/orchestrator_impl.rs
+++ b/engine/src/orchestrator/application/orchestrator_impl.rs
@@ -1096,7 +1096,7 @@ impl OrchestratorService for OrchestratorServiceImpl {
                     file_paths: Self::extract_file_paths(&record.task_results),
                     metadata: None,
                     scoring_results: self.collect_scoring_results(record.execution_id).await,
-                    sign: false,
+                    sign: true,
                     repository: input.repository.clone(),
                     author: input.author.clone(),
                     identity: input.identity.as_ref().map(IdentityRef::from_claim),
@@ -1690,7 +1690,7 @@ impl OrchestratorService for OrchestratorServiceImpl {
                     file_paths: Self::extract_file_paths(&record.task_results),
                     metadata: None,
                     scoring_results: self.collect_scoring_results(record.execution_id).await,
-                    sign: false,
+                    sign: true,
                     repository: input.repository.clone(),
                     author: input.author.clone(),
                     // run_from_template is the MCP auth-module path — the attested
@@ -2903,7 +2903,7 @@ mod tests {
         );
 
         // 2. The envelope derives the redacted sequence_policy_findings[].
-        let envelope = AuditEnvelopeFactoryImpl::new(None)
+        let envelope = AuditEnvelopeFactoryImpl::new(Some("test-key".to_string()))
             .build_envelope(input)
             .await
             .expect("envelope build");
@@ -3198,7 +3198,7 @@ mod tests {
         let repo: std::sync::Arc<
             dyn crate::audit::infrastructure::repository::AuditEnvelopeRepository,
         > = std::sync::Arc::new(LocalAuditEnvelopeRepository::new(dir.path().to_path_buf()));
-        let factory = AuditEnvelopeFactoryImpl::default();
+        let factory = AuditEnvelopeFactoryImpl::new(Some("test-key".to_string()));
         let run1 = factory
             .build_envelope(BuildEnvelopeInput {
                 execution_id: uuid::Uuid::new_v4(),
@@ -3222,7 +3222,7 @@ mod tests {
                 file_paths: vec![],
                 metadata: None,
                 scoring_results: std::collections::HashMap::new(),
-                sign: false,
+                sign: true,
                 repository: None,
                 author: Some("jeff@corp".to_string()),
                 identity: None,

--- a/engine/src/sequence_policy/infrastructure/history.rs
+++ b/engine/src/sequence_policy/infrastructure/history.rs
@@ -54,10 +54,11 @@ impl EnvelopeHistoryAdapter {
     }
 }
 
-/// Extract the executed node names from one envelope's event refs.
-///
-/// Node-completion events carry `payload.step_name`; duplicate names within
-/// one envelope collapse to the last occurrence (per-node completion).
+/// Extract executed actions from one envelope: per-node completions (event
+/// refs carrying `payload.step_name`) when present, falling back to a
+/// single RUN-LEVEL action identified by `template_id` — the signed trail
+/// records node events only for evidence-bearing runs (approval/scope/
+/// sequence), so plain runs are represented by the template that executed.
 fn actions_from_envelope(envelope: &AuditEnvelope) -> Vec<HistoryAction> {
     let principal = envelope
         .author
@@ -78,6 +79,13 @@ fn actions_from_envelope(envelope: &AuditEnvelope) -> Vec<HistoryAction> {
             node: step_name.to_string(),
             principal: principal.clone(),
             at: ev.occurred_at,
+        });
+    }
+    if out.is_empty() && !envelope.template_id.is_empty() {
+        out.push(HistoryAction {
+            node: envelope.template_id.clone(),
+            principal,
+            at: envelope.timestamp,
         });
     }
     out
@@ -179,6 +187,37 @@ mod tests {
                 a.node == "remove_attendance" && a.principal.as_deref() == Some("jeff@corp")
             }),
             "prior actions must include the saved node + principal: {actions:?}"
+        );
+    }
+
+    /// Plain runs (no evidence events) surface as a RUN-LEVEL action under
+    /// the template id — what the cross-run rule matches in the demo.
+    #[tokio::test]
+    async fn adapter_plain_run_surfaces_template_level_action() {
+        use crate::audit::application::factory::AuditEnvelopeFactory;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let repo: std::sync::Arc<
+            dyn crate::audit::infrastructure::repository::AuditEnvelopeRepository,
+        > = std::sync::Arc::new(LocalAuditEnvelopeRepository::new(dir.path().to_path_buf()));
+
+        let factory = AuditEnvelopeFactoryImpl::default();
+        let mut input = completed_envelope_input("ignored_node", "jeff@corp");
+        input.template_id = "attendance-remove".to_string();
+        input.events.clear(); // no evidence events — plain run
+        let envelope = factory.build_envelope(input).await.expect("build");
+        repo.save(&envelope).await.expect("save");
+
+        let adapter = EnvelopeHistoryAdapter::new(repo);
+        let actions = adapter
+            .prior_actions(chrono::Utc::now() - chrono::Duration::hours(1))
+            .await
+            .expect("history read");
+        assert!(
+            actions
+                .iter()
+                .any(|a| a.node == "attendance-remove"
+                    && a.principal.as_deref() == Some("jeff@corp")),
+            "plain run must surface the template id as the action: {actions:?}"
         );
     }
 

--- a/engine/tests/unit/sequence-policy/fail-closed/fail-closed_test.rs
+++ b/engine/tests/unit/sequence-policy/fail-closed/fail-closed_test.rs
@@ -47,6 +47,7 @@ fn test_safety_caps_are_part_of_the_config_contract() {
         max_steps_per_rule: 8,
         max_window: 5,
         max_regex_predicates_per_file: 8,
+        max_history_window_secs: 604_800,
     };
     let over_cap = SequencePolicyError::RuleExceedsCaps {
         rule: "registration-remove-then-reassign".into(),

--- a/engine/tests/unit/sequence-policy/sequencerule/sequencerule_test.rs
+++ b/engine/tests/unit/sequence-policy/sequencerule/sequencerule_test.rs
@@ -36,6 +36,7 @@ fn conference_rule() -> SequenceRule {
         ],
         window: Some(3),
         action: RuleAction::Promote,
+        history: None,
     }
 }
 

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -1143,11 +1143,18 @@ async fn build_real_engine(
         rigorix_engine::execution_engine::application::factory::SequencePolicySetup::from_env(
             std::path::Path::new(repo_root),
         );
+    // ── Event bus (shared: the executor publishes into it AND the
+    //    orchestrator drains it for the audit envelope — a split bus makes
+    //    engine envelopes evidence-empty) ──
+    let event_bus: Arc<dyn EventBusService> =
+        Arc::new(EventBusServiceImpl::new(EventBusConfig::default()));
+
     let execution_service: Arc<dyn ParallelExecutionService> = Arc::from(
         ParallelExecutionFactoryImpl::new()
             .create(ParallelExecutionFactoryConfig {
                 permission_enforcer,
                 hook_runner,
+                event_bus: Some(Arc::clone(&event_bus)),
                 approval_binding: rigorix_engine::execution_engine::application::factory::ApprovalBindingSetup::from_env(std::path::Path::new(repo_root)),
                 sequence_policy: sequence_policy.clone(),
                 ..ParallelExecutionFactoryConfig::default()
@@ -1166,10 +1173,6 @@ async fn build_real_engine(
     // ── Cancellation service ──
     let cancellation_service: Arc<dyn CancellationService> =
         Arc::new(CancellationManagerImpl::default());
-
-    // ── Event bus ──
-    let event_bus: Arc<dyn EventBusService> =
-        Arc::new(EventBusServiceImpl::new(EventBusConfig::default()));
 
     // ── Budget service (configurable via rigorix.toml; each runbook step
     //    consumes one call — a tight budget makes rigorix_run refuse) ──


### PR DESCRIPTION
Runtime evidence gaps found while validating the conference-demo end-to-end on the local build:

1. **sign: false hardcoded** in the orchestrator's 3 audit-dispatch sites — engine envelopes were never HMAC-signed even with a key. Flipped to sign: true (safe: the factory signs only when a key exists).
2. **R7 history adapter** only recovered node actions from event-ref payloads — plain successful runs persist no node events, so history was empty for normal runs. Now falls back to a run-level action under `template_id` per envelope.
3. **Split event bus in mcp main** — the executor got its own private bus while the orchestrator drained another, so node/approval events never reached the audit envelope. One shared bus now feeds both.

Engine lib 2020/2020. Verified against the demo: scene 9 R7 denial fires + envelopes carry `signature: PRESENT`.